### PR TITLE
Properly handle explicit "T extends Object" bounds in stub files

### DIFF
--- a/checker/jtreg/nullness/stub-typeparams/Box.java
+++ b/checker/jtreg/nullness/stub-typeparams/Box.java
@@ -1,0 +1,8 @@
+// This class is not compiled with the Nullness Checker,
+// so that no annotations are stored in bytecode.
+public class Box<T> {
+    static <S> Box<S> of(S in) {
+        // Implementation doesn't matter.
+        return null;
+    }
+}

--- a/checker/jtreg/nullness/stub-typeparams/NullableBox.java
+++ b/checker/jtreg/nullness/stub-typeparams/NullableBox.java
@@ -1,0 +1,10 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// This class is not compiled with the Nullness Checker,
+// so that only explicit annotations are stored in bytecode.
+public class NullableBox<T extends @Nullable Object> {
+    static <S extends @Nullable Object> NullableBox<S> of(S in) {
+        // Implementation doesn't matter.
+        return null;
+    }
+}

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClass.java
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClass.java
@@ -1,0 +1,15 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/*
+ * @test
+ * @summary Test class type parameters in stub files.
+ *
+ * @compile -XDrawDiagnostics -Xlint:unchecked Box.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-none.astub StubTypeParamsClass.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-nullable.astub StubTypeParamsClass.java
+ * @compile/fail/ref=StubTypeParamsClass.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-object.astub -Werror StubTypeParamsClass.java
+ * @compile/fail/ref=StubTypeParamsClass.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-nonnull.astub -Werror StubTypeParamsClass.java
+ */
+public class StubTypeParamsClass {
+    @Nullable Box<@Nullable Object> f;
+}

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClass.out
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClass.out
@@ -1,0 +1,2 @@
+StubTypeParamsClass.java:14:19: compiler.err.proc.messager: (type.argument.type.incompatible)
+1 error

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClassNbl.java
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClassNbl.java
@@ -1,0 +1,15 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/*
+ * @test
+ * @summary Test class type parameters in stub files.
+ *
+ * @compile -XDrawDiagnostics -Xlint:unchecked NullableBox.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-none.astub StubTypeParamsClassNbl.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-nullable.astub StubTypeParamsClassNbl.java
+ * @compile/fail/ref=StubTypeParamsClassNbl.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-object.astub -Werror StubTypeParamsClassNbl.java
+ * @compile/fail/ref=StubTypeParamsClassNbl.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-nonnull.astub -Werror StubTypeParamsClassNbl.java
+ */
+public class StubTypeParamsClassNbl {
+    @Nullable NullableBox<@Nullable Object> f;
+}

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClassNbl.out
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsClassNbl.out
@@ -1,0 +1,2 @@
+StubTypeParamsClassNbl.java:14:27: compiler.err.proc.messager: (type.argument.type.incompatible)
+1 error

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMeth.java
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMeth.java
@@ -1,0 +1,15 @@
+/*
+ * @test
+ * @summary Test method type parameters in stub files.
+ *
+ * @compile -XDrawDiagnostics -Xlint:unchecked Box.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-none.astub StubTypeParamsMeth.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-nullable.astub StubTypeParamsMeth.java
+ * @compile/fail/ref=StubTypeParamsMeth.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-object.astub -Werror StubTypeParamsMeth.java
+ * @compile/fail/ref=StubTypeParamsMeth.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=box-nonnull.astub -Werror StubTypeParamsMeth.java
+ */
+public class StubTypeParamsMeth {
+    void use() {
+        Box.of(null);
+    }
+}

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMeth.out
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMeth.out
@@ -1,0 +1,2 @@
+StubTypeParamsMeth.java:13:15: compiler.err.proc.messager: (type.argument.type.incompatible)
+1 error

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMethNbl.java
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMethNbl.java
@@ -1,0 +1,15 @@
+/*
+ * @test
+ * @summary Test method type parameters in stub files.
+ *
+ * @compile -XDrawDiagnostics -Xlint:unchecked NullableBox.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-none.astub StubTypeParamsMethNbl.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-nullable.astub StubTypeParamsMethNbl.java
+ * @compile/fail/ref=StubTypeParamsMethNbl.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-object.astub -Werror StubTypeParamsMethNbl.java
+ * @compile/fail/ref=StubTypeParamsMethNbl.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=nullablebox-nonnull.astub -Werror StubTypeParamsMethNbl.java
+ */
+public class StubTypeParamsMethNbl {
+    void use() {
+        NullableBox.of(null);
+    }
+}

--- a/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMethNbl.out
+++ b/checker/jtreg/nullness/stub-typeparams/StubTypeParamsMethNbl.out
@@ -1,0 +1,2 @@
+StubTypeParamsMethNbl.java:13:23: compiler.err.proc.messager: (type.argument.type.incompatible)
+1 error

--- a/checker/jtreg/nullness/stub-typeparams/box-none.astub
+++ b/checker/jtreg/nullness/stub-typeparams/box-none.astub
@@ -1,0 +1,6 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// T corresponds to "T extends @Nullable Object"
+class Box<T> {
+    static <S> Box<S> of(S in);
+}

--- a/checker/jtreg/nullness/stub-typeparams/box-nonnull.astub
+++ b/checker/jtreg/nullness/stub-typeparams/box-nonnull.astub
@@ -1,0 +1,5 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+class Box<T extends @NonNull Object> {
+    static <S extends @NonNull Object> Box<S> of(S in);
+}

