### PR TITLE
Bugfix/inf loop concurrenthashmap

### DIFF
--- a/checker/tests/nullness/InfiniteLoopIsSameType.java
+++ b/checker/tests/nullness/InfiniteLoopIsSameType.java
@@ -1,0 +1,28 @@
+// Test case for eisop issue 24:
+// https://github.com/eisop/checker-framework/issues/24
+
+// This test case is extracted from ConcurrentHashMap.java,
+// namely from the method `compute`.
+
+import org.checkerframework.checker.nullness.qual.PolyNull;
+
+public class InfiniteLoopIsSameType {
+    private interface Intf1<R> {
+        R apply();
+    }
+
+    public void compute(
+            // checker works fine if not annotated
+            Intf1<? extends @PolyNull Object> remappingFunction) {
+        // must assign null
+        Object nullval = null;
+        for (; ; ) {
+            // must assign to the null object
+            nullval = remappingFunction.apply();
+            // break must be in an if statement
+            if (true) {
+                break;
+            }
+        }
+    }
+}

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -506,10 +506,6 @@ public final class TypesUtils {
         JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
         com.sun.tools.javac.code.Types types =
                 com.sun.tools.javac.code.Types.instance(javacEnv.getContext());
-        if (types.isSameType(t1, t2)) {
-            // Special case if the two types are equal.
-            return t1;
-        }
         // Handle the 'null' type manually (not done by types.lub).
         if (t1.getKind() == TypeKind.NULL) {
             return t2;
@@ -536,6 +532,10 @@ public final class TypesUtils {
                 return elements.getTypeElement("java.lang.Object").asType();
             }
             t2 = bound;
+        }
+        if (types.isSameType(t1, t2)) {
+            // Special case if the two types are equal.
+            return t1;
         }
         // Special case for primitives.
         if (isPrimitive(t1) || isPrimitive(t2)) {


### PR DESCRIPTION
This should fix #24 .

The root cause of the issue is that in eisop version, `types.isSameType` returns true when comparing two Types that are both `? extends java.lang.Object` (or `? extends some other class`), while in typetools version this method returns false. Consequently, running this provided test case makes the eisop version checker go into infinite loop.

The idea of this PR is to change the execution order when getting the upper bound of a (wildcard) type; this PR moves the `isSameType` call to the rear, so the bound of a wildcard type can be first extracted and then returned, making `leastUpperBound` return the same result as in the typetools version.