### PR TITLE
Add more files to be ignored by pre-commit hook

### DIFF
--- a/checker/bin-devel/git.pre-commit
+++ b/checker/bin-devel/git.pre-commit
@@ -11,7 +11,16 @@ set -e
 # Need to keep checked files in sync with getJavaFilesToFormat in build.gradle.
 # Otherwise `./gradlew reformat` might not reformat a file that this
 # hook complains about.
-CHANGED_JAVA_FILES=$(git diff --staged --name-only --diff-filter=ACM | grep '\.java$' | grep -v '/jdk/' | grep -v 'stubparser/' | grep -v '/nullness-javac-errors/' | grep -v 'dataflow/manual/examples/' | grep -v '/java17/') || true
+CHANGED_JAVA_FILES=$(git diff --staged --name-only --diff-filter=ACM \
+                    | grep '\.java$' \
+                    | grep -v '/jdk/' \
+                    | grep -v 'stubparser/' \
+                    | grep -v '/nullness-javac-errors/' \
+                    | grep -v 'dataflow/manual/examples/' \
+                    | grep -v '/java17/' \
+                    | grep -v '/wholeprograminference/' \
+                    | grep -v '/stub/AddAnnotatedFor.java' \
+                    | grep -v '/stub/ToIndexFileConverter.java') || true
 # echo "CHANGED_JAVA_FILES=${CHANGED_JAVA_FILES}"
 if [ -n "$CHANGED_JAVA_FILES" ]; then
     ./gradlew getCodeFormatScripts -q


### PR DESCRIPTION
To see the effect, should run `./gradlew installGitHooks` locally.