### PR TITLE
Change postfix unary operation ordering in CFG

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3962,7 +3962,6 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
                     if (!isPostfix) {
                         result = unaryAssign;
                     }
-                    }
                     break;
                 }
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3956,11 +3956,12 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
                         result = new LocalVariableNode(resultExpr);
                         result.setInSource(false);
                         extendWithNode(result);
-                        createIncrementOrDecrementAssign(tree, expr, isIncrement, isPostfix);
-                    } else {
-                        result =
-                                createIncrementOrDecrementAssign(
-                                        tree, expr, isIncrement, isPostfix);
+                    }
+                    AssignmentNode unaryAssign =
+                            createIncrementOrDecrementAssign(tree, expr, isIncrement, isPostfix);
+                    if (!isPostfix) {
+                        result = unaryAssign;
+                    }
                     }
                     break;
                 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3926,8 +3926,6 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
                     boolean isPostfix =
                             kind == Tree.Kind.POSTFIX_INCREMENT
                                     || kind == Tree.Kind.POSTFIX_DECREMENT;
-                    AssignmentNode unaryAssign =
-                            createIncrementOrDecrementAssign(tree, expr, isIncrement, isPostfix);
 
                     if (isPostfix) {
                         TypeMirror exprType = TreeUtils.typeOf(exprTree);
@@ -3958,8 +3956,11 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
                         result = new LocalVariableNode(resultExpr);
                         result.setInSource(false);
                         extendWithNode(result);
+                        createIncrementOrDecrementAssign(tree, expr, isIncrement, isPostfix);
                     } else {
-                        result = unaryAssign;
+                        result =
+                                createIncrementOrDecrementAssign(
+                                        tree, expr, isIncrement, isPostfix);
                     }
                     break;
                 }


### PR DESCRIPTION
Previously, for statement
``` 
d *= i--;
```
The control flow graph is this:
<img width="867" alt="Screen Shot 2022-07-16 at 10 53 52 AM" src="https://user-images.githubusercontent.com/44760135/179360136-8c99019b-70a9-45c4-89e9-a9f2104e1fb4.png">
Notice that CFG builder creates one `tempPostfix#num0` variable to represent value `i` before decreasing. However, the ordering is wrong, the assignment of `tempPostfix#num0` is after the decreasing of `i` in the CFG.

After the fix, the CFG is this, which is as expected.
<img width="667" alt="Screen Shot 2022-07-16 at 10 56 08 AM" src="https://user-images.githubusercontent.com/44760135/179360227-719c39e6-77ea-4c1b-9030-9ce6f654eaf9.png">
