### PR TITLE
Fix AnnotatedTypeMirror.createType not removing annotations from the underlying type

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -11,6 +11,7 @@ import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypeKindUtils;
 import org.plumelib.util.CollectionsPlume;
 
@@ -62,13 +63,16 @@ public abstract class AnnotatedTypeMirror {
      * @param atypeFactory the type factory that will build the result
      * @param isDeclaration true if the result should represent a declaration, rather than a use, of
      *     a type
-     * @return an AnnotatedTypeMirror whose underlying type is {@code type}
+     * @return an AnnotatedTypeMirror whose underlying type is {@code type}, without any annotations
      */
     public static AnnotatedTypeMirror createType(
             TypeMirror type, AnnotatedTypeFactory atypeFactory, boolean isDeclaration) {
         if (type == null) {
             throw new BugInCF("AnnotatedTypeMirror.createType: input type must not be null");
         }
+
+        // Remove annotations on type to ensure that result.underlyingType is a bare type.
+        type = TypeAnnotationUtils.unannotatedType(type);
 
         AnnotatedTypeMirror result;
         switch (type.getKind()) {
@@ -121,9 +125,7 @@ public abstract class AnnotatedTypeMirror {
                                 + type.getKind()
                                 + ")");
         }
-        /*if (jctype.isAnnotated()) {
-            result.addAnnotations(jctype.getAnnotationMirrors());
-        }*/
+
         return result;
     }
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypeAnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypeAnnotationUtils.java
@@ -678,6 +678,11 @@ public class TypeAnnotationUtils {
             // TODO: file an issue that stripMetadata doesn't work for primitives.
             // See eisop/checker-framework issue #21.
             return impl.baseType();
+        } else if (impl instanceof Type.ForAll) {
+            // Since stripMetadata turns ForAlls into MethodTypes, we need to
+            // construct a new Forall.
+            com.sun.tools.javac.util.List<Type> tvars = ((Type.ForAll) impl).tvars;
+            return new Type.ForAll(tvars, impl.stripMetadata());
         } else {
             return impl.stripMetadata();
         }


### PR DESCRIPTION
Fixes #333 

I fixed this by having `createType()` strip `type` of any annotations, but I'm not sure if that's the right place or if we should already remove the annotations in the caller `AnnotatedTypeFactory.type()`. The documentation of all of these methods seems to assume that `TypeMirror`s never contain annotations, which is false.
