### PR TITLE
Only non-null transfer functions should be used

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -53,7 +53,7 @@ public abstract class AbstractAnalysis<
     /** The transfer function for regular nodes. */
     // TODO: make final. Currently, the transferFunction has a reference to the analysis, so it
     //  can't be created until the Analysis is initialized.
-    protected @Nullable T transferFunction;
+    protected @MonotonicNonNull T transferFunction;
 
     /** The current control flow graph to perform the analysis on. */
     protected @MonotonicNonNull ControlFlowGraph cfg;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -353,7 +353,6 @@ public abstract class AbstractAnalysis<
         }
         transferInput.node = node;
         setCurrentNode(node);
-        @SuppressWarnings("nullness") // CF bug: "INFERENCE FAILED"
         TransferResult<V, S> transferResult = node.accept(transferFunction, transferInput);
         setCurrentNode(null);
         if (node instanceof AssignmentNode) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/BackwardAnalysisImpl.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/BackwardAnalysisImpl.java
@@ -68,7 +68,7 @@ public class BackwardAnalysisImpl<
      *
      * @param transferFunction the transfer function
      */
-    public BackwardAnalysisImpl(@Nullable T transferFunction) {
+    public BackwardAnalysisImpl(T transferFunction) {
         this();
         this.transferFunction = transferFunction;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardAnalysisImpl.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardAnalysisImpl.java
@@ -89,7 +89,7 @@ public class ForwardAnalysisImpl<
      *
      * @param transfer the transfer function
      */
-    public ForwardAnalysisImpl(@Nullable T transfer) {
+    public ForwardAnalysisImpl(T transfer) {
         this(-1);
         this.transferFunction = transfer;
     }


### PR DESCRIPTION
Field is monotonic-non-null because it is set in subclasses.
In a future cleanup, try making the field final and understand the relation to Analysis better.