### PR TITLE
Fixes error due to changed method signature of loadClass in Resolve.java

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/reflection/DefaultReflectionResolver.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/DefaultReflectionResolver.java
@@ -16,6 +16,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Env;
 import com.sun.tools.javac.comp.Resolve;
+import com.sun.tools.javac.comp.Resolve.RecoveryLoadClass;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
@@ -488,9 +489,9 @@ public class DefaultReflectionResolver implements ReflectionResolver {
 
         List<Symbol> result = new ArrayList<>();
         try {
-            Method loadClass = Resolve.class.getDeclaredMethod("loadClass", Env.class, Name.class);
+            Method loadClass = Resolve.class.getDeclaredMethod("loadClass", Env.class, Name.class, RecoveryLoadClass.class);
             loadClass.setAccessible(true);
-            Symbol sym = (Symbol) loadClass.invoke(resolve, env, names.fromString(className));
+            Symbol sym = (Symbol) loadClass.invoke(resolve, env, names.fromString(className), null);
             if (!sym.exists()) {
                 debugReflection("Unable to resolve class: " + className);
                 return Collections.emptyList();
@@ -544,9 +545,9 @@ public class DefaultReflectionResolver implements ReflectionResolver {
 
         List<Symbol> result = new ArrayList<>();
         try {
-            Method loadClass = Resolve.class.getDeclaredMethod("loadClass", Env.class, Name.class);
+            Method loadClass = Resolve.class.getDeclaredMethod("loadClass", Env.class, Name.class, RecoveryLoadClass.class);
             loadClass.setAccessible(true);
-            Symbol symClass = (Symbol) loadClass.invoke(resolve, env, names.fromString(className));
+            Symbol symClass = (Symbol) loadClass.invoke(resolve, env, names.fromString(className), null);
             if (!symClass.exists()) {
                 debugReflection("Unable to resolve class: " + className);
                 return Collections.emptyList();


### PR DESCRIPTION
**Before fix :** 

- On running ./gradlew alltests :
Total tests: 161
Failures: 4
Skipped: 0
770 out of 776 total expected diagnostics were found
15 total unexpected diagnostics were found

- On running ./gradlew framework:alltests
Tests : 359
Failures : 30
Ignored : 1

**After fix :** 

- On running ./gradlew alltests : 
Total tests: 161
Failures: 3
Skipped: 0
770 out of 776 total expected diagnostics were found
7 total unexpected diagnostics were found

- On running ./gradlew framework:alltests
Tests : 359
Failures : 29
Ignored : 1