### PR TITLE
Test case for EISOP issue #321

### DIFF
--- a/checker/jtreg/stubs/stub-over-jdk/Issue321.astub
+++ b/checker/jtreg/stubs/stub-over-jdk/Issue321.astub
@@ -1,0 +1,2 @@
+package java.util;
+class Optional<T> {}

--- a/checker/jtreg/stubs/stub-over-jdk/Issue321.java
+++ b/checker/jtreg/stubs/stub-over-jdk/Issue321.java
@@ -1,0 +1,14 @@
+/*
+ * @test
+ * @summary Test for EISOP Issue #321
+ * @compile/fail/ref=Issue321.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker Issue321.java -Anomsgtext
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=Issue321.astub Issue321.java
+ */
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
+
+interface Issue321 {
+    @Nullable Optional<String> o();
+}

--- a/checker/jtreg/stubs/stub-over-jdk/Issue321.out
+++ b/checker/jtreg/stubs/stub-over-jdk/Issue321.out
@@ -1,0 +1,1 @@
+Issue321.java:12:32: compiler.err.proc.messager: (type.invalid.annotations.on.use)


### PR DESCRIPTION
@zcai1 I narrowed the problem down to starting with #305.
The issue seems to be that the absence of an annotation in the `.astub` file does not take precedence over the presence of an annotation in the annotated JDK.
Could you take a look?