### PR TITLE
Correctly handle multiple annotations in TypeFromMemberVisitor

### DIFF
--- a/checker/tests/nullness/ArrayCreationNullable.java
+++ b/checker/tests/nullness/ArrayCreationNullable.java
@@ -22,6 +22,8 @@ public class ArrayCreationNullable {
         // Allowed.
         objs = p;
         objs[0].toString();
+        // :: error: (type.invalid.conflicting.annos)
+        @Nullable @NonNull Object[] pro;
     }
 
     @DefaultQualifier(NonNull.class)

--- a/checker/tests/nullness/ArrayCreationNullable.java
+++ b/checker/tests/nullness/ArrayCreationNullable.java
@@ -22,8 +22,6 @@ public class ArrayCreationNullable {
         // Allowed.
         objs = p;
         objs[0].toString();
-        // :: error: (type.invalid.conflicting.annos)
-        @Nullable @NonNull Object[] pro;
     }
 
     @DefaultQualifier(NonNull.class)

--- a/checker/tests/nullness/generics/MixTypeAndDeclAnno.java
+++ b/checker/tests/nullness/generics/MixTypeAndDeclAnno.java
@@ -3,12 +3,24 @@
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+@SuppressWarnings("initialization.fields.uninitialized")
 class MixTypeAndDeclAnno<T extends @Nullable Object> {
     @NonNull T t;
     @android.annotation.NonNull T tdecl;
+    // :: error: (type.invalid.conflicting.annos)
+    @android.annotation.NonNull @Nullable T tdecl2;
 
     MixTypeAndDeclAnno(@NonNull T t, @android.annotation.NonNull T tdecl) {
         this.t = t;
         this.tdecl = tdecl;
     }
+
+    // :: error: (type.invalid.conflicting.annos)
+    @android.annotation.NonNull @android.annotation.Nullable Object f1;
+    // :: error: (type.invalid.conflicting.annos)
+    @android.annotation.NonNull @Nullable Object f2;
+    // Nullable applies to the array itself, while NonNull apply to components of the array.
+    @android.annotation.Nullable @NonNull Object[] g;
+    // :: error: (type.invalid.conflicting.annos)
+    @android.annotation.Nullable Object @NonNull [] k1;
 }

--- a/checker/tests/nullness/generics/MixTypeAndDeclAnno.java
+++ b/checker/tests/nullness/generics/MixTypeAndDeclAnno.java
@@ -3,18 +3,11 @@
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-@SuppressWarnings("initialization.fields.uninitialized")
 class MixTypeAndDeclAnno<T extends @Nullable Object> {
     @NonNull T t;
     @android.annotation.NonNull T tdecl;
     // :: error: (type.invalid.conflicting.annos)
     @android.annotation.NonNull @Nullable T tdecl2;
-
-    MixTypeAndDeclAnno(@NonNull T t, @android.annotation.NonNull T tdecl) {
-        this.t = t;
-        this.tdecl = tdecl;
-    }
-
     // :: error: (type.invalid.conflicting.annos)
     @android.annotation.NonNull @android.annotation.Nullable Object f1;
     // :: error: (type.invalid.conflicting.annos)
@@ -22,5 +15,24 @@ class MixTypeAndDeclAnno<T extends @Nullable Object> {
     // Nullable applies to the array itself, while NonNull apply to components of the array.
     @android.annotation.Nullable @NonNull Object[] g;
     // :: error: (type.invalid.conflicting.annos)
-    @android.annotation.Nullable Object @NonNull [] k1;
+    @android.annotation.Nullable Object @NonNull [] k;
+
+    MixTypeAndDeclAnno(
+            @NonNull T t,
+            @android.annotation.NonNull T tdecl,
+            // :: error: (type.invalid.conflicting.annos)
+            @android.annotation.NonNull @android.annotation.Nullable Object f1,
+            // :: error: (type.invalid.conflicting.annos)
+            @android.annotation.NonNull @Nullable Object f2,
+            // :: error: (type.invalid.conflicting.annos)
+            @android.annotation.Nullable Object @NonNull [] k) {
+        this.t = t;
+        this.tdecl = tdecl;
+        // :: error: (type.invalid.conflicting.annos)
+        this.f1 = f1;
+        // :: error: (type.invalid.conflicting.annos)
+        this.f2 = f2;
+        // :: error: (type.invalid.conflicting.annos)
+        this.k = k;
+    }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -108,7 +108,6 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
         if (lambdaParamType != null) {
             return lambdaParamType;
         }
-
         return result;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -95,7 +95,9 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
                     result.replaceAnnotation(anno);
                 } else {
                     // Type annotations apply to the innermost type.
-                    innerType.replaceAnnotation(anno);
+                    // We need to use addAnnotation instead of replaceAnnotation, otherwise testcase
+                    // would fail.
+                    innerType.addAnnotation(anno);
                 }
             }
         }


### PR DESCRIPTION
This PR undoes the `addAnnotations` to `replaceAnnotation` changes of https://github.com/eisop/checker-framework/pull/193, to solve the downstream test of https://github.com/opprop/checker-framework-inference/pull/395.
Using `addAnnotations` can add multiple annotations from the same hierarchy, which is required to get the desired error messages about duplicate annotations.

I have tested all the cases and added one new test case.