### PR TITLE
Add @SideEffectFree to transfer function files

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/BackwardTransferFunction.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/BackwardTransferFunction.java
@@ -2,6 +2,7 @@ package org.checkerframework.dataflow.analysis;
 
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.dataflow.cfg.node.ReturnNode;
+import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ public interface BackwardTransferFunction<V extends AbstractValue<V>, S extends 
      *     underlying AST is not a method)
      * @return the initial store that should be used at the normal exit block
      */
+    @SideEffectFree
     S initialNormalExitStore(UnderlyingAST underlyingAST, List<ReturnNode> returnNodes);
 
     /**
@@ -36,5 +38,6 @@ public interface BackwardTransferFunction<V extends AbstractValue<V>, S extends 
      * @param underlyingAST the underlying AST of the given control flow graph
      * @return the initial store that should be used at the exceptional exit block
      */
+    @SideEffectFree
     S initialExceptionalExitStore(UnderlyingAST underlyingAST);
 }

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -1296,6 +1296,10 @@ public abstract class CFAbstractTransfer<
     /**
      * Returns the abstract value of {@code (value1, value2)} that is more specific. If the two are
      * incomparable, then {@code value1} is returned.
+     *
+     * @param value1 an abstract value to be compared with
+     * @param value2 an abstract value to be compared with
+     * @return A more specific value of the two params
      */
     @SideEffectFree
     public V moreSpecificValue(V value1, V value2) {

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -43,6 +43,7 @@ import org.checkerframework.dataflow.cfg.node.WideningConversionNode;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.LocalVariable;
+import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.dataflow.util.NodeUtils;
 import org.checkerframework.framework.flow.CFAbstractAnalysis.FieldInitialValue;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -147,6 +148,7 @@ public abstract class CFAbstractTransfer<
      * @return true if the transfer function uses sequential semantics, false if it uses concurrent
      *     semantics
      */
+    @SideEffectFree
     public boolean usesSequentialSemantics() {
         return sequentialSemantics;
     }
@@ -162,6 +164,7 @@ public abstract class CFAbstractTransfer<
      * @param store the store
      * @return the possibly-modified value
      */
+    @SideEffectFree
     protected @Nullable V finishValue(@Nullable V value, S store) {
         return value;
     }
@@ -178,6 +181,7 @@ public abstract class CFAbstractTransfer<
      * @param elseStore the "else" store
      * @return the possibly-modified value
      */
+    @SideEffectFree
     protected @Nullable V finishValue(@Nullable V value, S thenStore, S elseStore) {
         return value;
     }
@@ -490,6 +494,7 @@ public abstract class CFAbstractTransfer<
      * @param methodDeclTree the declaration of the method or constructor
      * @return true if the receiver of a method or constructor might not yet be fully initialized
      */
+    @SideEffectFree
     protected boolean isNotFullyInitializedReceiver(MethodTree methodDeclTree) {
         return TreeUtils.isConstructor(methodDeclTree);
     }
@@ -566,6 +571,7 @@ public abstract class CFAbstractTransfer<
      * @param in the transfer input
      * @return the input information, as a TransferResult
      */
+    @SideEffectFree
     protected TransferResult<V, S> createTransferResult(@Nullable V value, TransferInput<V, S> in) {
         if (in.containsTwoStores()) {
             S thenStore = in.getThenStore();
@@ -588,6 +594,7 @@ public abstract class CFAbstractTransfer<
      * @param in the TransferResult to copy
      * @return the input informatio
      */
+    @SideEffectFree
     protected TransferResult<V, S> recreateTransferResult(
             @Nullable V value, TransferResult<V, S> in) {
         if (in.containsTwoStores()) {
@@ -822,6 +829,7 @@ public abstract class CFAbstractTransfer<
      * @return a list containing all the right- and left-hand sides in the given assignment node; it
      *     contains just the node itself if it is not an assignment)
      */
+    @SideEffectFree
     protected List<Node> splitAssignments(Node node) {
         if (node instanceof AssignmentNode) {
             List<Node> result = new ArrayList<>(2);
@@ -1289,6 +1297,7 @@ public abstract class CFAbstractTransfer<
      * Returns the abstract value of {@code (value1, value2)} that is more specific. If the two are
      * incomparable, then {@code value1} is returned.
      */
+    @SideEffectFree
     public V moreSpecificValue(V value1, V value2) {
         if (value1 == null) {
             return value2;
@@ -1326,6 +1335,7 @@ public abstract class CFAbstractTransfer<
      * @return an abstract value with the given {@code type} and the annotations from {@code
      *     annotatedValue}; returns null if {@code annotatedValue} is null
      */
+    @SideEffectFree
     protected V getNarrowedValue(TypeMirror type, V annotatedValue) {
         if (annotatedValue == null) {
             return null;
@@ -1348,6 +1358,7 @@ public abstract class CFAbstractTransfer<
      * @return an abstract value with the given {@code type} and the annotations from {@code
      *     annotatedValue}; returns null if {@code annotatedValue} is null
      */
+    @SideEffectFree
     protected V getWidenedValue(TypeMirror type, V annotatedValue) {
         if (annotatedValue == null) {
             return null;

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -1300,7 +1300,8 @@ public abstract class CFAbstractTransfer<
      *
      * @param value1 an abstract value to be compared with
      * @param value2 an abstract value to be compared with
-     * @return the more specific value of the two parameters, or, if they are incomparable, {@code value1}
+     * @return the more specific value of the two parameters, or, if they are incomparable, {@code
+     *     value1}
      */
     @Pure
     public V moreSpecificValue(V value1, V value2) {

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -1300,7 +1300,7 @@ public abstract class CFAbstractTransfer<
      *
      * @param value1 an abstract value to be compared with
      * @param value2 an abstract value to be compared with
-     * @return A more specific value of the two params
+     * @return the more specific value of the two parameters, or, if they are incomparable, {@code value1}
      */
     @Pure
     public V moreSpecificValue(V value1, V value2) {

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -165,7 +165,7 @@ public abstract class CFAbstractTransfer<
      * @param store the store
      * @return the possibly-modified value
      */
-    @Pure
+    @SideEffectFree
     protected @Nullable V finishValue(@Nullable V value, S store) {
         return value;
     }
@@ -182,7 +182,7 @@ public abstract class CFAbstractTransfer<
      * @param elseStore the "else" store
      * @return the possibly-modified value
      */
-    @Pure
+    @SideEffectFree
     protected @Nullable V finishValue(@Nullable V value, S thenStore, S elseStore) {
         return value;
     }

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -43,6 +43,7 @@ import org.checkerframework.dataflow.cfg.node.WideningConversionNode;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.LocalVariable;
+import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.dataflow.util.NodeUtils;
 import org.checkerframework.framework.flow.CFAbstractAnalysis.FieldInitialValue;
@@ -148,7 +149,7 @@ public abstract class CFAbstractTransfer<
      * @return true if the transfer function uses sequential semantics, false if it uses concurrent
      *     semantics
      */
-    @SideEffectFree
+    @Pure
     public boolean usesSequentialSemantics() {
         return sequentialSemantics;
     }
@@ -164,7 +165,7 @@ public abstract class CFAbstractTransfer<
      * @param store the store
      * @return the possibly-modified value
      */
-    @SideEffectFree
+    @Pure
     protected @Nullable V finishValue(@Nullable V value, S store) {
         return value;
     }
@@ -181,7 +182,7 @@ public abstract class CFAbstractTransfer<
      * @param elseStore the "else" store
      * @return the possibly-modified value
      */
-    @SideEffectFree
+    @Pure
     protected @Nullable V finishValue(@Nullable V value, S thenStore, S elseStore) {
         return value;
     }
@@ -494,7 +495,7 @@ public abstract class CFAbstractTransfer<
      * @param methodDeclTree the declaration of the method or constructor
      * @return true if the receiver of a method or constructor might not yet be fully initialized
      */
-    @SideEffectFree
+    @Pure
     protected boolean isNotFullyInitializedReceiver(MethodTree methodDeclTree) {
         return TreeUtils.isConstructor(methodDeclTree);
     }
@@ -1301,7 +1302,7 @@ public abstract class CFAbstractTransfer<
      * @param value2 an abstract value to be compared with
      * @return A more specific value of the two params
      */
-    @SideEffectFree
+    @Pure
     public V moreSpecificValue(V value1, V value2) {
         if (value1 == null) {
             return value2;


### PR DESCRIPTION
For methods in `CFAbstractTransfer.java`, `BackwardTransferFunction.java`, `ForwardTransferFunction.java` with no side effect, add SideEffectFree annotations.