### PR TITLE
Update Gradle scripts to use errorprone compiler.

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -20,5 +20,4 @@ extraction:
     - (cd ${LGTM_WORKSPACE}/annotation-tools; ant compile)
     index:
       build_command:
-      - cd checker
-      - ant -Djsr308.langtools=${LGTM_WORKSPACE}/jsr308-langtools -Dannotation.tools=${LGTM_WORKSPACE}/annotation-tools -Dstubparser.loc=${LGTM_WORKSPACE}/stubparser dist-downloadjdk
+      - JSR308=${LGTM_WORKSPACE} ./gradlew assemble

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,16 @@ allprojects {
     repositories {
         mavenCentral()
     }
+    configurations {
+        jsr308Javac
+    }
+    dependencies {
+        jsr308Javac group: 'com.google.errorprone', name: 'javac', version: '9+181-r4173-1'
+
+        // Comment the above and uncomment the below to use jsr308-langtools.
+        // jsr308Javac files("${jsr308}/jsr308-langtools/cfmake/javac-jdk.jar")
+        // jsr308Javac files("${jsr308}/jsr308-langtools/cfmake/javac.jar")
+    }
 
     // After all the tasks have been created, modify some of them.
     afterEvaluate {
@@ -96,6 +106,8 @@ allprojects {
                     "-Xlint",
             ]
             options.encoding = 'UTF-8'
+            options.fork = true
+            options.forkOptions.jvmArgs += ["-Xbootclasspath/p:${configurations.jsr308Javac.asPath}"]
         }
     }
 }
@@ -379,6 +391,8 @@ subprojects {
             if (project.hasProperty('emit.test.debug')) {
                 systemProperties += ["emit.test.debug": 'true']
             }
+
+            jvmArgs "-Xbootclasspath/p:${configurations.jsr308Javac.asPath}"
 
             testLogging {
                 showStandardStreams = true

--- a/javacutil/build.gradle
+++ b/javacutil/build.gradle
@@ -21,7 +21,7 @@ sourceSets {
 }
 
 dependencies {
-    compile files(configurations.jsr308Javac.asPath)
+    compile configurations.jsr308Javac
     compileOnly project(':checker-qual')
 
     tagletCompile files("${toolsJar}")

--- a/javacutil/build.gradle
+++ b/javacutil/build.gradle
@@ -21,7 +21,7 @@ sourceSets {
 }
 
 dependencies {
-    compile files("${toolsJar}")
+    compile files(configurations.jsr308Javac.asPath)
     compileOnly project(':checker-qual')
 
     tagletCompile files("${toolsJar}")


### PR DESCRIPTION
I've only done this for compiling and the Junit tests.  We'll need to do something similar for jtreg tests and other test targets.  