### PR TITLE
fix wildcardtype.bound not having the correct bound as revealed in Ternary.java

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
@@ -570,7 +570,7 @@ public abstract class BaseTypeChecker extends SourceChecker implements BaseTypeC
 
         /**
          * Sets the WildcardType.bound field of the given wildcardTypeArg to the given typeParam, if
-         * and only if the owner of the existing bound and the typeParam are different.
+         * and only if the owners of the existing bound and the typeParam are different.
          *
          * <p>This is used to work around a bug in javac 9 where sometimes the bound field is set to
          * the transitive supertype's type parameter instead of the type parameter for which the


### PR DESCRIPTION
javac 9 updates the wildcardtype.bound field to the type parameter of the transitive superclass of the class which the wildcard instantiates, during its visitation of ternary expressions within the body of a method.

this PR fixes this problem by setting the bound to the type parameter for which the wildcard directly instantiates.