### PR TITLE
Fix build job of group "misc"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ allprojects {
                 options.memberLevel = javadocMemberLevel
                 classpath += files(project(':checker').tasks.getByName('shadowJar').archivePath)
                 options.taglets 'org.checkerframework.taglet.ManualTaglet'
-                options.tagletPath(project(':framework-test').sourceSets.taglet.output as File[])
+                options.tagletPath(project(':framework-test').sourceSets.taglet.output.getFiles() as File[])
                 options.links = ['https://docs.oracle.com/javase/8/docs/api/', 'https://docs.oracle.com/javase/8/docs/jdk/api/javac/tree/']
                 // This file is looked for by Javadoc.
                 file("${destinationDir}/resources/fonts/").mkdirs()


### PR DESCRIPTION
This fixes the failure of group "misc" in [job 87.1](https://travis-ci.org/eisop/checker-framework/jobs/495124108): `Cannot cast object 'taglet classes' with class 'org.gradle.api.internal.tasks.DefaultSourceSetOutput_Decorated' to class 'java.io.File'`. A successful build is [here](https://travis-ci.org/zhangjiangqige/checker-framework/jobs/500556342).

By calling `getFiles` we can get a `Set<File>` which is convertible.