### PR TITLE
Fixes invalid flag error in checkPurity task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,8 +163,10 @@ def createCheckTypeTask(projectName, checker, shortName) {
                 '-Xlint:-processing',
                 '-AprintErrorStack',
                 "-Xbootclasspath/p:${rootDir}/checker/dist/jdk8.jar",
-                "-source 8",
-                "-target 8",
+                "-source",
+                "8",
+                "-target",
+                "8"
         ]
     }
 }


### PR DESCRIPTION
This fix solves the error : 
```
Execution failed for task ':checker-framework:framework:checkPurity'.
		> invalid flag: -source 8
```