### PR TITLE
Check the enclosing expression of an object creation for nullness

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -721,6 +721,15 @@ public class NullnessVisitor
 
     @Override
     public Void visitNewClass(NewClassTree node, Void p) {
+        Tree enclosingExpr = node.getEnclosingExpression();
+        if (enclosingExpr != null) {
+            AnnotatedDeclaredType type =
+                    (AnnotatedDeclaredType) atypeFactory.getAnnotatedType(enclosingExpr);
+            AnnotationMirror nullableAnno = type.getAnnotation(Nullable.class);
+            if (nullableAnno != null) {
+                checker.reportError(node, "nullness.on.receiver");
+            }
+        }
         AnnotatedDeclaredType type = atypeFactory.getAnnotatedType(node);
         ExpressionTree identifier = node.getIdentifier();
         if (identifier instanceof AnnotatedTypeTree) {

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -721,14 +721,9 @@ public class NullnessVisitor
 
     @Override
     public Void visitNewClass(NewClassTree node, Void p) {
-        Tree enclosingExpr = node.getEnclosingExpression();
+        ExpressionTree enclosingExpr = node.getEnclosingExpression();
         if (enclosingExpr != null) {
-            AnnotatedDeclaredType type =
-                    (AnnotatedDeclaredType) atypeFactory.getAnnotatedType(enclosingExpr);
-            AnnotationMirror nullableAnno = type.getAnnotation(Nullable.class);
-            if (nullableAnno != null) {
-                checker.reportError(node, "nullness.on.receiver");
-            }
+            checkForNullability(enclosingExpr, "nullness.on.receiver");
         }
         AnnotatedDeclaredType type = atypeFactory.getAnnotatedType(node);
         ExpressionTree identifier = node.getIdentifier();

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -723,7 +723,7 @@ public class NullnessVisitor
     public Void visitNewClass(NewClassTree node, Void p) {
         ExpressionTree enclosingExpr = node.getEnclosingExpression();
         if (enclosingExpr != null) {
-            checkForNullability(enclosingExpr, "nullness.on.receiver");
+            checkForNullability(enclosingExpr, DEREFERENCE_OF_NULLABLE);
         }
         AnnotatedDeclaredType type = atypeFactory.getAnnotatedType(node);
         ExpressionTree identifier = node.getIdentifier();

--- a/checker/tests/nullness/InnerCrash.java
+++ b/checker/tests/nullness/InnerCrash.java
@@ -8,7 +8,7 @@ class InnerCrash {
     }
 
     static void foo() {
-        // :: error: (nullness.on.receiver)
+        // :: error: (dereference.of.nullable)
         Object o = getInnerCrash().new Inner();
     }
 }

--- a/checker/tests/nullness/InnerCrash.java
+++ b/checker/tests/nullness/InnerCrash.java
@@ -1,0 +1,14 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class InnerCrash {
+    class Inner {}
+
+    static @Nullable InnerCrash getInnerCrash() {
+        return null;
+    }
+
+    static void foo() {
+        // ::error: (nullness.on.receiver)
+        Object o = getInnerCrash().new Inner();
+    }
+}

--- a/checker/tests/nullness/InnerCrash.java
+++ b/checker/tests/nullness/InnerCrash.java
@@ -8,7 +8,7 @@ class InnerCrash {
     }
 
     static void foo() {
-        // ::error: (nullness.on.receiver)
+        // :: error: (nullness.on.receiver)
         Object o = getInnerCrash().new Inner();
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ memory consumption.
 
 **Closed issues:**
 
-eisop#270, typetools#5189.
+eisop#270, typetools#5189, eisop#281.
 
 
 Version 3.22.2 (July 1, 2022)


### PR DESCRIPTION
This pr checks the receiver of a new class, including the test case.

Fixes #281.