### PR TITLE
fix busyexpr directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,8 +144,8 @@ checker/tests/nullness-temp/*.class
 checker/tests/nullness-temp/*.java
 checker/tests/nullness/generics/*.class
 
-dataflow/tests/busy-expression/Out.txt
-dataflow/tests/busy-expression/*.class
+dataflow/tests/busyexpr/Out.txt
+dataflow/tests/busyexpr/*.class
 dataflow/tests/issue3447/Out.txt
 dataflow/tests/issue3447/*.class
 dataflow/tests/live-variable/Out.txt


### PR DESCRIPTION
Renaming the directory but forgot to change it as well in the `.gitignore` file