### PR TITLE
Fix compound assignment cast types by removing type annotations

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -145,6 +145,7 @@ import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypeKindUtils;
 import org.checkerframework.javacutil.TypesUtils;
 import org.checkerframework.javacutil.trees.TreeBuilder;
@@ -1685,9 +1686,10 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
                     }
                     extendWithNode(operNode);
 
-                    TypeCastTree castTree = treeBuilder.buildTypeCast(leftType, operTree);
+                    TypeMirror castType = TypeAnnotationUtils.unannotatedType(leftType);
+                    TypeCastTree castTree = treeBuilder.buildTypeCast(castType, operTree);
                     handleArtificialTree(castTree);
-                    TypeCastNode castNode = new TypeCastNode(castTree, operNode, leftType, types);
+                    TypeCastNode castNode = new TypeCastNode(castTree, operNode, castType, types);
                     castNode.setInSource(false);
                     extendWithNode(castNode);
 
@@ -1735,10 +1737,11 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
                         }
                         extendWithNode(operNode);
 
-                        TypeCastTree castTree = treeBuilder.buildTypeCast(leftType, operTree);
+                        TypeMirror castType = TypeAnnotationUtils.unannotatedType(leftType);
+                        TypeCastTree castTree = treeBuilder.buildTypeCast(castType, operTree);
                         handleArtificialTree(castTree);
                         TypeCastNode castNode =
-                                new TypeCastNode(castTree, operNode, leftType, types);
+                                new TypeCastNode(castTree, operNode, castType, types);
                         castNode.setInSource(false);
                         extendWithNode(castNode);
 
@@ -1781,9 +1784,10 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
                     }
                     extendWithNode(operNode);
 
-                    TypeCastTree castTree = treeBuilder.buildTypeCast(leftType, operTree);
+                    TypeMirror castType = TypeAnnotationUtils.unannotatedType(leftType);
+                    TypeCastTree castTree = treeBuilder.buildTypeCast(castType, operTree);
                     handleArtificialTree(castTree);
-                    TypeCastNode castNode = new TypeCastNode(castTree, operNode, leftType, types);
+                    TypeCastNode castNode = new TypeCastNode(castTree, operNode, castType, types);
                     castNode.setInSource(false);
                     extendWithNode(castNode);
 
@@ -1834,9 +1838,10 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
                 }
                 extendWithNode(operNode);
 
-                TypeCastTree castTree = treeBuilder.buildTypeCast(leftType, operTree);
+                TypeMirror castType = TypeAnnotationUtils.unannotatedType(leftType);
+                TypeCastTree castTree = treeBuilder.buildTypeCast(castType, operTree);
                 handleArtificialTree(castTree);
-                TypeCastNode castNode = new TypeCastNode(castTree, operNode, leftType, types);
+                TypeCastNode castNode = new TypeCastNode(castTree, operNode, castType, types);
                 castNode.setInSource(false);
                 extendWithNode(castNode);
 

--- a/framework/tests/value/CompoundAssignment.java
+++ b/framework/tests/value/CompoundAssignment.java
@@ -2,6 +2,7 @@
 // Also test case for Issue 624
 // https://github.com/typetools/checker-framework/issues/624
 
+import org.checkerframework.common.value.qual.IntRange;
 import org.checkerframework.common.value.qual.IntVal;
 import org.checkerframework.common.value.qual.StringVal;
 
@@ -49,6 +50,39 @@ public class CompoundAssignment {
         @IntVal(1) int i = 1;
         // :: error: (assignment.type.incompatible)
         i = i + 1;
+    }
+
+    @IntRange(from = 5, to = 10) int afield;
+
+    void afield() {
+        if (afield == 5) {
+            afield += 5;
+        }
+        // :: error: (compound.assignment.type.incompatible)
+        afield += 2;
+    }
+
+    void aparam(@IntRange(from = 5, to = 10) int aparam) {
+        if (aparam == 5) {
+            aparam += 5;
+        }
+        // :: error: (compound.assignment.type.incompatible)
+        aparam += 2;
+    }
+
+    void alocal() {
+        @IntRange(from = 5, to = 10) int alocal;
+        if (this.hashCode() > 100) {
+            alocal = 5;
+        } else {
+            alocal = 10;
+        }
+
+        if (alocal == 5) {
+            alocal += 5;
+        }
+        // :: error: (compound.assignment.type.incompatible)
+        alocal += 2;
     }
 
     void noErrorCompoundAssignments() {


### PR DESCRIPTION
Fixes #121 

javac stores type annotations in TypeMirrors for fields and parameters (and maybe others). #121 uncovered that using that annotated type in a compound assignment cast type leads to incorrect results.