### PR TITLE
Fix enclosing type in deprecated fromNewClass; make AnnotatedTypeMirror.setEnclosingType public

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2798,7 +2798,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // Type may already have explicit dependent type annotations that have not yet been vpa.
         type.clearAnnotations();
         type.addAnnotations(explicitAnnos);
-        // add enclosing annos if there it is
+        // Use the receiver type as enclosing type, if present.
         AnnotatedDeclaredType enclosingType = (AnnotatedDeclaredType) getReceiverType(newClassTree);
         if (enclosingType != null) {
             type.setEnclosingType(enclosingType);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2798,6 +2798,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // Type may already have explicit dependent type annotations that have not yet been vpa.
         type.clearAnnotations();
         type.addAnnotations(explicitAnnos);
+        // add enclosing annos if there it is
+        AnnotatedDeclaredType enclosingType = (AnnotatedDeclaredType) getReceiverType(newClassTree);
+        if (enclosingType != null) {
+            type.setEnclosingType(enclosingType);
+        }
         return type;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1095,7 +1095,7 @@ public abstract class AnnotatedTypeMirror {
          *
          * @param enclosingType the new enclosing type
          */
-        /*package-private*/ void setEnclosingType(@Nullable AnnotatedDeclaredType enclosingType) {
+        public void setEnclosingType(@Nullable AnnotatedDeclaredType enclosingType) {
             this.enclosingType = enclosingType;
         }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1095,7 +1095,7 @@ public abstract class AnnotatedTypeMirror {
          *
          * @param enclosingType the new enclosing type
          */
-        public void setEnclosingType(@Nullable AnnotatedDeclaredType enclosingType) {
+        /*package-private*/ void setEnclosingType(@Nullable AnnotatedDeclaredType enclosingType) {
             this.enclosingType = enclosingType;
         }
 


### PR DESCRIPTION
This PR change the method **setEnclosingType** of class **AnnotatedTypeMirror** to public, because in CFI pr: https://github.com/opprop/checker-framework-inference/pull/395, we need to override one method involving this one.