### PR TITLE
Fix eisop issue #321

### DIFF
--- a/checker/jtreg/stubs/stub-over-jdk/Issue321.astub
+++ b/checker/jtreg/stubs/stub-over-jdk/Issue321.astub
@@ -1,0 +1,2 @@
+package java.util;
+class Optional<T> {}

--- a/checker/jtreg/stubs/stub-over-jdk/Issue321.java
+++ b/checker/jtreg/stubs/stub-over-jdk/Issue321.java
@@ -1,0 +1,14 @@
+/*
+ * @test
+ * @summary Test for EISOP Issue #321
+ * @compile/fail/ref=Issue321.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker Issue321.java -Anomsgtext
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=Issue321.astub Issue321.java
+ */
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
+
+interface Issue321 {
+    @Nullable Optional<String> o();
+}

--- a/checker/jtreg/stubs/stub-over-jdk/Issue321.out
+++ b/checker/jtreg/stubs/stub-over-jdk/Issue321.out
@@ -1,1 +1,2 @@
-Issue321.java:12:32: compiler.err.proc.messager: (type.invalid.annotations.on.use)
+Issue321.java:13:32: compiler.err.proc.messager: (type.invalid.annotations.on.use)
+1 error

--- a/checker/jtreg/stubs/stub-over-jdk/Issue321.out
+++ b/checker/jtreg/stubs/stub-over-jdk/Issue321.out
@@ -1,0 +1,1 @@
+Issue321.java:12:32: compiler.err.proc.messager: (type.invalid.annotations.on.use)

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -886,7 +886,7 @@ public class AnnotationFileElementTypes {
         boolean added = processingClasses.add(typeName);
         if (!added) {
             throw new BugInCF(
-                    "Trying to process " + typeName + " which is already being processed.");
+                    "Trying to process type " + typeName + " which is already being processed.");
         }
     }
 
@@ -899,8 +899,7 @@ public class AnnotationFileElementTypes {
     void postProcessTopLevelType(String typeName) {
         boolean removed = processingClasses.remove(typeName);
         if (!removed) {
-            throw new BugInCF(
-                    "Trying to remove a type " + typeName + " that has no processing record.");
+            throw new BugInCF("Cannot find the processing record for type " + typeName);
         }
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -891,7 +891,7 @@ public class AnnotationFileElementTypes {
      * This method is invoked each time after {@link AnnotationFileParser} processes a top-level
      * type.
      *
-     * @param typeName The fully qualified name of the top-level type
+     * @param typeName the fully qualified name of the top-level type
      */
     void postProcessTopLevelType(String typeName) {
         boolean success = processingClasses.remove(typeName);

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -880,7 +880,7 @@ public class AnnotationFileElementTypes {
      * This method is invoked each time before {@link AnnotationFileParser} processes a top-level
      * type.
      *
-     * @param typeName The fully qualified name of the top-level type
+     * @param typeName the fully qualified name of the top-level type
      */
     void preProcessTopLevelType(String typeName) {
         boolean success = processingClasses.add(typeName);

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -883,8 +883,11 @@ public class AnnotationFileElementTypes {
      * @param typeName the fully qualified name of the top-level type
      */
     void preProcessTopLevelType(String typeName) {
-        boolean success = processingClasses.add(typeName);
-        assert success;
+        boolean added = processingClasses.add(typeName);
+        if (!added) {
+            throw new BugInCF(
+                    "Trying to process " + typeName + " which is already being processed.");
+        }
     }
 
     /**
@@ -894,7 +897,10 @@ public class AnnotationFileElementTypes {
      * @param typeName the fully qualified name of the top-level type
      */
     void postProcessTopLevelType(String typeName) {
-        boolean success = processingClasses.remove(typeName);
-        assert success;
+        boolean removed = processingClasses.remove(typeName);
+        if (!removed) {
+            throw new BugInCF(
+                    "Trying to remove a type " + typeName + " that has no processing record.");
+        }
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -417,7 +417,7 @@ public class AnnotationFileParser {
      * @param atypeFactory AnnotatedTypeFactory to use
      * @param processingEnv ProcessingEnvironment to use
      * @param fileType the type of file being parsed (stub file or ajava file) and its source
-     * @param fileElementTypes The manager that controls the stub file parsing process
+     * @param fileElementTypes the manager that controls the stub file parsing process
      */
     private AnnotationFileParser(
             String filename,

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -3278,10 +3278,4 @@ public class AnnotationFileParser {
             }
         }
     }
-
-    public interface Listener {
-        default void preProcessTopLevelType(String typeName) {}
-
-        default void postProcessTopLevelType(String typeName) {}
-    }
 }

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -673,7 +673,7 @@ public class AnnotationFileParser {
      * @param processingEnv ProcessingEnvironment to use
      * @param annotationFileAnnos annotations from the annotation file; side-effected by this method
      * @param fileType the annotation file type and source
-     * @param fileElementTypes The manager that controls the stub file parsing process
+     * @param fileElementTypes the manager that controls the stub file parsing process
      */
     public static void parseStubFile(
             String filename,

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -202,8 +202,13 @@ public class AnnotationFileParser {
     // Not final in order to accommodate a default value.
     private StubUnit stubUnit;
 
+    /** The processing environment */
     private final ProcessingEnvironment processingEnv;
+
+    /** The type factory */
     private final AnnotatedTypeFactory atypeFactory;
+
+    /** The element utilities */
     private final Elements elements;
 
     /** The manager that controls the stub file parsing process. */

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -706,7 +706,7 @@ public class AnnotationFileParser {
      * @param atypeFactory AnnotatedTypeFactory to use
      * @param processingEnv ProcessingEnvironment to use
      * @param ajavaAnnos annotations from the ajava file; side-effected by this method
-     * @param fileElementTypes The manager that controls the stub file parsing process
+     * @param fileElementTypes the manager that controls the stub file parsing process
      */
     public static void parseAjavaFile(
             String filename,


### PR DESCRIPTION
This PR fixes #321 by preventing the parsing of multiple stub files for the same JDK class in the same round.