### PR TITLE
Recognize that `@NullMarked` restricts `<T>` to non-null types.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -49,6 +49,7 @@ import org.checkerframework.framework.type.typeannotator.PropagationTypeAnnotato
 import org.checkerframework.framework.type.typeannotator.TypeAnnotator;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.QualifierKind;
+import org.checkerframework.framework.util.defaults.QualifierDefaults;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.Pair;
@@ -485,6 +486,11 @@ public class NullnessAnnotatedTypeFactory
         defaultForTypeAnnotator.addAtmClass(AnnotatedNoType.class, NONNULL);
         defaultForTypeAnnotator.addAtmClass(AnnotatedPrimitiveType.class, NONNULL);
         return defaultForTypeAnnotator;
+    }
+
+    @Override
+    protected QualifierDefaults createQualifierDefaults() {
+        return new QualifierDefaults(elements, this, /*shouldApplyNullMarkedDefaults=*/ true);
     }
 
     @Override

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessNullMarkedSubpackageTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessNullMarkedSubpackageTest.java
@@ -9,31 +9,27 @@ import java.util.Collections;
 import java.util.List;
 
 /** JUnit tests for the Nullness checker. */
-public class NullnessTest extends CheckerFrameworkPerDirectoryTest {
+public class NullnessNullMarkedSubpackageTest extends CheckerFrameworkPerDirectoryTest {
 
     /**
-     * Create a NullnessTest.
+     * Create a NullnessAssertsTest.
      *
      * @param testFiles the files containing test code, which will be type-checked
      */
-    public NullnessTest(List<File> testFiles) {
-        // TODO: remove soundArrayCreationNullness option once it's no
-        // longer needed.  See issue #986:
-        // https://github.com/typetools/checker-framework/issues/986
+    public NullnessNullMarkedSubpackageTest(List<File> testFiles) {
         super(
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
                 Collections.singletonList("../../jspecify/build/libs/jspecify-0.0.0-SNAPSHOT.jar"),
                 "-AcheckPurityAnnotations",
+                "-AassumeAssertionsAreEnabled",
                 "-Anomsgtext",
-                "-Xlint:deprecation",
-                "-Alint=soundArrayCreationNullness,"
-                        + NullnessChecker.LINT_REDUNDANTNULLCOMPARISON);
+                "-Xlint:deprecation");
     }
 
     @Parameters
     public static String[] getTestDirs() {
-        return new String[] {"nullness", "initialization", "all-systems"};
+        return new String[] {"nullness-nullmarked-subpackage"};
     }
 }

--- a/checker/tests/nullness-nullmarked-subpackage/parentandchildpackage/NotNullMarkedBecauseChildPackage.java
+++ b/checker/tests/nullness-nullmarked-subpackage/parentandchildpackage/NotNullMarkedBecauseChildPackage.java
@@ -1,0 +1,7 @@
+package parent.child;
+
+import org.jspecify.nullness.Nullable;
+
+public class NotNullMarkedBecauseChildPackage<T> {
+  void foo(NotNullMarkedBecauseChildPackage<@Nullable String> d) {}
+}

--- a/checker/tests/nullness-nullmarked-subpackage/parentandchildpackage/package-info.java
+++ b/checker/tests/nullness-nullmarked-subpackage/parentandchildpackage/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.nullness.NullMarked
+package parent;

--- a/checker/tests/nullness-nullmarked-subpackage/singlepackage/NullMarkedBecausePackageIs.java
+++ b/checker/tests/nullness-nullmarked-subpackage/singlepackage/NullMarkedBecausePackageIs.java
@@ -1,0 +1,8 @@
+package other;
+
+import org.jspecify.nullness.Nullable;
+
+public class NullMarkedBecausePackageIs<T> {
+  // :: error: (type.argument.type.incompatible)
+  void foo(NullMarkedBecausePackageIs<@Nullable String> d) {}
+}

--- a/checker/tests/nullness-nullmarked-subpackage/singlepackage/package-info.java
+++ b/checker/tests/nullness-nullmarked-subpackage/singlepackage/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.nullness.NullMarked
+package other;

--- a/checker/tests/nullness/DefaultNullMarked.java
+++ b/checker/tests/nullness/DefaultNullMarked.java
@@ -1,0 +1,8 @@
+import org.jspecify.nullness.NullMarked;
+import org.jspecify.nullness.Nullable;
+
+@NullMarked
+public class DefaultNullMarked<T> {
+  // :: error: (type.argument.type.incompatible)
+  void foo(DefaultNullMarked<@Nullable String> d) {}
+}


### PR DESCRIPTION
See https://jspecify.dev/spec#object-bounded-type-parameter

This approach is a bit ugly, since it builds knowledge of `@NullMarked`
into the type-system-agnostic `QualifierDefaults`. A cleaner approach
would be something more along the lines of a `populateNewDefaults` hook,
as shown in the commits linked from
https://github.com/jspecify/checker-framework/issues/7. However, that,
too, got ugly....