### PR TITLE
Test cases for anonymous and inner class constructors

### DIFF
--- a/checker/tests/regex/Constructors.java
+++ b/checker/tests/regex/Constructors.java
@@ -1,0 +1,27 @@
+import org.checkerframework.checker.regex.qual.Regex;
+
+public class Constructors {
+    public Constructors(Constructors con) {}
+
+    public Constructors(@Regex String s, int i) {}
+
+    public class MyConstructors extends Constructors {
+        public MyConstructors(@Regex String s) {
+            super(s, 0);
+        }
+    }
+
+    public void testAnonymousConstructor(String s) {
+
+        Constructors m = new Constructors(null);
+
+        // :: error: (argument.type.incompatible)
+        new MyConstructors(s);
+        // :: error: (argument.type.incompatible)
+        new MyConstructors(s) {};
+        // :: error: (argument.type.incompatible)
+        m.new MyConstructors(s);
+        // :: error: (argument.type.incompatible)
+        m.new MyConstructors(s) {};
+    }
+}

--- a/checker/tests/regex/Nested.java
+++ b/checker/tests/regex/Nested.java
@@ -1,0 +1,17 @@
+import org.checkerframework.checker.regex.qual.Regex;
+
+// TODO: @Regex is not allowed on arbitrary types. Find a better test case.
+public class Nested {
+
+    // :: warning: (cast.unsafe.constructor.invocation) :: error: (anno.on.irrelevant)
+    OuterI.@Regex InnerA fa = new OuterI.@Regex InnerA() {};
+
+    // :: warning: (cast.unsafe.constructor.invocation) :: error: (anno.on.irrelevant)
+    OuterI.@Regex InnerB<Object> fb = new OuterI.@Regex InnerB<Object>() {};
+}
+
+class OuterI {
+    static class InnerA {}
+
+    static class InnerB<T> {}
+}


### PR DESCRIPTION
These tests are from
https://github.com/opprop/checker-framework/pull/171 and
https://github.com/opprop/checker-framework/pull/174.
The logic-changes from those PRs were subsumed by later changes, but the tests are good to have.

Co-authored-by: d367wang <d367wang@uwaterloo.ca>