### PR TITLE
Test case for typetools issue 3025

### DIFF
--- a/checker/tests/nullness/generics/Issue3025.java
+++ b/checker/tests/nullness/generics/Issue3025.java
@@ -1,0 +1,18 @@
+// Test case for issue #3025:
+// https://github.com/typetools/checker-framework/issues/3025
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// Classes need to be separate top-level classes to reproduce the issue
+class Issue3025Caller {
+    <T> void foo(Issue3025Sub<? super T> arg) {
+        bar(arg);
+        hashCode();
+    }
+
+    void bar(Issue3025Sub<?> arg) {}
+}
+
+interface Issue3025Super<T> {}
+
+interface Issue3025Sub<T> extends Issue3025Super<@Nullable T> {}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ Version 3.22.1-eisop1 (June ?, 2022)
 
 **Closed issues:**
 
-typetools#3030.
+typetools#3025, typetools#3030.
 
 
 Version 3.22.1 (June 1, 2022)


### PR DESCRIPTION
Crash is already fixed by some eisop changes.  Still crashes with typetools.
Fixes typetools issue 3025.

@cpovirk I don't remember why I looked at this issue. The test now passes, without any errors. Did you expect any errors for that test?