### PR TITLE
Configure annotated jdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Please see the Checker Framework manual ([HTML](https://checkerframework.org/manual/), [PDF](https://checkerframework.org/manual/checker-framework-manual.pdf)).
 
 Additional documentation for Checker Framework developers
-is in directory `docs/developer/`
+is in directory `docs/developer/`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Please see the Checker Framework manual ([HTML](https://checkerframework.org/manual/), [PDF](https://checkerframework.org/manual/checker-framework-manual.pdf)).
 
 Additional documentation for Checker Framework developers
-is in directory `docs/developer/`.
+is in directory `docs/developer/`

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -29,7 +29,7 @@ import org.checkerframework.javacutil.PluginUtil;
  *   <li>add {@code jdk8.jar} to the compile time bootclasspath of the javac argument list passed to
  *       javac while using Java 8
  *   <li>patch JDK modules while using Java9+ using {@code --patch-module
- *       <module>=<annotatedModule>} annotated modules are present in {@code
+ *       &lt;module&gt;=&lt;annotatedModule&gt;} annotated modules are present in {@code
  *       checker/dist/annotatedJDK/jdk*\/} directory. All {@code --patch-module} arguments are
  *       provided using {@code checker/dist/annotatedJDK/jdk{VERSION}\/Patch_Modules_argsfile}
  *   <li>parse and implement any special options used by the Checker Framework, e.g., using

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -28,9 +28,10 @@ import org.checkerframework.javacutil.PluginUtil;
  *       Framework.
  *   <li>add {@code jdk8.jar} to the compile time bootclasspath of the javac argument list passed to
  *       javac while using Java 8
- *   <li>patch JDK modules while using Java9+ using {@code --patch-module <module>=<annotatedModule>}
- *       annotated modules are present in {@code checker/dist/annotatedJDK/jdk*\/} directory
- *       all {@code --patch-module} arguments are provided using {@code checker/dist/annotatedJDK/jdk*\/Patch_Modules_argsfile}
+ *   <li>patch JDK modules while using Java9+ using {@code --patch-module
+ *       <module>=<annotatedModule>} annotated modules are present in {@code
+ *       checker/dist/annotatedJDK/jdk*\/} directory all {@code --patch-module} arguments are
+ *       provided using {@code checker/dist/annotatedJDK/jdk*\/Patch_Modules_argsfile}
  *   <li>parse and implement any special options used by the Checker Framework, e.g., using
  *       "shortnames" for annotation processors
  *   <li>pass all remaining command-line arguments to the real javac
@@ -61,8 +62,9 @@ public class CheckerMain {
         System.exit(exitStatus);
     }
 
-    /** The path to the annotated jdk jar to use in case of Java8
-     *  or directory containing annotated-jdk modules in case of Java9+
+    /**
+     * The path to the annotated jdk jar to use in case of Java8 or directory containing
+     * annotated-jdk modules in case of Java9+
      */
     protected final File jdkJar;
 
@@ -118,11 +120,13 @@ public class CheckerMain {
 
         if (PluginUtil.getJreVersion() > 8) {
             final int jreVersion = PluginUtil.getJreVersion();
-            final String jdkVersionFolderName = "jdk"+ jreVersion;
+            final String jdkVersionFolderName = "jdk" + jreVersion;
             this.jdkJar =
-                    extractFileArg(PluginUtil.JDK_PATH_OPT, new File(annotatedJDKSearchPath, jdkVersionFolderName), args);
-        }
-        else {
+                    extractFileArg(
+                            PluginUtil.JDK_PATH_OPT,
+                            new File(annotatedJDKSearchPath, jdkVersionFolderName),
+                            args);
+        } else {
             final String jdkJarName = PluginUtil.getJdkJarName();
             this.jdkJar =
                     extractFileArg(PluginUtil.JDK_PATH_OPT, new File(searchPath, jdkJarName), args);

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -30,8 +30,8 @@ import org.checkerframework.javacutil.PluginUtil;
  *       javac while using Java 8
  *   <li>patch JDK modules while using Java9+ using {@code --patch-module
  *       <module>=<annotatedModule>} annotated modules are present in {@code
- *       checker/dist/annotatedJDK/jdk*\/} directory all {@code --patch-module} arguments are
- *       provided using {@code checker/dist/annotatedJDK/jdk*\/Patch_Modules_argsfile}
+ *       checker/dist/annotatedJDK/jdk*\/} directory. All {@code --patch-module} arguments are
+ *       provided using {@code checker/dist/annotatedJDK/jdk{VERSION}\/Patch_Modules_argsfile}
  *   <li>parse and implement any special options used by the Checker Framework, e.g., using
  *       "shortnames" for annotation processors
  *   <li>pass all remaining command-line arguments to the real javac
@@ -712,7 +712,7 @@ public class CheckerMain {
                 missingAbsoluteFilenames.add(missingFile.getAbsolutePath());
             }
             throw new RuntimeException(
-                    "The following files could not be located: "
+                    "The following files/directory could not be located: "
                             + String.join(", ", missingAbsoluteFilenames));
         }
     }

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -121,11 +121,12 @@ public class CheckerMain {
         if (PluginUtil.getJreVersion() > 8) {
             final int jreVersion = PluginUtil.getJreVersion();
             final String jdkVersionFolderName = "jdk" + jreVersion;
-            this.jdkJar =
-                    extractFileArg(
-                            PluginUtil.JDK_PATH_OPT,
-                            new File(annotatedJDKSearchPath, jdkVersionFolderName),
-                            args);
+            final File jdkVersionModuleLocation =
+                    new File(annotatedJDKSearchPath, jdkVersionFolderName);
+            this.jdkJar = extractFileArg(PluginUtil.JDK_PATH_OPT, jdkVersionModuleLocation, args);
+            final File patchModuleArgsFile =
+                    new File(jdkVersionModuleLocation, "Patch_Modules_argfile");
+            argListFiles.add(patchModuleArgsFile);
         } else {
             final String jdkJarName = PluginUtil.getJdkJarName();
             this.jdkJar =

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -121,12 +121,11 @@ public class CheckerMain {
         if (PluginUtil.getJreVersion() > 8) {
             final int jreVersion = PluginUtil.getJreVersion();
             final String jdkVersionFolderName = "jdk" + jreVersion;
-            final File jdkVersionModuleLocation =
-                    new File(annotatedJDKSearchPath, jdkVersionFolderName);
-            this.jdkJar = extractFileArg(PluginUtil.JDK_PATH_OPT, jdkVersionModuleLocation, args);
-            final File patchModuleArgsFile =
-                    new File(jdkVersionModuleLocation, "Patch_Modules_argfile");
-            argListFiles.add(patchModuleArgsFile);
+            this.jdkJar =
+                    extractFileArg(
+                            PluginUtil.JDK_PATH_OPT,
+                            new File(annotatedJDKSearchPath, jdkVersionFolderName),
+                            args);
         } else {
             final String jdkJarName = PluginUtil.getJdkJarName();
             this.jdkJar =

--- a/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
@@ -37,7 +37,7 @@ public class PluginUtil {
      * Option name for specifying an alternative jdk.jar location in case of Java8. The accompanying
      * value MUST be the path to the jar file (NOT the path to its encompassing directory) In Case
      * of Java 9+ this option specifies directory containing alternate <modules>.jar which will be
-     * patched using {@code --patch-module <module>=<NewModule>}
+     * patched using {@code --patch-module &lt;module&gt;=&lt;NewModule&gt;}
      */
     public static final String JDK_PATH_OPT = "-jdkJar";
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
@@ -34,10 +34,10 @@ public class PluginUtil {
     public static final String JAVAC_PATH_OPT = "-javacJar";
 
     /**
-     * Option name for specifying an alternative jdk.jar location in case of Java8. The accompanying value MUST be
-     * the path to the jar file (NOT the path to its encompassing directory)
-     * In Case of Java 9+ this option specifies directory containing alternate <modules>.jar
-     * which will be patched using {@code --patch-module <module>=<NewModule>}
+     * Option name for specifying an alternative jdk.jar location in case of Java8. The accompanying
+     * value MUST be the path to the jar file (NOT the path to its encompassing directory) In Case
+     * of Java 9+ this option specifies directory containing alternate <modules>.jar which will be
+     * patched using {@code --patch-module <module>=<NewModule>}
      */
     public static final String JDK_PATH_OPT = "-jdkJar";
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
@@ -36,8 +36,8 @@ public class PluginUtil {
     /**
      * Option name for specifying an alternative jdk.jar location in case of Java8. The accompanying
      * value MUST be the path to the jar file (NOT the path to its encompassing directory) In Case
-     * of Java 9+ this option specifies directory containing alternate &lt;module&gt;.jar which will be
-     * patched using {@code --patch-module &lt;module&gt;=&lt;NewModule&gt;}
+     * of Java 9+ this option specifies directory containing alternate &lt;module&gt;.jar which will
+     * be patched using {@code --patch-module &lt;module&gt;=&lt;NewModule&gt;}
      */
     public static final String JDK_PATH_OPT = "-jdkJar";
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
@@ -36,7 +36,7 @@ public class PluginUtil {
     /**
      * Option name for specifying an alternative jdk.jar location in case of Java8. The accompanying
      * value MUST be the path to the jar file (NOT the path to its encompassing directory) In Case
-     * of Java 9+ this option specifies directory containing alternate <modules>.jar which will be
+     * of Java 9+ this option specifies directory containing alternate &lt;module&gt;.jar which will be
      * patched using {@code --patch-module &lt;module&gt;=&lt;NewModule&gt;}
      */
     public static final String JDK_PATH_OPT = "-jdkJar";

--- a/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
@@ -34,8 +34,10 @@ public class PluginUtil {
     public static final String JAVAC_PATH_OPT = "-javacJar";
 
     /**
-     * Option name for specifying an alternative jdk.jar location. The accompanying value MUST be
+     * Option name for specifying an alternative jdk.jar location in case of Java8. The accompanying value MUST be
      * the path to the jar file (NOT the path to its encompassing directory)
+     * In Case of Java 9+ this option specifies directory containing alternate <modules>.jar
+     * which will be patched using {@code --patch-module <module>=<NewModule>}
      */
     public static final String JDK_PATH_OPT = "-jdkJar";
 


### PR DESCRIPTION
This pull request makes changes so that CheckerMain class doesn't search for jdk{VERSION}.jar while using JDK9+. 
Instead, search for $CHECKERFRAMEWORK/checker/dist/annotatedJDK/jdk{VERSION} directory.