### PR TITLE
Do not mix up pre- and post-conversion values when boxing

### DIFF
--- a/checker/tests/signedness/Desugar.java
+++ b/checker/tests/signedness/Desugar.java
@@ -12,6 +12,13 @@ public class Desugar {
         @Signed Integer box2 = method(box);
     }
 
+    void testDesugared(int x) {
+        int i = getI();
+        Integer box = Integer.valueOf(i);
+        @Signed Integer boxy = box;
+        @Signed Integer box2 = method(box);
+    }
+
     @PolySigned Integer method(@PolySigned Integer i) {
         return i;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -269,14 +269,10 @@ public abstract class AbstractAnalysis<
     @Override
     public @Nullable V getValue(Tree t) {
         // Dataflow is analyzing the tree, so no value is available.
-        if (t == currentTree || cfg == null) {
+        if (t == currentTree) {
             return null;
         }
-        V result = getValue(getNodesForTree(t));
-        if (result == null) {
-            result = getValue(cfg.getTreeLookup().get(t));
-        }
-        return result;
+        return getValue(getNodesForTree(t));
     }
 
     /**


### PR DESCRIPTION
When boxing a primitive value, the CFG creates an artificial call like `Integer.valueOf(arg)`.
The tree `arg` then maps to the post-conversion node as well as the pre-conversion one, and
`AbstractAnalysis.getValue(Tree)` prefers the post-conversion node, falling back to the
pre-conversion node only when the former has no value yet. Once the boxing node has been analyzed
once, a later query for `arg` returns the boxed value, which is then used as the argument to
`valueOf`.

This PR gives the argument its own temporary variable, so the argument and the result of the
conversion have distinct trees and their values cannot be mixed up.

Rebased on current master by merge. One conflict, in `CFGTranslationPhaseOne`: master renamed
`treeLookupMap`/`convertedTreeLookupMap` to `treeToCfgNodes`/`treeToConvertedCfgNodes` and replaced
`findOwner()` with `TreePathUtil.findNearestEnclosingElement(getCurrentPath())`. Both sides kept.

## The checklist, three years on

**Write a test case that requires a fix-point iteration.** Done, as `Desugar.testBoxingInLoop`,
though the framing needed correcting: a fix-point iteration is not what is required. What is
required is that the boxing node be *evaluated more than once*, so that the `valueOf` node still
holds a value from a previous evaluation when the argument tree is queried again. A loop does
that. So does a compound assignment, within a single pass.

The test discriminates. With the `getValue` revert but without the temporary variable:

```
4 unexpected diagnostics were found:
  Desugar.java:11: error: (assignment.type.incompatible)
  Desugar.java:12: error: (assignment.type.incompatible)
  Desugar.java:28: error: (assignment.type.incompatible)
  Desugar.java:29: error: (assignment.type.incompatible)
```

Lines 11 and 12 are the cases this branch already had; 28 and 29 are the new loop. Reverting
`getValue` on its own, with no other change, produces exactly lines 11 and 12 — which is why the
temporary variable is needed rather than just the revert.

**A test type system where `valueOf` takes one type and returns an incompatible different type.**
Built, but it belongs in #2123 rather than here, because it turned out to expose a different and
independent problem: a conversion that the CFG desugars into a method call is never type-checked
at all, since the synthetic tree is not part of the AST that `BaseTypeVisitor` scans. I confirmed
that this PR's change, ported to current master, does not affect that behaviour either way.

**The performance overhead.** Re-measured on current master; the ">2x" in the original description
does not reproduce. Nullness Checker on `framework/tests/all-systems/Issue301.java`, 9 runs each,
alternating builds that differ only in whether `box()` calls `buildValueOfArgument`:

| | median | min |
|---|---|---|
| with the temporary variable | 5.19s | 5.00s |
| without | 4.08s | 3.64s |
| ratio | 1.27x | 1.37x |

So roughly a 25–35% overhead on a file chosen for being boxing-heavy, not a doubling. Whether
that is acceptable is a judgement call, but it is a different judgement call than the one the
original description set up.

**Extract the temporary-variable code into a helper.** Still open. `buildValueOfArgument` is
close to the `tempPostfix` code in `visitUnary` and to the switch and conditional-expression
temporaries; they could share a helper.

## Testing

`:checker:test` and `:framework:test` both pass on the merged branch. `alltests` was not run
locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNxRUSWibi5znEwTTkdqHr
