### PR TITLE
Uses un-annotated type variables as key to typevars map

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -93,16 +93,19 @@ public class BoundsInitializer {
             typeArgs.add(typeArg);
 
             // Add mapping from type parameter to the annotated type argument.
-            typeArgMap.put(
+            // In Java 9, the symbol now contains the type annotation that is present in the source
+            // code. However, `typevars` map isn't prepared for this. So we take un-annotated type
+            // variables as the key for this map.
+            TypeVariable key =
                     (TypeVariable)
-                            (TypeAnnotationUtils.unannotatedType(
-                                    typeElement.getTypeParameters().get(i).asType())),
-                    typeArg);
+                            TypeAnnotationUtils.unannotatedType(
+                                    typeElement.getTypeParameters().get(i).asType());
+            typeArgMap.put(key, typeArg);
 
             if (javaTypeArg.getKind() == TypeKind.TYPEVAR) {
                 // Add mapping from Java type argument to the annotated type argument.
-                typeArgMap.put(
-                        (TypeVariable) (TypeAnnotationUtils.unannotatedType(javaTypeArg)), typeArg);
+                key = (TypeVariable) TypeAnnotationUtils.unannotatedType(javaTypeArg);
+                typeArgMap.put(key, typeArg);
             }
         }
 
@@ -460,10 +463,11 @@ public class BoundsInitializer {
                     }
                     break;
                 case TYPEVAR:
-                    if (typevars.containsKey(
-                            TypeAnnotationUtils.unannotatedType(type.getUnderlyingType()))) {
-                        return typevars.get(
-                                TypeAnnotationUtils.unannotatedType(type.getUnderlyingType()));
+                    TypeVariable key =
+                            (TypeVariable)
+                                    TypeAnnotationUtils.unannotatedType(type.getUnderlyingType());
+                    if (typevars.containsKey(key)) {
+                        return typevars.get(key);
                     }
                     break;
                 default:

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -69,8 +69,8 @@ public class BoundsInitializer {
                 (TypeElement) declaredType.atypeFactory.types.asElement(actualType);
         final List<AnnotatedTypeMirror> typeArgs = new ArrayList<>();
 
-        // Create AnnotatedTypeMirror for each type argument and store them in the typeArgsMap.Take
-        // un-annotated type variables as the key for this map.
+        // Create AnnotatedTypeMirror for each type argument and store them in the typeArgsMap.
+        // Take un-annotated type variables as the key for this map.
         Map<TypeVariable, AnnotatedTypeMirror> typeArgMap = new HashMap<>();
         for (int i = 0; i < typeElement.getTypeParameters().size(); i++) {
             TypeMirror javaTypeArg;

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -93,8 +93,8 @@ public class BoundsInitializer {
             typeArgs.add(typeArg);
 
             // Add mapping from type parameter to the annotated type argument.
-            // In Java 9, the symbol now contains the type annotation that is present in the source
-            // code. However, `typevars` map isn't prepared for this. So we take un-annotated type
+            // The symbol now contains the type annotation that is present in the source
+            // code. However, `typeArgMap` isn't prepared for this. So we take un-annotated type
             // variables as the key for this map.
             TypeVariable key =
                     (TypeVariable)

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -69,7 +69,8 @@ public class BoundsInitializer {
                 (TypeElement) declaredType.atypeFactory.types.asElement(actualType);
         final List<AnnotatedTypeMirror> typeArgs = new ArrayList<>();
 
-        // Create AnnotatedTypeMirror for each type argument and store them in the typeArgsMap.
+        // Create AnnotatedTypeMirror for each type argument and store them in the typeArgsMap.Take
+        // un-annotated type variables as the key for this map.
         Map<TypeVariable, AnnotatedTypeMirror> typeArgMap = new HashMap<>();
         for (int i = 0; i < typeElement.getTypeParameters().size(); i++) {
             TypeMirror javaTypeArg;
@@ -93,9 +94,6 @@ public class BoundsInitializer {
             typeArgs.add(typeArg);
 
             // Add mapping from type parameter to the annotated type argument.
-            // The symbol now contains the type annotation that is present in the source
-            // code. However, `typeArgMap` isn't prepared for this. So we take un-annotated type
-            // variables as the key for this map.
             TypeVariable key =
                     (TypeVariable)
                             TypeAnnotationUtils.unannotatedType(

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -36,6 +36,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcard
 import org.checkerframework.framework.type.visitor.AnnotatedTypeVisitor;
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.PluginUtil;
+import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 /**
@@ -92,11 +93,16 @@ public class BoundsInitializer {
             typeArgs.add(typeArg);
 
             // Add mapping from type parameter to the annotated type argument.
-            typeArgMap.put((TypeVariable) typeElement.getTypeParameters().get(i).asType(), typeArg);
+            typeArgMap.put(
+                    (TypeVariable)
+                            (TypeAnnotationUtils.unannotatedType(
+                                    typeElement.getTypeParameters().get(i).asType())),
+                    typeArg);
 
             if (javaTypeArg.getKind() == TypeKind.TYPEVAR) {
                 // Add mapping from Java type argument to the annotated type argument.
-                typeArgMap.put((TypeVariable) javaTypeArg, typeArg);
+                typeArgMap.put(
+                        (TypeVariable) (TypeAnnotationUtils.unannotatedType(javaTypeArg)), typeArg);
             }
         }
 
@@ -454,8 +460,10 @@ public class BoundsInitializer {
                     }
                     break;
                 case TYPEVAR:
-                    if (typevars.containsKey(type.getUnderlyingType())) {
-                        return typevars.get(type.getUnderlyingType());
+                    if (typevars.containsKey(
+                            TypeAnnotationUtils.unannotatedType(type.getUnderlyingType()))) {
+                        return typevars.get(
+                                TypeAnnotationUtils.unannotatedType(type.getUnderlyingType()));
                     }
                     break;
                 default:


### PR DESCRIPTION
Fixes issues while running 'Tainting Test : Issue1942.java' by using un-annotated type variables as key to `typevars` map,  both when adding or looking something in the map.

The following failures were solved : 
```
1 expected diagnostic was not found :
Issue1111.java:15: error: (argument.type.incompatible)

2 unexpected diagnostics were found :
Issue1942.java:14: error: (override.param.invalid)

:- 1:other: error: AsSuperVisitor: type is not an erased subtype of supertype.
        type: @Untainted Object
        superType: @Tainted Integer
        Compilation unit: tests/tainting/Issue1111.java
        Last visited tree at line 13 column 15:
           void foo2(Box<@Untainted ? super Integer> box, List<Integer> list) { 
```

