### PR TITLE
Gradle task `fastAssemble` for executing assemble without Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1208,6 +1208,18 @@ task checkBasicStyle(group: 'Format') {
 
 assemble.mustRunAfter(clean)
 
+/**
+ * Creates a new task named `fastAssemble` that executes
+ * the `assemble` task without generating any Javadoc.
+ */
+task fastAssemble(group: 'Build') {
+    tasks.withType(Javadoc) {
+        enabled = false
+    }
+
+    finalizedBy assemble
+}
+
 task buildAll(group: 'Build') {
     description 'Build all jar files, including source and javadoc jars'
     dependsOn(allJavadoc)

--- a/build.gradle
+++ b/build.gradle
@@ -1209,10 +1209,10 @@ task checkBasicStyle(group: 'Format') {
 assemble.mustRunAfter(clean)
 
 /**
- * Creates a new task named `fastAssemble` that executes
- * the `assemble` task without generating any Javadoc.
+ * Execute the `assemble` task without generating any Javadoc or sources.jar files.
  */
 task fastAssemble(group: 'Build') {
+    description 'Assembles the outputs of this project without generating any Javadoc or sources.jar files'
     tasks.withType(Javadoc) {
         enabled = false
     }

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -81,7 +81,7 @@ fi
 # If so, the next command gets another chance to try the download.
 (./gradlew help || sleep 10) > /dev/null 2>&1
 
-echo "running \"./gradlew assemble\" for checker-framework"
-./gradlew assemble --console=plain --warning-mode=all -s -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+echo "running \"./gradlew fastAssemble\" for checker-framework"
+./gradlew fastAssemble --console=plain --warning-mode=all -s -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 echo Exiting checker/bin-devel/build.sh in "$(pwd)"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,8 +7,8 @@ Version 3.21.4-eisop2 (April ?, 2022)
 
 Added a new gradle task `fastAssemble` to quickly rebuild the Checker
 Framework for local development. This command will assemble the jar
-files without generating any Javadoc, thus it's faster than the gradle
-assemble task.
+files without generating any Javadoc or sources.jar files, thus it is
+faster than the gradle assemble task.
 
 Type system test drivers no longer need to pass `-Anomsgtext`.
 The Checker Framework test driver (in `TypecheckExecutor.compile`) now always

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ Version 3.21.4-eisop2 (April ?, 2022)
 
 **Implementation details:**
 
+Added a new gradle task `fastAssemble` to quickly rebuild the Checker
+Framework for local development. This command will assemble the jar
+files without generating any Javadoc, thus it's faster than the gradle
+assemble task.
+
 Type system test drivers no longer need to pass `-Anomsgtext`.
 The Checker Framework test driver (in `TypecheckExecutor.compile`) now always
 passes the `-Anomsgtext` option.

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -859,7 +859,8 @@ ensure that the Checker Framework's version is used.
 
 \item To quickly rebuild the Checker Framework for local development,
 run \code{./gradlew fastAssemble}. This command will assemble the jar
-files without generating any Javadoc, thus it's faster than \code{./gradlew assemble}.
+files without generating any Javadoc or sources.jar files, thus it is
+faster than \code{./gradlew assemble}.
 
 \end{enumerate}
 

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -857,6 +857,10 @@ ensure that the Checker Framework's version is used.
 
   \end{itemize}
 
+\item To quickly rebuild the Checker Framework for local development,
+run \code{./gradlew fastAssemble}. This command will assemble the jar
+files without generating any Javadoc, thus it's faster than \code{./gradlew assemble}.
+
 \end{enumerate}
 
 


### PR DESCRIPTION
On my computer, `./gradlew assemble` tasks ~4m and `./gradlew fastAssemble` takes ~3m.

I don't think we really need a test for this task since it looks very straightforward. 