### PR TITLE
Temporarily remove support for "Whole Program Inference"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,9 @@ ext {
 
     parentDir = file("${rootDir}/../").absolutePath
 
-    annotationTools = "${parentDir}/annotation-tools"
-    afu = "${annotationTools}/annotation-file-utilities"
+    // NO-AFU
+    // annotationTools = "${parentDir}/annotation-tools"
+    // afu = "${annotationTools}/annotation-file-utilities"
 
     stubparser = "${parentDir}/stubparser"
     stubparserJar = "${stubparser}/javaparser-core/target/stubparser-3.22.1.jar"
@@ -990,7 +991,8 @@ subprojects {
         tasks.create(name: 'inferenceTests', group: 'Verification') {
             description 'Run inference tests.'
             if (project.name.is('checker')) {
-                dependsOn('ainferTest', 'wpiManyTest', 'wpiPlumeLibTest')
+                // NO-AFU: Needs to depend on future AFU version of CF
+                // dependsOn('ainferTest', 'wpiManyTest', 'wpiPlumeLibTest')
             }
         }
 

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -33,19 +33,20 @@ fi
 # Clone the annotated JDK into ../jdk .
 "$PLUME_SCRIPTS/git-clone-related" eisop jdk
 
-AFU="${AFU:-../annotation-tools/annotation-file-utilities}"
-# Don't use `AT=${AFU}/..` which causes a git failure.
-AT=$(dirname "${AFU}")
+# NO-AFU
+# AFU="${AFU:-../annotation-tools/annotation-file-utilities}"
+# # Don't use `AT=${AFU}/..` which causes a git failure.
+# AT=$(dirname "${AFU}")
 
-## Build annotation-tools (Annotation File Utilities)
-"$PLUME_SCRIPTS/git-clone-related" eisop annotation-tools "${AT}"
-if [ ! -d ../annotation-tools ] ; then
-  ln -s "${AT}" ../annotation-tools
-fi
+# ## Build annotation-tools (Annotation File Utilities)
+# "$PLUME_SCRIPTS/git-clone-related" eisop annotation-tools "${AT}"
+# if [ ! -d ../annotation-tools ] ; then
+#   ln -s "${AT}" ../annotation-tools
+# fi
 
-echo "Running:  (cd ${AT} && ./.build-without-test.sh)"
-(cd "${AT}" && ./.build-without-test.sh)
-echo "... done: (cd ${AT} && ./.build-without-test.sh)"
+# echo "Running:  (cd ${AT} && ./.build-without-test.sh)"
+# (cd "${AT}" && ./.build-without-test.sh)
+# echo "... done: (cd ${AT} && ./.build-without-test.sh)"
 
 
 ## Build stubparser

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -29,11 +29,15 @@ dependencies {
     implementation project(':javacutil')
     implementation project(':dataflow')
     implementation project(':framework')
+
+    /* NO-AFU
     // AFU is an "includedBuild" imported in checker-framework/settings.gradle, so the version number doesn't matter.
     // https://docs.gradle.org/current/userguide/composite_builds.html#settings_defined_composite
     implementation('org.checkerframework:annotation-file-utilities:*') {
         exclude group: 'com.google.errorprone', module: 'javac'
     }
+    */
+
     implementation project(':checker-qual')
     implementation project(':checker-util')
 

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
@@ -13,7 +13,6 @@ import org.checkerframework.checker.formatter.util.FormatUtil;
 import org.checkerframework.checker.signature.qual.CanonicalName;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.common.wholeprograminference.WholeProgramInferenceJavaParserStorage;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.MostlyNoElementQualifierHierarchy;
@@ -25,14 +24,16 @@ import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TypeSystemError;
 
-import scenelib.annotations.Annotation;
-import scenelib.annotations.el.AField;
-import scenelib.annotations.el.AMethod;
-
 import java.util.IllegalFormatException;
-import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
+
+/* NO-AFU
+   import org.checkerframework.common.wholeprograminference.WholeProgramInferenceJavaParserStorage;
+   import scenelib.annotations.Annotation;
+   import scenelib.annotations.el.AField;
+   import scenelib.annotations.el.AMethod;
+*/
 
 /**
  * Adds {@link Format} to the type of tree, if it is a {@code String} or {@code char} literal that
@@ -84,12 +85,13 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         return new ListTreeAnnotator(super.createTreeAnnotator(), new FormatterTreeAnnotator(this));
     }
 
-    /**
+    /* NO-AFU
      * {@inheritDoc}
      *
      * <p>If a method is annotated with {@code @FormatMethod}, remove any {@code @Format} annotation
      * from its first argument.
      */
+    /* NO-AFU
     @Override
     public void prepareMethodForWriting(AMethod method) {
         if (hasFormatMethodAnno(method)) {
@@ -103,13 +105,15 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
         }
     }
+    */
 
-    /**
+    /* NO-AFU
      * {@inheritDoc}
      *
      * <p>If a method is annotated with {@code @FormatMethod}, remove any {@code @Format} annotation
      * from its first argument.
      */
+    /* NO-AFU
     @Override
     public void prepareMethodForWriting(
             WholeProgramInferenceJavaParserStorage.CallableDeclarationAnnos methodAnnos) {
@@ -118,13 +122,15 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             atm.removeAnnotationByClass(org.checkerframework.checker.formatter.qual.Format.class);
         }
     }
+    */
 
-    /**
+    /* NO-AFU
      * Returns true if the method has a {@code @FormatMethod} annotation.
      *
      * @param methodAnnos method annotations
      * @return true if the method has a {@code @FormatMethod} annotation
      */
+    /* NO-AFU
     private boolean hasFormatMethodAnno(AMethod methodAnnos) {
         for (Annotation anno : methodAnnos.tlAnnotationsHere) {
             String annoName = anno.def.name;
@@ -135,13 +141,15 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
         return false;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Returns true if the method has a {@code @FormatMethod} annotation.
      *
      * @param methodAnnos method annotations
      * @return true if the method has a {@code @FormatMethod} annotation
      */
+    /* NO-AFU
     private boolean hasFormatMethodAnno(
             WholeProgramInferenceJavaParserStorage.CallableDeclarationAnnos methodAnnos) {
         Set<AnnotationMirror> declarationAnnos = methodAnnos.getDeclarationAnnotations();
@@ -151,6 +159,7 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 || AnnotationUtils.containsSameByName(
                         declarationAnnos, "com.google.errorprone.annotations.FormatMethod");
     }
+    */
 
     /** The tree annotator for the Format String Checker. */
     private class FormatterTreeAnnotator extends TreeAnnotator {

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
@@ -16,7 +16,6 @@ import org.checkerframework.checker.formatter.qual.FormatMethod;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
-import org.checkerframework.common.wholeprograminference.WholeProgramInference;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ElementUtils;
@@ -32,6 +31,10 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+
+/* NO-AFU
+   import org.checkerframework.common.wholeprograminference.WholeProgramInference;
+*/
 
 /**
  * Whenever a format method invocation is found in the syntax tree, checks are performed as
@@ -163,13 +166,15 @@ public class FormatterVisitor extends BaseTypeVisitor<FormatterAnnotatedTypeFact
                 }
             }
 
-            // Support -Ainfer command-line argument.
-            WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
-            if (wpi != null && forwardsArguments(node, enclosingMethod)) {
-                wpi.addMethodDeclarationAnnotation(
-                        TreeUtils.elementFromDeclaration(enclosingMethod),
-                        atypeFactory.FORMATMETHOD);
-            }
+            /* NO-AFU
+                   // Support -Ainfer command-line argument.
+                   WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
+                   if (wpi != null && forwardsArguments(node, enclosingMethod)) {
+                       wpi.addMethodDeclarationAnnotation(
+                               TreeUtils.elementFromDeclaration(enclosingMethod),
+                               atypeFactory.FORMATMETHOD);
+                   }
+            */
         }
         return super.visitMethodInvocation(node, p);
     }

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -15,7 +15,6 @@ import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.nullness.NullnessChecker;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
-import org.checkerframework.common.wholeprograminference.WholeProgramInference;
 import org.checkerframework.dataflow.expression.ClassName;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.JavaExpression;
@@ -45,6 +44,10 @@ import java.util.StringJoiner;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+
+/* NO-AFU
+   import org.checkerframework.common.wholeprograminference.WholeProgramInference;
+*/
 
 /**
  * The visitor for the freedom-before-commitment type-system. The freedom-before-commitment
@@ -445,20 +448,22 @@ public class InitializationVisitor<
             }
         }
 
-        // Support -Ainfer command-line argument.
-        WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
-        if (wpi != null) {
-            // For each uninitialized field, treat it as if the default value is assigned to it.
-            List<VariableTree> uninitFields = new ArrayList<>(violatingFields);
-            uninitFields.addAll(nonviolatingFields);
-            for (VariableTree fieldTree : uninitFields) {
-                Element elt = TreeUtils.elementFromTree(fieldTree);
-                wpi.updateFieldFromType(
-                        fieldTree,
-                        elt,
-                        fieldTree.getName().toString(),
-                        atypeFactory.getDefaultValueAnnotatedType(elt.asType()));
-            }
-        }
+        /* NO-AFU
+               // Support -Ainfer command-line argument.
+               WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
+               if (wpi != null) {
+                   // For each uninitialized field, treat it as if the default value is assigned to it.
+                   List<VariableTree> uninitFields = new ArrayList<>(violatingFields);
+                   uninitFields.addAll(nonviolatingFields);
+                   for (VariableTree fieldTree : uninitFields) {
+                       Element elt = TreeUtils.elementFromTree(fieldTree);
+                       wpi.updateFieldFromType(
+                               fieldTree,
+                               elt,
+                               fieldTree.getName().toString(),
+                               atypeFactory.getDefaultValueAnnotatedType(elt.asType()));
+                   }
+               }
+        */
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -16,24 +16,18 @@ import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
-import com.sun.tools.javac.code.Symbol.ClassSymbol;
-import com.sun.tools.javac.code.Symbol.VarSymbol;
 
 import org.checkerframework.checker.initialization.InitializationAnnotatedTypeFactory;
 import org.checkerframework.checker.initialization.qual.FBCBottom;
 import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
-import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.dataflow.analysis.Analysis;
-import org.checkerframework.dataflow.analysis.Analysis.BeforeOrAfter;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeFormatter;
@@ -58,7 +52,6 @@ import org.checkerframework.framework.util.QualifierKind;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.Pair;
-import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypeSystemError;
 import org.checkerframework.javacutil.TypesUtils;
@@ -75,7 +68,6 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -785,6 +777,7 @@ public class NullnessAnnotatedTypeFactory
         return result;
     }
 
+    /* NO-AFU
     // If
     //  1. rhs is @Nullable
     //  2. lhs is a field of this
@@ -853,30 +846,35 @@ public class NullnessAnnotatedTypeFactory
         return super.createRequiresOrEnsuresQualifier(
                 expression, qualifier, declaredType, preOrPost, preconds);
     }
+    */
 
-    /**
+    /* NO-AFU
      * Returns a {@code RequiresNonNull("...")} annotation for the given expression.
      *
      * @param expression an expression
      * @return a {@code RequiresNonNull("...")} annotation for the given expression
      */
+    /* NO-AFU
     private AnnotationMirror requiresNonNullAnno(String expression) {
         AnnotationBuilder builder = new AnnotationBuilder(processingEnv, RequiresNonNull.class);
         builder.setValue("value", new String[] {expression});
         AnnotationMirror am = builder.build();
         return am;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Returns a {@code EnsuresNonNull("...")} annotation for the given expression.
      *
      * @param expression an expression
      * @return a {@code EnsuresNonNull("...")} annotation for the given expression
      */
+    /* NO-AFU
     private AnnotationMirror ensuresNonNullAnno(String expression) {
         AnnotationBuilder builder = new AnnotationBuilder(processingEnv, EnsuresNonNull.class);
         builder.setValue("value", new String[] {expression});
         AnnotationMirror am = builder.build();
         return am;
     }
+    */
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ Version 3.17.0-eisop1 (August ?, 2021)
 The new `-AnoJreVersionCheck` command-line argument can be used to not get
 a warning about running the Checker Framework on an unsupported JRE version.
 
+Temporarily remove support for "Whole Program Inference" - the -Ainfer option and
+related scripts.
+
 **Implementation details:**
 
 Changes to `AnnotatedTypeMirror`:

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -18,6 +18,11 @@ sourceSets {
         resources {
             // Stub files, message.properties, etc.
             srcDirs += ['src/main/java', "${buildDir}/generated/resources"]
+
+            // NO-AFU
+            exclude '**/org/checkerframework/common/wholeprograminference/**'
+            exclude '**/org/checkerframework/framework/stub/AddAnnotatedFor.java'
+            exclude '**/org/checkerframework/framework/stub/ToIndexFileConverter.java'
         }
     }
     testannotations

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -8,6 +8,13 @@ ext {
 
 sourceSets {
     main {
+        java {
+            // NO-AFU
+            exclude '**/org/checkerframework/common/wholeprograminference/**'
+            exclude '**/org/checkerframework/framework/stub/AddAnnotatedFor.java'
+            exclude '**/org/checkerframework/framework/stub/ToIndexFileConverter.java'
+        }
+
         resources {
             // Stub files, message.properties, etc.
             srcDirs += ['src/main/java', "${buildDir}/generated/resources"]
@@ -31,11 +38,16 @@ dependencies {
     api project(':javacutil')
     api project(':dataflow')
     api files("${stubparserJar}")
+
+    // NO-AFU
+    /*
     // AFU is an "includedBuild" imported in checker-framework/settings.gradle, so the version number doesn't matter.
     // https://docs.gradle.org/current/userguide/composite_builds.html#settings_defined_composite
     api('org.checkerframework:annotation-file-utilities:*') {
         exclude group: 'com.google.errorprone', module: 'javac'
     }
+    */
+
     api project(':checker-qual')
 
     // External dependencies:

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -50,8 +50,6 @@ import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.common.wholeprograminference.WholeProgramInference;
-import org.checkerframework.dataflow.analysis.Analysis;
 import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.node.BooleanLiteralNode;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -148,6 +146,10 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.tools.Diagnostic.Kind;
 
+/* NO-AFU
+   import org.checkerframework.common.wholeprograminference.WholeProgramInference;
+*/
+
 /**
  * A {@link SourceVisitor} that performs assignment and pseudo-assignment checking, method
  * invocation checking, and assignability checking.
@@ -237,8 +239,12 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
     /** True if "-Ashowchecks" was passed on the command line. */
     private final boolean showchecks;
-    /** True if "-Ainfer" was passed on the command line. */
+
+    /* NO-AFU True if "-Ainfer" was passed on the command line. */
+    /* NO-AFU
     private final boolean infer;
+    */
+
     /** True if "-AsuggestPureMethods" or "-Ainfer" was passed on the command line. */
     private final boolean suggestPureMethods;
     /**
@@ -281,8 +287,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         targetValueElement = TreeUtils.getMethod(Target.class, "value", 0, env);
         unusedWhenElement = TreeUtils.getMethod(Unused.class, "when", 0, env);
         showchecks = checker.hasOption("showchecks");
-        infer = checker.hasOption("infer");
-        suggestPureMethods = checker.hasOption("suggestPureMethods") || infer;
+        /* NO-AFU
+               infer = checker.hasOption("infer");
+        */
+        suggestPureMethods = checker.hasOption("suggestPureMethods"); // NO-AFU || infer;
         checkPurity = checker.hasOption("checkPurityAnnotations") || suggestPureMethods;
     }
 
@@ -977,20 +985,22 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             checkContractsAtMethodDeclaration(
                     node, methodElement, formalParamNames, abstractMethod);
 
-            // Infer postconditions
-            if (atypeFactory.getWholeProgramInference() != null) {
-                assert ElementUtils.isElementFromSourceCode(methodElement);
+            /* NO-AFU
+                   // Infer postconditions
+                   if (atypeFactory.getWholeProgramInference() != null) {
+                       assert ElementUtils.isElementFromSourceCode(methodElement);
 
-                // TODO: Infer conditional postconditions too.
-                CFAbstractStore<?, ?> store = atypeFactory.getRegularExitStore(node);
-                // The store is null if the method has no normal exit, for example if its body is a
-                // throw statement.
-                if (store != null) {
-                    atypeFactory
-                            .getWholeProgramInference()
-                            .updateContracts(Analysis.BeforeOrAfter.AFTER, methodElement, store);
-                }
-            }
+                       // TODO: Infer conditional postconditions too.
+                       CFAbstractStore<?, ?> store = atypeFactory.getRegularExitStore(node);
+                       // The store is null if the method has no normal exit, for example if its body is a
+                       // throw statement.
+                       if (store != null) {
+                           atypeFactory
+                                   .getWholeProgramInference()
+                                   .updateContracts(Analysis.BeforeOrAfter.AFTER, methodElement, store);
+                       }
+                   }
+            */
 
             checkForPolymorphicQualifiers(node.getTypeParameters());
 
@@ -1057,31 +1067,33 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 additionalKinds.remove(Pure.Kind.DETERMINISTIC);
             }
             if (!additionalKinds.isEmpty()) {
-                if (infer) {
-                    if (inferPurity) {
-                        WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
-                        ExecutableElement methodElt = TreeUtils.elementFromDeclaration(node);
-                        if (additionalKinds.size() == 2) {
-                            wpi.addMethodDeclarationAnnotation(methodElt, PURE);
-                        } else if (additionalKinds.contains(Pure.Kind.SIDE_EFFECT_FREE)) {
-                            wpi.addMethodDeclarationAnnotation(methodElt, SIDE_EFFECT_FREE);
-                        } else if (additionalKinds.contains(Pure.Kind.DETERMINISTIC)) {
-                            wpi.addMethodDeclarationAnnotation(methodElt, DETERMINISTIC);
-                        } else {
-                            throw new BugInCF("Unexpected purity kind in " + additionalKinds);
-                        }
-                    }
+                /* NO-AFU
+                              if (infer) {
+                                  if (inferPurity) {
+                                      WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
+                                      ExecutableElement methodElt = TreeUtils.elementFromDeclaration(node);
+                                      if (additionalKinds.size() == 2) {
+                                          wpi.addMethodDeclarationAnnotation(methodElt, PURE);
+                                      } else if (additionalKinds.contains(Pure.Kind.SIDE_EFFECT_FREE)) {
+                                          wpi.addMethodDeclarationAnnotation(methodElt, SIDE_EFFECT_FREE);
+                                      } else if (additionalKinds.contains(Pure.Kind.DETERMINISTIC)) {
+                                          wpi.addMethodDeclarationAnnotation(methodElt, DETERMINISTIC);
+                                      } else {
+                                          throw new BugInCF("Unexpected purity kind in " + additionalKinds);
+                                      }
+                                  }
+                              } else {
+                */
+                if (additionalKinds.size() == 2) {
+                    checker.reportWarning(node, "purity.more.pure", node.getName());
+                } else if (additionalKinds.contains(Pure.Kind.SIDE_EFFECT_FREE)) {
+                    checker.reportWarning(node, "purity.more.sideeffectfree", node.getName());
+                } else if (additionalKinds.contains(Pure.Kind.DETERMINISTIC)) {
+                    checker.reportWarning(node, "purity.more.deterministic", node.getName());
                 } else {
-                    if (additionalKinds.size() == 2) {
-                        checker.reportWarning(node, "purity.more.pure", node.getName());
-                    } else if (additionalKinds.contains(Pure.Kind.SIDE_EFFECT_FREE)) {
-                        checker.reportWarning(node, "purity.more.sideeffectfree", node.getName());
-                    } else if (additionalKinds.contains(Pure.Kind.DETERMINISTIC)) {
-                        checker.reportWarning(node, "purity.more.deterministic", node.getName());
-                    } else {
-                        throw new BugInCF("Unexpected purity kind in " + additionalKinds);
-                    }
+                    throw new BugInCF("Unexpected purity kind in " + additionalKinds);
                 }
+                // NO-AFU }
             }
         }
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -41,10 +41,6 @@ import org.checkerframework.common.reflection.MethodValAnnotatedTypeFactory;
 import org.checkerframework.common.reflection.MethodValChecker;
 import org.checkerframework.common.reflection.ReflectionResolver;
 import org.checkerframework.common.reflection.qual.MethodVal;
-import org.checkerframework.common.wholeprograminference.WholeProgramInference;
-import org.checkerframework.common.wholeprograminference.WholeProgramInferenceImplementation;
-import org.checkerframework.common.wholeprograminference.WholeProgramInferenceJavaParserStorage;
-import org.checkerframework.common.wholeprograminference.WholeProgramInferenceScenesStorage;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.framework.qual.AnnotatedFor;
 import org.checkerframework.framework.qual.EnsuresQualifier;
@@ -96,9 +92,6 @@ import org.plumelib.util.CollectionsPlume;
 import org.plumelib.util.ImmutableTypes;
 import org.plumelib.util.StringsPlume;
 
-import scenelib.annotations.el.AMethod;
-import scenelib.annotations.el.ATypeElement;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -143,7 +136,15 @@ import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import javax.tools.Diagnostic;
+
+/* NO-AFU
+   import org.checkerframework.common.wholeprograminference.WholeProgramInference;
+   import org.checkerframework.common.wholeprograminference.WholeProgramInferenceImplementation;
+   import org.checkerframework.common.wholeprograminference.WholeProgramInferenceJavaParserStorage;
+   import org.checkerframework.common.wholeprograminference.WholeProgramInferenceScenesStorage;
+   import scenelib.annotations.el.AMethod;
+   import scenelib.annotations.el.ATypeElement;
+*/
 
 /**
  * The methods of this class take an element or AST node, and return the annotated type as an {@link
@@ -260,8 +261,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /** Represent the type relations. */
     protected TypeHierarchy typeHierarchy;
 
-    /** Performs whole-program inference. If null, whole-program inference is disabled. */
+    /* NO-AFU Performs whole-program inference. If null, whole-program inference is disabled. */
+    /* NO-AFU
     private final @Nullable WholeProgramInference wholeProgramInference;
+    */
 
     /**
      * This formatter is used for converting AnnotatedTypeMirrors to Strings. This formatter will be
@@ -435,11 +438,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /** AnnotationClassLoader used to load type annotation classes via reflective lookup. */
     protected AnnotationClassLoader loader;
 
-    /**
+    /* NO-AFU
      * Which whole-program inference output format to use, if doing whole-program inference. This
      * variable would be final, but it is not set unless WPI is enabled.
      */
+    /* NO-AFU
     public WholeProgramInference.OutputFormat wpiOutputFormat;
+    */
 
     /**
      * Should results be cached? This means that ATM.deepCopy() will be called. ATM.deepCopy() used
@@ -565,47 +570,50 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         this.typeFormatter = createAnnotatedTypeFormatter();
         this.annotationFormatter = createAnnotationFormatter();
 
-        if (checker.hasOption("infer")) {
-            checkInvalidOptionsInferSignatures();
-            String inferArg = checker.getOption("infer");
-            // No argument means "jaifs", for (temporary) backwards compatibility.
-            if (inferArg == null) {
-                inferArg = "jaifs";
-            }
-            switch (inferArg) {
-                case "stubs":
-                    wpiOutputFormat = WholeProgramInference.OutputFormat.STUB;
-                    break;
-                case "jaifs":
-                    wpiOutputFormat = WholeProgramInference.OutputFormat.JAIF;
-                    break;
-                case "ajava":
-                    wpiOutputFormat = WholeProgramInference.OutputFormat.AJAVA;
-                    break;
-                default:
-                    throw new UserError(
-                            "Bad argument -Ainfer="
-                                    + inferArg
-                                    + " should be one of: -Ainfer=jaifs, -Ainfer=stubs,"
-                                    + " -Ainfer=ajava");
-            }
-            if (wpiOutputFormat == WholeProgramInference.OutputFormat.AJAVA) {
-                wholeProgramInference =
-                        new WholeProgramInferenceImplementation<AnnotatedTypeMirror>(
-                                this, new WholeProgramInferenceJavaParserStorage(this));
-            } else {
-                wholeProgramInference =
-                        new WholeProgramInferenceImplementation<ATypeElement>(
-                                this, new WholeProgramInferenceScenesStorage(this));
-            }
-            if (!checker.hasOption("warns")) {
-                // Without -Awarns, the inference output may be incomplete, because javac halts
-                // after issuing an error.
-                checker.message(Diagnostic.Kind.ERROR, "Do not supply -Ainfer without -Awarns");
-            }
-        } else {
-            wholeProgramInference = null;
-        }
+        /* NO-AFU
+               if (checker.hasOption("infer")) {
+                   checkInvalidOptionsInferSignatures();
+                   String inferArg = checker.getOption("infer");
+                   // No argument means "jaifs", for (temporary) backwards compatibility.
+                   if (inferArg == null) {
+                       inferArg = "jaifs";
+                   }
+                   switch (inferArg) {
+                       case "stubs":
+                           wpiOutputFormat = WholeProgramInference.OutputFormat.STUB;
+                           break;
+                       case "jaifs":
+                           wpiOutputFormat = WholeProgramInference.OutputFormat.JAIF;
+                           break;
+                       case "ajava":
+                           wpiOutputFormat = WholeProgramInference.OutputFormat.AJAVA;
+                           break;
+                       default:
+                           throw new UserError(
+                                   "Bad argument -Ainfer="
+                                           + inferArg
+                                           + " should be one of: -Ainfer=jaifs, -Ainfer=stubs,"
+                                           + " -Ainfer=ajava");
+                   }
+                   if (wpiOutputFormat == WholeProgramInference.OutputFormat.AJAVA) {
+                       wholeProgramInference =
+                               new WholeProgramInferenceImplementation<AnnotatedTypeMirror>(
+                                       this, new WholeProgramInferenceJavaParserStorage(this));
+                   } else {
+                       wholeProgramInference =
+                               new WholeProgramInferenceImplementation<ATypeElement>(
+                                       this, new WholeProgramInferenceScenesStorage(this));
+                   }
+                   if (!checker.hasOption("warns")) {
+                       // Without -Awarns, the inference output may be incomplete, because javac halts
+                       // after issuing an error.
+                       checker.message(Diagnostic.Kind.ERROR, "Do not supply -Ainfer without -Awarns");
+                   }
+               } else {
+                   wholeProgramInference = null;
+               }
+        */
+
         ignoreUninferredTypeArguments = !checker.hasOption("conservativeUninferredTypeArguments");
 
         objectGetClass = TreeUtils.getMethod("java.lang.Object", "getClass", 0, processingEnv);
@@ -688,7 +696,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         }
     }
 
-    /**
+    /* NO-AFU
      * This method is called only when {@code -Ainfer} is passed as an option. It checks if another
      * option that should not occur simultaneously with the whole-program inference is also passed
      * as argument, and aborts the process if that is the case. For example, the whole-program
@@ -696,6 +704,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *
      * <p>Subclasses may override this method to add more options.
      */
+    /* NO-AFU
     protected void checkInvalidOptionsInferSignatures() {
         // See Issue 683
         // https://github.com/typetools/checker-framework/issues/683
@@ -705,6 +714,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                     "The option -Ainfer=... cannot be used together with conservative defaults.");
         }
     }
+    */
 
     /**
      * Actions that logically belong in the constructor, but need to run after the subclass
@@ -815,14 +825,16 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         return qualifierUpperBounds;
     }
 
-    /**
+    /* NO-AFU
      * Returns the WholeProgramInference instance (may be null).
      *
      * @return the WholeProgramInference instance, or null
      */
+    /* NO-AFU
     public WholeProgramInference getWholeProgramInference() {
         return wholeProgramInference;
     }
+    */
 
     protected void initializeReflectionResolution() {
         if (checker.shouldResolveReflection()) {
@@ -845,14 +857,16 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @param root the new compilation unit to use
      */
     public void setRoot(@Nullable CompilationUnitTree root) {
-        if (root != null && wholeProgramInference != null) {
-            for (Tree typeDecl : root.getTypeDecls()) {
-                if (typeDecl.getKind() == Tree.Kind.CLASS) {
-                    ClassTree classTree = (ClassTree) typeDecl;
-                    wholeProgramInference.preprocessClassTree(classTree);
-                }
-            }
-        }
+        /* NO-AFU
+               if (root != null && wholeProgramInference != null) {
+                   for (Tree typeDecl : root.getTypeDecls()) {
+                       if (typeDecl.getKind() == Tree.Kind.CLASS) {
+                           ClassTree classTree = (ClassTree) typeDecl;
+                           wholeProgramInference.preprocessClassTree(classTree);
+                       }
+                   }
+               }
+        */
 
         this.root = root;
         // Do not clear here. Only the primary checker should clear this cache.
@@ -1325,14 +1339,16 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     public void postProcessClassTree(ClassTree tree) {
         TypesIntoElements.store(processingEnv, this, tree);
         DeclarationsIntoElements.store(processingEnv, this, tree);
-        if (wholeProgramInference != null) {
-            // Write out the results of whole-program inference, just once for each class.  As soon
-            // as any class is finished processing, all modified scenes are written to files, in
-            // case this was the last class to be processed.  Post-processing of subsequent classes
-            // might result in re-writing some of the scenes if new information has been written to
-            // them.
-            wholeProgramInference.writeResultsToFile(wpiOutputFormat, this.checker);
-        }
+        /* NO-AFU
+               if (wholeProgramInference != null) {
+                   // Write out the results of whole-program inference, just once for each class.  As soon
+                   // as any class is finished processing, all modified scenes are written to files, in
+                   // case this was the last class to be processed.  Post-processing of subsequent classes
+                   // might result in re-writing some of the scenes if new information has been written to
+                   // them.
+                   wholeProgramInference.writeResultsToFile(wpiOutputFormat, this.checker);
+               }
+        */
     }
 
     /**
@@ -5453,7 +5469,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         return null;
     }
 
-    /**
+    /* NO-AFU
      * Changes the type of {@code rhsATM} when being assigned to a field, for use by whole-program
      * inference. The default implementation does nothing.
      *
@@ -5463,38 +5479,46 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @param rhsATM the type of the expression being assigned to the field, which is side-effected
      *     by this method
      */
+    /* NO-AFU
     public void wpiAdjustForUpdateField(
             Tree lhsTree, Element element, String fieldName, AnnotatedTypeMirror rhsATM) {}
+    */
 
-    /**
+    /* NO-AFU
      * Changes the type of {@code rhsATM} when being assigned to anything other than a field, for
      * use by whole-program inference. The default implementation does nothing.
      *
      * @param rhsATM the type of the rhs of the pseudo-assignment, which is side-effected by this
      *     method
      */
+    /* NO-AFU
     public void wpiAdjustForUpdateNonField(AnnotatedTypeMirror rhsATM) {}
+    */
 
-    /**
+    /* NO-AFU
      * Side-effects the method or constructor annotations to make any desired changes before writing
      * to an annotation file.
      *
      * @param methodAnnos the method or constructor annotations to modify
      */
+    /* NO-AFU
     public void prepareMethodForWriting(AMethod methodAnnos) {
         // This implementation does nothing.
     }
+    */
 
-    /**
+    /* NO-AFU
      * Side-effects the method or constructor annotations to make any desired changes before writing
      * to an ajava file.
      *
      * @param methodAnnos the method or constructor annotations to modify
      */
+    /* NO-AFU
     public void prepareMethodForWriting(
             WholeProgramInferenceJavaParserStorage.CallableDeclarationAnnos methodAnnos) {
         // This implementation does nothing.
     }
+    */
 
     /**
      * Does {@code anno}, which is an {@link org.checkerframework.framework.qual.AnnotatedFor}

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -18,9 +18,6 @@ import com.sun.source.util.TreePath;
 import org.checkerframework.checker.formatter.qual.FormatMethod;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.common.wholeprograminference.WholeProgramInferenceImplementation;
-import org.checkerframework.common.wholeprograminference.WholeProgramInferenceJavaParserStorage;
-import org.checkerframework.common.wholeprograminference.WholeProgramInferenceScenesStorage;
 import org.checkerframework.dataflow.analysis.Analysis;
 import org.checkerframework.dataflow.analysis.Analysis.BeforeOrAfter;
 import org.checkerframework.dataflow.analysis.AnalysisResult;
@@ -99,9 +96,6 @@ import org.plumelib.reflection.Signatures;
 import org.plumelib.util.CollectionsPlume;
 import org.plumelib.util.SystemPlume;
 
-import scenelib.annotations.el.AField;
-import scenelib.annotations.el.AMethod;
-
 import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -129,6 +123,14 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+
+/* NO-AFU
+   import org.checkerframework.common.wholeprograminference.WholeProgramInferenceImplementation;
+   import org.checkerframework.common.wholeprograminference.WholeProgramInferenceJavaParserStorage;
+   import org.checkerframework.common.wholeprograminference.WholeProgramInferenceScenesStorage;
+   import scenelib.annotations.el.AField;
+   import scenelib.annotations.el.AMethod;
+*/
 
 /**
  * A factory that extends {@link AnnotatedTypeFactory} to optionally use flow-sensitive qualifier
@@ -2392,7 +2394,7 @@ public abstract class GenericAnnotatedTypeFactory<
         return defaultValueATM;
     }
 
-    /**
+    /* NO-AFU
      * Return the contract annotations (that is, pre- and post-conditions) for the given AMethod.
      * Does not modify the AMethod. This method must only be called when using
      * WholeProgramInferenceScenes.
@@ -2400,6 +2402,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param m AFU representation of a method
      * @return contract annotations for the method
      */
+    /* NO-AFU
     public List<AnnotationMirror> getContractAnnotations(AMethod m) {
         List<AnnotationMirror> preconds = getPreconditionAnnotations(m);
         List<AnnotationMirror> postconds = getPostconditionAnnotations(m, preconds);
@@ -2407,14 +2410,16 @@ public abstract class GenericAnnotatedTypeFactory<
         result.addAll(postconds);
         return result;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Return the precondition annotations for the given AMethod. Does not modify the AMethod. This
      * method must only be called when using WholeProgramInferenceScenes.
      *
      * @param m AFU representation of a method
      * @return precondition annotations for the method
      */
+    /* NO-AFU
     public List<AnnotationMirror> getPreconditionAnnotations(AMethod m) {
         List<AnnotationMirror> result = new ArrayList<>(m.getPreconditions().size());
         for (Map.Entry<String, AField> entry : m.getPreconditions().entrySet()) {
@@ -2438,8 +2443,9 @@ public abstract class GenericAnnotatedTypeFactory<
         Collections.sort(result, Ordering.usingToString());
         return result;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Return the postcondition annotations for the given AMethod. Does not modify the AMethod. This
      * method must only be called when using WholeProgramInferenceScenes.
      *
@@ -2448,6 +2454,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *     postconditions
      * @return postcondition annotations for the method
      */
+    /* NO-AFU
     public List<AnnotationMirror> getPostconditionAnnotations(
             AMethod m, List<AnnotationMirror> preconds) {
         List<AnnotationMirror> result = new ArrayList<>(m.getPostconditions().size());
@@ -2475,14 +2482,16 @@ public abstract class GenericAnnotatedTypeFactory<
         Collections.sort(result, Ordering.usingToString());
         return result;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Return the contract annotations (that is, pre- and post-conditions) for the given
      * CallableDeclarationAnnos. Does not modify the CallableDeclarationAnnos.
      *
      * @param methodAnnos annotation data for a method
      * @return contract annotations for the method
      */
+    /* NO-AFU
     public List<AnnotationMirror> getContractAnnotations(
             WholeProgramInferenceJavaParserStorage.CallableDeclarationAnnos methodAnnos) {
         List<AnnotationMirror> preconds = getPreconditionAnnotations(methodAnnos);
@@ -2491,14 +2500,16 @@ public abstract class GenericAnnotatedTypeFactory<
         result.addAll(postconds);
         return result;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Return the precondition annotations for the given CallableDeclarationAnnos. Does not modify
      * the CallableDeclarationAnnos.
      *
      * @param methodAnnos annotation data for a method
      * @return precondition annotations for the method
      */
+    /* NO-AFU
     public List<AnnotationMirror> getPreconditionAnnotations(
             WholeProgramInferenceJavaParserStorage.CallableDeclarationAnnos methodAnnos) {
         List<AnnotationMirror> result = new ArrayList<>();
@@ -2511,8 +2522,9 @@ public abstract class GenericAnnotatedTypeFactory<
         Collections.sort(result, Ordering.usingToString());
         return result;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Return the postcondition annotations for the given CallableDeclarationAnnos. Does not modify
      * the CallableDeclarationAnnos.
      *
@@ -2521,6 +2533,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *     postconditions
      * @return postcondition annotations for the method
      */
+    /* NO-AFU
     public List<AnnotationMirror> getPostconditionAnnotations(
             WholeProgramInferenceJavaParserStorage.CallableDeclarationAnnos methodAnnos,
             List<AnnotationMirror> preconds) {
@@ -2537,8 +2550,9 @@ public abstract class GenericAnnotatedTypeFactory<
         Collections.sort(result, Ordering.usingToString());
         return result;
     }
+    */
 
-    /**
+    /* NO-AFU
      * Returns a list of inferred {@code @RequiresQualifier} annotations for the given expression.
      * By default this list does not include any qualifier that has elements/arguments, which
      * {@code @RequiresQualifier} does not support. Subclasses may remove this restriction by
@@ -2554,13 +2568,15 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param declaredType the declared type of the expression
      * @return precondition annotations for the element (possibly an empty list)
      */
+    /* NO-AFU
     public final List<AnnotationMirror> getPreconditionAnnotations(
             String expression, AnnotatedTypeMirror inferredType, AnnotatedTypeMirror declaredType) {
         return getPreOrPostconditionAnnotations(
                 expression, inferredType, declaredType, BeforeOrAfter.BEFORE, null);
     }
+    */
 
-    /**
+    /* NO-AFU
      * Returns a list of inferred {@code @EnsuresQualifier} annotations for the given expression. By
      * default this list does not include any qualifier that has elements/arguments, which
      * {@code @EnsuresQualifier} does not support; and, preconditions are not used to suppress
@@ -2579,6 +2595,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *     postconditions
      * @return postcondition annotations for the element (possibly an empty list)
      */
+    /* NO-AFU
     public final List<AnnotationMirror> getPostconditionAnnotations(
             String expression,
             AnnotatedTypeMirror inferredType,
@@ -2587,8 +2604,9 @@ public abstract class GenericAnnotatedTypeFactory<
         return getPreOrPostconditionAnnotations(
                 expression, inferredType, declaredType, BeforeOrAfter.AFTER, preconds);
     }
+    */
 
-    /**
+    /* NO-AFU
      * Creates pre- and postcondition annotations. Helper method for {@link
      * #getPreconditionAnnotations} and {@link #getPostconditionAnnotations}.
      *
@@ -2610,6 +2628,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *     postconditions; non-null exactly when {@code preOrPost} is {@code AFTER}
      * @return precondition or postcondition annotations for the element (possibly an empty list)
      */
+    /* NO-AFU
     protected List<AnnotationMirror> getPreOrPostconditionAnnotations(
             String expression,
             AnnotatedTypeMirror inferredType,
@@ -2642,6 +2661,7 @@ public abstract class GenericAnnotatedTypeFactory<
         }
         return result;
     }
+    */
 
     /**
      * Matches parameter expressions as they appear in {@link EnsuresQualifier} and {@link

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,8 @@ include 'checker-qual'
 include 'checker-qual-android'
 include 'checker-util'
 include 'framework-test'
+
+/* NO-AFU
 includeBuild ('../annotation-tools/annotation-file-utilities') {
     if (!file('../annotation-tools/annotation-file-utilities').exists()) {
         exec {
@@ -14,3 +16,4 @@ includeBuild ('../annotation-tools/annotation-file-utilities') {
         }
     }
 }
+*/


### PR DESCRIPTION
This allows us to remove the annotation-tools dependency.
All changes are marked with "NO-AFU" and a future PR will add support in a separate jar file.