### PR TITLE
Use $SLUGOWNER/guava in the job downstream

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -162,7 +162,7 @@ if [[ "${GROUP}" == "downstream" || "${GROUP}" == "all" ]]; then
   REPO=`/tmp/plume-scripts/git-find-fork ${SLUGOWNER} typetools guava`
   BRANCH=`/tmp/plume-scripts/git-find-branch ${REPO} ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} cf-master`
   if [ $BRANCH = "master" ] ; then
-    REPO=https://github.com/typetools/guava.git
+    REPO=https://github.com/${SLUGOWNER}/guava.git
     BRANCH=`/tmp/plume-scripts/git-find-branch ${REPO} ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} cf-master`
     if [ $BRANCH = "master" ] ; then
       BRANCH=cf-master


### PR DESCRIPTION
This PR is a part of the fix for the downstream build. Now the build job would use eisop/guava instead of typetools/guava.

In addition to this, a new branch `cf-master` needs to be created in the repo guava for the build to succeed, because of this [commit](https://github.com/eisop/checker-framework/commit/8f9b00afbc1ccce1a0bc0a76883ac17db92174eb). Creating `cf-master` from `master` would do the job.