### PR TITLE
Add -source 8 and -target 8 when building the default TestConfiguration

### DIFF
--- a/framework-test/src/main/java/org/checkerframework/framework/test/TestConfigurationBuilder.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TestConfigurationBuilder.java
@@ -61,13 +61,15 @@ public class TestConfigurationBuilder {
             configBuilder.addOption("-d", outputClassDirectory.getAbsolutePath());
         }
 
-        // Use the annotated jdk for the compile bootclasspath
-        String jdkJarPath = getJdkJarPathFromProperty();
-        if (notNullOrEmpty(jdkJarPath)) {
-            configBuilder.addOption("-Xbootclasspath/p:" + jdkJarPath);
-        }
+        if (PluginUtil.getJreVersion() == 8) {
+            // Use the annotated jdk for the compile bootclasspath
+            String jdkJarPath = getJdkJarPathFromProperty();
+            if (notNullOrEmpty(jdkJarPath)) {
+                configBuilder.addOption("-Xbootclasspath/p:" + jdkJarPath);
+            }
 
-        configBuilder.addOption("-source", "8").addOption("-target", "8");
+            configBuilder.addOption("-source", "8").addOption("-target", "8");
+        }
 
         configBuilder
                 .addOptionIfValueNonEmpty("-sourcepath", testSourcePath)

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TestConfigurationBuilder.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TestConfigurationBuilder.java
@@ -67,6 +67,8 @@ public class TestConfigurationBuilder {
             configBuilder.addOption("-Xbootclasspath/p:" + jdkJarPath);
         }
 
+        configBuilder.addOption("-source", "8").addOption("-target", "8");
+
         configBuilder
                 .addOptionIfValueNonEmpty("-sourcepath", testSourcePath)
                 .addOption("-implicit:class")

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
@@ -48,6 +48,13 @@ public class TypecheckExecutor {
         final List<String> options = new ArrayList<>();
         options.add("-processor");
         options.add(String.join(",", configuration.getProcessors()));
+        if (PluginUtil.getJreVersion() == 8) {
+            options.add("-source");
+            options.add("8");
+            options.add("-target");
+            options.add("8");
+        }
+
         List<String> nonJvmOptions = new ArrayList<>();
         for (String option : configuration.getFlatOptions()) {
             if (!option.startsWith("-J-")) {

--- a/framework/src/main/java/org/checkerframework/framework/stub/StubGenerator.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/StubGenerator.java
@@ -23,6 +23,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.PluginUtil;
 import org.checkerframework.javacutil.TypesUtils;
 
 /**
@@ -415,9 +416,11 @@ public class StubGenerator {
 
         Context context = new Context();
         Options options = Options.instance(context);
-        options.put(Option.SOURCE, "8");
-        options.put(Option.TARGET, "8");
-        options.put(Option.XBOOTCLASSPATH_PREPEND, "jdk8.jar");
+        if (PluginUtil.getJreVersion() == 8) {
+            options.put(Option.SOURCE, "8");
+            options.put(Option.TARGET, "8");
+            options.put(Option.XBOOTCLASSPATH_PREPEND, "jdk8.jar");
+        }
 
         JavaCompiler javac = JavaCompiler.instance(context);
         javac.initModules(com.sun.tools.javac.util.List.nil());


### PR DESCRIPTION
This fixes the missing module error of checker-framework-inference https://github.com/eisop/checker-framework-inference/pull/1#issuecomment-492868310 .

It's also possible to add these parameters to [TypecheckExecutor.compile](https://github.com/eisop/checker-framework/blob/00a9acc3e3795879c1a5ca6cc3a6cf2086654023/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java#L31) instead of here, but I'm not sure which is more appropriate.