### PR TITLE
Improve nullness value presentation

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessValue.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessValue.java
@@ -89,7 +89,7 @@ public class NullnessValue extends CFAbstractValue<NullnessValue> {
                 + ", "
                 + TypesUtils.simpleTypeName(underlyingType)
                 + ", "
-                + ("poly nn/n= " + (isPolyNullNonNull ? 't' : 'f'))
+                + ("poly nn/n = " + (isPolyNullNonNull ? 't' : 'f'))
                 + ("/" + (isPolyNullNull ? 't' : 'f'))
                 + '}';
     }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessValue.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessValue.java
@@ -89,9 +89,8 @@ public class NullnessValue extends CFAbstractValue<NullnessValue> {
                 + ", "
                 + TypesUtils.simpleTypeName(underlyingType)
                 + ", "
-                + (isPolyNullNonNull ? 't' : 'f')
-                + ' '
-                + (isPolyNullNull ? 't' : 'f')
+                + ("poly nn/n= " + (isPolyNullNonNull ? 't' : 'f'))
+                + ("/" + (isPolyNullNull ? 't' : 'f'))
                 + '}';
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessValue.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessValue.java
@@ -89,8 +89,10 @@ public class NullnessValue extends CFAbstractValue<NullnessValue> {
                 + ", "
                 + TypesUtils.simpleTypeName(underlyingType)
                 + ", "
-                + ("poly nn/n = " + (isPolyNullNonNull ? 't' : 'f'))
-                + ("/" + (isPolyNullNull ? 't' : 'f'))
+                + "poly nn/n = "
+                + (isPolyNullNonNull ? 't' : 'f')
+                + "/"
+                + (isPolyNullNull ? 't' : 'f')
                 + '}';
     }
 }


### PR DESCRIPTION
A small refinement to the representation of nullness value in store.

Previously, it looks like this:
where`f` stands for `false` (the key is `isPolyNullNonNull` and `isPolyNullNull`)
<img width="691" alt="Screen Shot 2022-04-11 at 11 05 27 PM" src="https://user-images.githubusercontent.com/44760135/162871486-b41174d6-6f32-4924-aa78-27bf2011198b.png">

Now it looks like this:
where `poly nn` stands for `isPolyNullNonNull`, `poly n` stands for `isPolyNullNull`, `f` stands for `false`.
<img width="556" alt="Screen Shot 2022-04-11 at 11 06 35 PM" src="https://user-images.githubusercontent.com/44760135/162871614-b4c5be97-3290-4165-9cf9-9f2f0426fc4a.png">

