### PR TITLE
Fix NullnessFbc Test : Compare with NULL_COMPLETER

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationTransfer.java
@@ -31,6 +31,7 @@ import org.checkerframework.framework.flow.CFAbstractValue;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.javacutil.TreeUtils;
+import com.sun.tools.javac.code.Symbol.Completer;
 
 /**
  * A transfer function that extends {@link CFAbstractTransfer} and tracks {@link
@@ -129,7 +130,7 @@ public class InitializationTransfer<
             List<VariableElement> result, TypeElement clazzElem) {
         List<VariableElement> fields = ElementFilter.fieldsIn(clazzElem.getEnclosedElements());
         for (VariableElement field : fields) {
-            if (((Symbol) field).type.tsym.completer != null) {
+            if (((Symbol) field).type.tsym.completer != Completer.NULL_COMPLETER) {
                 // If the type is not completed yet, we might run
                 // into trouble. Skip the field.
                 // TODO: is there a nicer solution?


### PR DESCRIPTION
The completer of a symbol is compared with 'NULL_COMPLETER' instead of 'null'.
Counts of errors before fix:
Tests : 161
Failures : 12
Ignored : 0

Failed Tests : 
    IndexTest. run[index]
    LockSafeDefaultsTest. run[lock-safedefaults]
    LockTest. run[lock]
    NestedAggregateCheckerTest. run[all-systems]
    NullnessFbcTest. run[all-systems]
    NullnessFbcTest. run[nullness/init]
    NullnessFbcTest. run[nullness]
    NullnessRawnessTest. run[all-systems]
    NullnessRawnessTest. run[nullness/init]
    NullnessRawnessTest. run[nullness]
    NullnessReflectionTest. run[nullness-reflection]
    TaintingTest. run[tainting]

Counts of errors after fix:
Tests : 161
Failures : 10
Ignored : 0

Failed Tests : 
	IndexTest. run[index]
	LockSafeDefaultsTest. run[lock-safedefaults]
	LockTest. run[lock]
	NestedAggregateCheckerTest. run[all-systems]
	NullnessFbcTest. run[all-systems]
	NullnessFbcTest. run[nullness]
	NullnessRawnessTest. run[all-systems]
	NullnessRawnessTest. run[nullness]
	NullnessReflectionTest. run[nullness-reflection]
	TaintingTest. run[tainting]