### PR TITLE
Fix dataflow of ternary expressions

### DIFF
--- a/checker/tests/regex/Issue3281.java
+++ b/checker/tests/regex/Issue3281.java
@@ -1,10 +1,10 @@
 // Test case for Issue 3281:
 // https://github.com/typetools/checker-framework/issues/3281
 
-// @skip-test until the bug is fixed
-
 import org.checkerframework.checker.regex.qual.Regex;
 import org.checkerframework.checker.regex.util.RegexUtil;
+
+import java.util.regex.Pattern;
 
 public class Issue3281 {
 
@@ -44,6 +44,7 @@ public class Issue3281 {
     void m4(String s, String s2) {
         RegexUtil.isRegex(s);
         if (RegexUtil.isRegex(s2)) {
+            // :: error: (argument.type.incompatible)
             Pattern.compile(s);
         }
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -2504,25 +2504,84 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
         Label falseStart = new Label();
         Label merge = new Label();
 
+        // create a synthetic variable for the value of the conditional expression
+        VariableTree condExprVarTree =
+                treeBuilder.buildVariableDecl(exprType, uniqueName("condExpr"), findOwner(), null);
+        VariableDeclarationNode condExprVarNode = new VariableDeclarationNode(condExprVarTree);
+        condExprVarNode.setInSource(false);
+        extendWithNode(condExprVarNode);
+
         Node condition = unbox(scan(tree.getCondition(), p));
         ConditionalJump cjump = new ConditionalJump(trueStart, falseStart);
         extendWithExtendedNode(cjump);
 
         addLabelForNextNode(trueStart);
-        Node trueExpr = scan(tree.getTrueExpression(), p);
-        trueExpr = conditionalExprPromotion(trueExpr, exprType);
+        ExpressionTree trueExprTree = tree.getTrueExpression();
+        Node trueExprNode = scan(trueExprTree, p);
+        trueExprNode = conditionalExprPromotion(trueExprNode, exprType);
+
+        extendWithAssignmentForConditionalExpr(condExprVarTree, trueExprTree, trueExprNode);
+
         extendWithExtendedNode(new UnconditionalJump(merge));
 
         addLabelForNextNode(falseStart);
-        Node falseExpr = scan(tree.getFalseExpression(), p);
-        falseExpr = conditionalExprPromotion(falseExpr, exprType);
+        ExpressionTree falseExprTree = tree.getFalseExpression();
+        Node falseExprNode = scan(falseExprTree, p);
+        falseExprNode = conditionalExprPromotion(falseExprNode, exprType);
+
+        extendWithAssignmentForConditionalExpr(condExprVarTree, falseExprTree, falseExprNode);
+
         extendWithExtendedNode(new UnconditionalJump(merge));
 
         addLabelForNextNode(merge);
-        Node node = new TernaryExpressionNode(tree, condition, trueExpr, falseExpr);
+        Pair<IdentifierTree, LocalVariableNode> treeAndLocalVarNode =
+                extendWithVarUseNode(condExprVarTree);
+        Node node =
+                new TernaryExpressionNode(
+                        tree, condition, trueExprNode, falseExprNode, treeAndLocalVarNode.second);
         extendWithNode(node);
 
         return node;
+    }
+
+    /**
+     * Extend the CFG with an assignment for either the true or false case of a conditional
+     * expression, assigning the value of the expression for the case to the synthetic variable for
+     * the conditional expression
+     *
+     * @param condExprVarTree tree for synthetic variable for conditional expression
+     * @param caseExprTree expression tree for the case
+     * @param caseExprNode node for the case
+     */
+    private void extendWithAssignmentForConditionalExpr(
+            VariableTree condExprVarTree, ExpressionTree caseExprTree, Node caseExprNode) {
+        Pair<IdentifierTree, LocalVariableNode> treeAndLocalVarNode =
+                extendWithVarUseNode(condExprVarTree);
+
+        AssignmentTree assign =
+                treeBuilder.buildAssignment(treeAndLocalVarNode.first, caseExprTree);
+        handleArtificialTree(assign);
+
+        AssignmentNode assignmentNode =
+                new AssignmentNode(assign, treeAndLocalVarNode.second, caseExprNode, false);
+        assignmentNode.setInSource(false);
+        extendWithNode(assignmentNode);
+    }
+
+    /**
+     * Extend the CFG with a {@link LocalVariableNode} representing a use of some variable
+     *
+     * @param varTree tree for the variable
+     * @return a pair whose first element is the synthetic {@link IdentifierTree} for the use, and
+     *     whose second element is the {@link LocalVariableNode} representing the use
+     */
+    private Pair<IdentifierTree, LocalVariableNode> extendWithVarUseNode(VariableTree varTree) {
+        IdentifierTree condExprVarUseTree = treeBuilder.buildVariableUse(varTree);
+        handleArtificialTree(condExprVarUseTree);
+        LocalVariableNode condExprVarUseNode = new LocalVariableNode(condExprVarUseTree);
+        condExprVarUseNode.setInSource(false);
+        //        extendWithNode(condExprVarUseNode);
+        return Pair.of(condExprVarUseTree, condExprVarUseNode);
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -82,6 +82,7 @@ import org.checkerframework.dataflow.cfg.node.ConditionalOrNode;
 import org.checkerframework.dataflow.cfg.node.DoubleLiteralNode;
 import org.checkerframework.dataflow.cfg.node.EqualToNode;
 import org.checkerframework.dataflow.cfg.node.ExplicitThisNode;
+import org.checkerframework.dataflow.cfg.node.ExpressionStatementNode;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.FloatLiteralNode;
 import org.checkerframework.dataflow.cfg.node.FloatingDivisionNode;
@@ -2650,7 +2651,10 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
 
     @Override
     public Node visitExpressionStatement(ExpressionStatementTree tree, Void p) {
-        return scan(tree.getExpression(), p);
+        ExpressionTree exprTree = tree.getExpression();
+        scan(exprTree, p);
+        extendWithNode(new ExpressionStatementNode(exprTree));
+        return null;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AbstractNodeVisitor.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AbstractNodeVisitor.java
@@ -385,4 +385,9 @@ public abstract class AbstractNodeVisitor<R, P> implements NodeVisitor<R, P> {
     public R visitMarker(MarkerNode n, P p) {
         return visitNode(n, p);
     }
+
+    @Override
+    public R visitExpressionStatement(ExpressionStatementNode n, P p) {
+        return visitNode(n, p);
+    }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AssignmentNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AssignmentNode.java
@@ -30,7 +30,30 @@ public class AssignmentNode extends Node {
     protected final Node lhs;
     protected final Node rhs;
 
+    /** Should the then-store and else-store be merged regarding the context? */
+    private final boolean mergeStore;
+
+    /**
+     * Create an AssignmentNode where, if the transfer result is conditional, the then-store and
+     * else-store are always merged.
+     *
+     * @param tree the {@code AssignmentTree} corresponding to the {@code AssignmentNode}
+     * @param target the lhs of {@code tree}
+     * @param expression the rhs of {@code tree}
+     */
     public AssignmentNode(Tree tree, Node target, Node expression) {
+        this(tree, target, expression, true);
+    }
+
+    /**
+     * Create an AssignmentNode.
+     *
+     * @param tree the {@code AssignmentTree} corresponding to the {@code AssignmentNode}
+     * @param target the lhs of {@code tree}
+     * @param expression the rhs of {@code tree}
+     * @param mergeStore Should the then-store and else-store be merged?
+     */
+    public AssignmentNode(Tree tree, Node target, Node expression, boolean mergeStore) {
         super(TreeUtils.typeOf(tree));
         assert tree instanceof AssignmentTree
                 || tree instanceof VariableTree
@@ -42,6 +65,7 @@ public class AssignmentNode extends Node {
         this.tree = tree;
         this.lhs = target;
         this.rhs = expression;
+        this.mergeStore = mergeStore;
     }
 
     /**
@@ -60,6 +84,11 @@ public class AssignmentNode extends Node {
     @Override
     public Tree getTree() {
         return tree;
+    }
+
+    /** Check if the then-store and else-store should be merged. */
+    public boolean shouldMergeStore() {
+        return mergeStore;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AssignmentNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AssignmentNode.java
@@ -30,7 +30,7 @@ public class AssignmentNode extends Node {
     protected final Node lhs;
     protected final Node rhs;
 
-    /** Should the then-store and else-store be merged regarding the context? */
+    /** Whether the then-store and else-store should be merged. */
     private final boolean mergeStore;
 
     /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ExpressionStatementNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ExpressionStatementNode.java
@@ -1,0 +1,57 @@
+package org.checkerframework.dataflow.cfg.node;
+
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.Tree;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.javacutil.TreeUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+/** An expression that is used as a statement. */
+public class ExpressionStatementNode extends Node {
+    /** The expression constituting this ExpressionStatementNode. */
+    protected final ExpressionTree tree;
+
+    /**
+     * Construct a ExpressionStatementNode.
+     *
+     * @param t the expression constituting this ExpressionStatementNode
+     */
+    public ExpressionStatementNode(ExpressionTree t) {
+        super(TreeUtils.typeOf(t));
+        tree = t;
+    }
+
+    @Override
+    public @Nullable Tree getTree() {
+        return null;
+    }
+
+    @Override
+    public Collection<Node> getOperands() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, P> R accept(NodeVisitor<R, P> visitor, P p) {
+        return visitor.visitExpressionStatement(this, p);
+    }
+
+    @Override
+    public String toString() {
+        return "expression statement " + tree.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return this == obj;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toString());
+    }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NodeVisitor.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NodeVisitor.java
@@ -163,4 +163,15 @@ public interface NodeVisitor<R, P> {
 
     // Anonymous/inner/nested class declaration within a method
     R visitClassDeclaration(ClassDeclarationNode classDeclarationNode, P p);
+
+    /**
+     * Visits a non-syntactical {@link ExpressionStatementNode}, which is appended to the
+     * syntactical nodes of an expression statement.
+     *
+     * @param n the {@link ExpressionStatementNode} to be visited
+     * @param p the argument of the operation implemented by this visitor
+     * @return the return type of the operation implemented by this visitor, use Void if no return
+     *     type is needed
+     */
+    R visitExpressionStatement(ExpressionStatementNode n, P p);
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/TernaryExpressionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/TernaryExpressionNode.java
@@ -18,30 +18,84 @@ import java.util.Objects;
  */
 public class TernaryExpressionNode extends Node {
 
+    /** The {@code ConditionalExpressionTree} corresponding to this node */
     protected final ConditionalExpressionTree tree;
+
+    /** Node representing the condition checked by the expression */
     protected final Node condition;
+
+    /** Node representing the "then" case of the expression */
     protected final Node thenOperand;
+
+    /** Node representing the "else" case of the expression */
     protected final Node elseOperand;
 
+    /**
+     * This is a variable created by dataflow to which each case expression of the ternary
+     * expression is assigned. Its value should be used for the value of the switch expression.
+     */
+    private final LocalVariableNode ternaryExpressionVar;
+
+    /**
+     * Creates a new TernaryExpressionNode.
+     *
+     * @param tree the {@code ConditionalExpressionTree} for the node
+     * @param condition node representing the condition checked by the expression
+     * @param thenOperand node representing the "then" case of the expression
+     * @param elseOperand node representing the "else" case of the expression
+     * @param ternaryExpressionVar a variable created by dataflow to which each case expression of
+     *     the ternary expression is assigned. Its value should be used for the value of the switch
+     *     expression.
+     */
     public TernaryExpressionNode(
-            ConditionalExpressionTree tree, Node condition, Node thenOperand, Node elseOperand) {
+            ConditionalExpressionTree tree,
+            Node condition,
+            Node thenOperand,
+            Node elseOperand,
+            LocalVariableNode ternaryExpressionVar) {
         super(TreeUtils.typeOf(tree));
         this.tree = tree;
         this.condition = condition;
         this.thenOperand = thenOperand;
         this.elseOperand = elseOperand;
+        this.ternaryExpressionVar = ternaryExpressionVar;
     }
 
+    /**
+     * Gets the node representing the conditional operand for this node
+     *
+     * @return the condition operand node
+     */
     public Node getConditionOperand() {
         return condition;
     }
 
+    /**
+     * Gets the node representing the "then" operand for this node
+     *
+     * @return the "then" operand node
+     */
     public Node getThenOperand() {
         return thenOperand;
     }
 
+    /**
+     * Gets the node representing the "else" operand for this node
+     *
+     * @return the "else" operand node
+     */
     public Node getElseOperand() {
         return elseOperand;
+    }
+
+    /**
+     * This is a variable created by dataflow to which each case expression of the ternary
+     * expression is assigned. Its value should be used for the value of the switch expression.
+     *
+     * @return the variable for this ternary expression
+     */
+    public LocalVariableNode getTernaryExpressionVar() {
+        return ternaryExpressionVar;
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -23,6 +23,7 @@ import org.checkerframework.dataflow.cfg.node.CaseNode;
 import org.checkerframework.dataflow.cfg.node.ClassNameNode;
 import org.checkerframework.dataflow.cfg.node.ConditionalNotNode;
 import org.checkerframework.dataflow.cfg.node.EqualToNode;
+import org.checkerframework.dataflow.cfg.node.ExpressionStatementNode;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.InstanceOfNode;
 import org.checkerframework.dataflow.cfg.node.LambdaResultExpressionNode;
@@ -1345,6 +1346,14 @@ public abstract class CFAbstractTransfer<
         TransferResult<V, S> result = super.visitStringConversion(n, p);
         result.setResultValue(p.getValueOfSubNode(n.getOperand()));
         return result;
+    }
+
+    @Override
+    public TransferResult<V, S> visitExpressionStatement(
+            ExpressionStatementNode n, TransferInput<V, S> vsTransferInput) {
+        // Merge the input
+        S info = vsTransferInput.getRegularStore();
+        return new RegularTransferResult<>(finishValue(null, info), info);
     }
 
     /**


### PR DESCRIPTION
typetools PR 5000 https://github.com/eisop/checker-framework/pull/151/commits/48f2652bc8bf4801b2e750cd92325583939f2f52 added synthetic variables for ternary expressions to the CFG.
This broke how the Nullness Checker handles ternary expressions, leading to false positives.

This PR fixes handling of ternary expressions by using a special AssignmentNode that does not merge stores, for the assignment of the synthetic variable used in a ternary expression.