### PR TITLE
Update to expect version 0.0.0-SNAPSHOT of jspecify.

### DIFF
--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJSpecifySamplesTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessJSpecifySamplesTest.java
@@ -41,7 +41,7 @@ public class NullnessJSpecifySamplesTest extends CheckerFrameworkPerDirectoryTes
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "../../../jspecify/samples",
-                Collections.singletonList("../../jspecify/build/libs/jspecify-0.1.0-SNAPSHOT.jar"),
+                Collections.singletonList("../../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"),
                 "-Anomsgtext");
     }
 


### PR DESCRIPTION
See
https://github.com/jspecify/jspecify/commit/0d39a0e8bf4ec863a2738835bb2421b25c48f282
and
https://github.com/jspecify/nullness-checker-for-checker-framework/commit/5fe600a48ddd3210cb49794f79bf74a38a94ff45

This change lets `./gradlew :checker:NullnessJSpecifySamples` identify
"real failures" instead of "package org.jspecify.nullness does not
exist."