### PR TITLE
Set duplicate strategy for framework jars

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -33,6 +33,12 @@ sourcesJar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
+jar {
+    // The resources duplicate content from the src directory.
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+
 def versions = [
         autoValue       : "1.7.4",
         lombok          : "1.18.22",


### PR DESCRIPTION
Builds frequently fail for me with this error:

````
* What went wrong:
Execution failed for task ':framework:jar'.
> Entry org/checkerframework/framework/source/messages.properties is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.3/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
````

We set duplicate strategies in many other places, but it seems to be missing for framework jars.