### PR TITLE
Fix IllegalArgumentException caused by mismatch of arguments in createFlowAnalysis()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 3.21.3-eisop2 (March ?, 2022)
 **Implementation details:**
 
 **Closed issues:**
+eisop#199.
 
 
 Version 3.21.3-eisop1 (March 23, 2022)

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -614,7 +614,7 @@ public abstract class GenericAnnotatedTypeFactory<
             FlowAnalysis result =
                     BaseTypeChecker.invokeConstructorFor(
                             BaseTypeChecker.getRelatedClassName(checkerClass, "Analysis"),
-                            new Class<?>[] {BaseTypeChecker.class, this.getClass(), List.class},
+                            new Class<?>[] {BaseTypeChecker.class, this.getClass()},
                             new Object[] {checker, this});
             if (result != null) {
                 return result;


### PR DESCRIPTION
The last 2 arguments in `BaseTypeChecker.invokeConstructorFor` have different number of parameters. Checkers using this method will get a `java.lang.IllegalArgumentException` error in runtime.

```
  Underlying Exception: java.lang.IllegalArgumentException: wrong number of arguments; java.lang.IllegalArgumentException: wrong number of arguments
  	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
  	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
  	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
  	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
  	at org.checkerframework.common.basetype.BaseTypeChecker.invokeConstructorFor(BaseTypeChecker.java:331)
  	at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.createFlowAnalysis(GenericAnnotatedTypeFactory.java:615)
  	at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.postInit(GenericAnnotatedTypeFactory.java:406)
  	at pico.typecheck.PICOAnnotatedTypeFactory.<init>(PICOAnnotatedTypeFactory.java:85)
  	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
  	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
  	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
  	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
  	at org.checkerframework.common.basetype.BaseTypeChecker.invokeConstructorFor(BaseTypeChecker.java:331)
  	at org.checkerframework.common.basetype.BaseTypeVisitor.createTypeFactory(BaseTypeVisitor.java:305)
  	at org.checkerframework.common.basetype.BaseTypeVisitor.<init>(BaseTypeVisitor.java:268)
  	at org.checkerframework.common.basetype.BaseTypeVisitor.<init>(BaseTypeVisitor.java:257)
  	at org.checkerframework.checker.initialization.InitializationVisitor.<init>(InitializationVisitor.java:79)
  	at pico.typecheck.PICOVisitor.<init>(PICOVisitor.java:72)
  	at pico.typecheck.PICOChecker.createSourceVisitor(PICOChecker.java:28)
  	at pico.typecheck.PICOChecker.createSourceVisitor(PICOChecker.java:13)
  	at org.checkerframework.framework.source.SourceChecker.initChecker(SourceChecker.java:892)
  	at org.checkerframework.common.basetype.BaseTypeChecker.initChecker(BaseTypeChecker.java:117)
  	at pico.typecheck.PICOChecker.initChecker(PICOChecker.java:22)
  	at org.checkerframework.framework.source.SourceChecker.typeProcessingStart(SourceChecker.java:843)
  	at org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:170)
```