--- a/checker/jtreg/nullness/stub-typeparams/box-nullable.astub
+++ b/checker/jtreg/nullness/stub-typeparams/box-nullable.astub
@@ -1,0 +1,5 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class Box<T extends @Nullable Object> {
+    static <S extends @Nullable Object> Box<S> of(S in);
+}

--- a/checker/jtreg/nullness/stub-typeparams/box-object.astub
+++ b/checker/jtreg/nullness/stub-typeparams/box-object.astub
@@ -1,0 +1,6 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// Explicit bound corresponds to "T extends @NonNull Object"
+class Box<T extends Object> {
+    static <S extends Object> Box<S> of(S in);
+}

--- a/checker/jtreg/nullness/stub-typeparams/nullablebox-none.astub
+++ b/checker/jtreg/nullness/stub-typeparams/nullablebox-none.astub
@@ -1,0 +1,6 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// T corresponds to "T extends @Nullable Object"
+class NullableBox<T> {
+    static <S> NullableBox<S> of(S in);
+}

--- a/checker/jtreg/nullness/stub-typeparams/nullablebox-nonnull.astub
+++ b/checker/jtreg/nullness/stub-typeparams/nullablebox-nonnull.astub
@@ -1,0 +1,5 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+class NullableBox<T extends @NonNull Object> {
+    static <S extends @NonNull Object> NullableBox<S> of(S in);
+}

--- a/checker/jtreg/nullness/stub-typeparams/nullablebox-nullable.astub
+++ b/checker/jtreg/nullness/stub-typeparams/nullablebox-nullable.astub
@@ -1,0 +1,5 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class NullableBox<T extends @Nullable Object> {
+    static <S extends @Nullable Object> NullableBox<S> of(S in);
+}

--- a/checker/jtreg/nullness/stub-typeparams/nullablebox-object.astub
+++ b/checker/jtreg/nullness/stub-typeparams/nullablebox-object.astub
@@ -1,0 +1,6 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// Explicit bound corresponds to "T extends @NonNull Object"
+class NullableBox<T extends Object> {
+    static <S extends Object> NullableBox<S> of(S in);
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ Version 3.22.1-eisop1 (June ?, 2022)
 
 **Closed issues:**
 
+typetools#3030.
+
 
 Version 3.22.1 (June 1, 2022)
 ---------------------------------

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -1339,7 +1339,6 @@ public class AnnotationFileParser {
         if (fileType.isStub()) {
             typeParameters.removeAll(methodType.getTypeVariables());
         }
-
         return methodType.getTypeVariables();
     }
 
@@ -1801,10 +1800,10 @@ public class AnnotationFileParser {
             warn(decl, msg);
             return;
         }
+
         for (int i = 0; i < typeParameters.size(); ++i) {
             TypeParameter param = typeParameters.get(i);
             AnnotatedTypeVariable paramType = (AnnotatedTypeVariable) typeArguments.get(i);
-
             if (param.getTypeBound() == null || param.getTypeBound().isEmpty()) {
                 // No bound so annotations are both lower and upper bounds
                 annotate(paramType, param.getAnnotations(), param);
@@ -1815,6 +1814,18 @@ public class AnnotationFileParser {
                     // TODO: add support for intersection types
                     stubWarnNotFound(
                             param, "Annotations on intersection types are not yet supported");
+                }
+                if (param.getTypeBound().size() == 1
+                        && param.getTypeBound().get(0).getAnnotations().isEmpty()
+                        && paramType
+                                .getUpperBound()
+                                .getUnderlyingType()
+                                .toString()
+                                .contentEquals("java.lang.Object")) {
+                    // If there is an explicit "T extends Object" type parameter bound,
+                    // treat it like an explicit use of "Object" in code.
+                    AnnotatedTypeMirror ub = atypeFactory.getAnnotatedType(Object.class);
+                    paramType.getUpperBound().addAnnotations(ub.getAnnotations());
                 }
             }
             putMerge(

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -1339,6 +1339,7 @@ public class AnnotationFileParser {
         if (fileType.isStub()) {
             typeParameters.removeAll(methodType.getTypeVariables());
         }
+
         return methodType.getTypeVariables();
     }
 
@@ -1800,10 +1801,10 @@ public class AnnotationFileParser {
             warn(decl, msg);
             return;
         }
-
         for (int i = 0; i < typeParameters.size(); ++i) {
             TypeParameter param = typeParameters.get(i);
             AnnotatedTypeVariable paramType = (AnnotatedTypeVariable) typeArguments.get(i);
+
             if (param.getTypeBound() == null || param.getTypeBound().isEmpty()) {
                 // No bound so annotations are both lower and upper bounds
                 annotate(paramType, param.getAnnotations(), param);

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -1825,7 +1825,7 @@ public class AnnotationFileParser {
                     // If there is an explicit "T extends Object" type parameter bound,
                     // treat it like an explicit use of "Object" in code.
                     AnnotatedTypeMirror ub = atypeFactory.getAnnotatedType(Object.class);
-                    paramType.getUpperBound().addAnnotations(ub.getAnnotations());
+                    paramType.getUpperBound().replaceAnnotations(ub.getAnnotations());
                 }
             }
             putMerge(


### PR DESCRIPTION
This fixes typetools issue 3030.