### PR TITLE
Revert support .java files as stub files.

### DIFF
--- a/checker/jtreg/stubs/Issue1542Driver.java
+++ b/checker/jtreg/stubs/Issue1542Driver.java
@@ -3,7 +3,7 @@
  * @summary Test case for Issue 1542 https://github.com/typetools/checker-framework/issues/1542
  *
  * @compile -XDrawDiagnostics issue1542/NeedsIntRange.java issue1542/Stub.java issue1542/ExampleAnno.java
- * @compile -XDrawDiagnostics -processor org.checkerframework.common.value.ValueChecker issue1542/UsesIntRange.java -Astubs=issue1542/NeedsIntRange.astub:issue1542/Stub.astub -AstubWarnIfNotFound -Werror
+ * @compile -XDrawDiagnostics -processor org.checkerframework.common.value.ValueChecker issue1542/UsesIntRange.java -Astubs=issue1542 -AstubWarnIfNotFound -Werror
  */
 
 public class Issue1542Driver {}

--- a/framework/src/main/java/org/checkerframework/framework/stub/StubUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/StubUtil.java
@@ -307,7 +307,7 @@ public class StubUtil {
     }
 
     private static boolean isStub(String path) {
-        return path.endsWith(".astub") || path.endsWith(".java");
+        return path.endsWith(".astub");
     }
 
     private static boolean isJar(File f) {


### PR DESCRIPTION
These changes have been move to a pull request against typetools:
https://github.com/typetools/checker-framework/pull/2666

So, revert them here.