### PR TITLE
Correct type.invalid.super.wildcard message

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -638,8 +638,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                             checker.reportError(
                                     tree.getTypeArguments().get(i),
                                     "type.invalid.super.wildcard",
-                                    wildcard.getExtendsBound(),
-                                    wildcard.getSuperBound());
+                                    wildcard.getSuperBound(),
+                                    wildcard.getExtendsBound());
                         }
                     }
                 }

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -622,19 +622,19 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                         // (See https://bugs.openjdk.java.net/browse/JDK-8054309.)
                         // In this case, the Checker Framework uses the annotations on the super
                         // bound of the wildcard and ignores the annotations on the extends bound.
+                        // For example, Set<@1 ? super @2 Object> will collapse into Set<@2 Object>.
                         // So, issue a warning if the annotations on the extends bound are not the
                         // same as the annotations on the super bound.
+                        Set<AnnotationMirror> extendsBoundAnnos =
+                                wildcard.getExtendsBound().getAnnotations();
+                        Set<AnnotationMirror> superBoundAnnos =
+                                wildcard.getSuperBound().getEffectiveAnnotations();
                         if (!(atypeFactory
                                         .getQualifierHierarchy()
-                                        .isSubtype(
-                                                wildcard.getSuperBound().getEffectiveAnnotations(),
-                                                wildcard.getExtendsBound().getAnnotations())
+                                        .isSubtype(extendsBoundAnnos, superBoundAnnos)
                                 && atypeFactory
                                         .getQualifierHierarchy()
-                                        .isSubtype(
-                                                wildcard.getExtendsBound().getAnnotations(),
-                                                wildcard.getSuperBound()
-                                                        .getEffectiveAnnotations()))) {
+                                        .isSubtype(superBoundAnnos, extendsBoundAnnos))) {
                             checker.reportError(
                                     tree.getTypeArguments().get(i),
                                     "type.invalid.super.wildcard",


### PR DESCRIPTION
The arguments passed to type.invalid.super.wildcard were not in the right order, so this PR fixes it.

The behavior of this check should be valid as described in: https://github.com/typetools/checker-framework/issues/5006

We encountered a warning in:
```
import java.util.Set;
import org.checkerframework.checker.nullness.qual.*;

public class TestSet {
    void foo(Set<Object> s1, Set<? super Object> s2) {
        s1.retainAll(s2);
    }
}
```
because the capture of `Set<? super Object>` is `Set<Object>` and its implicit upper bound is `@Nullable`.