### PR TITLE
Improve the document in DefaultQualifierInHierarchy.java

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/framework/qual/DefaultQualifierInHierarchy.java
+++ b/checker-qual/src/main/java/org/checkerframework/framework/qual/DefaultQualifierInHierarchy.java
@@ -13,7 +13,8 @@ import java.lang.annotation.Target;
  *
  * <p>Other defaults can be specified for a checker via the {@link DefaultFor} meta-annotation,
  * which takes precedence over {@code DefaultQualifierInHierarchy}, or via {@code
- * GenericAnnotatedTypeFactory.addCheckedCodeDefaults()}.
+ * GenericAnnotatedTypeFactory.addCheckedCodeDefaults()}. For more details, see <a
+ * href="https://checkerframework.org/manual/#defaults">Default qualifier for the unannotated</a>
  *
  * <p>The {@link DefaultQualifier} annotation, which targets Java code elements, takes precedence
  * over {@code DefaultQualifierInHierarchy}.

--- a/checker-qual/src/main/java/org/checkerframework/framework/qual/DefaultQualifierInHierarchy.java
+++ b/checker-qual/src/main/java/org/checkerframework/framework/qual/DefaultQualifierInHierarchy.java
@@ -13,8 +13,8 @@ import java.lang.annotation.Target;
  *
  * <p>Other defaults can be specified for a checker via the {@link DefaultFor} meta-annotation,
  * which takes precedence over {@code DefaultQualifierInHierarchy}, or via {@code
- * GenericAnnotatedTypeFactory.addCheckedCodeDefaults()}. For more details, see <a
- * href="https://checkerframework.org/manual/#defaults">Default qualifier for the unannotated</a>
+ * GenericAnnotatedTypeFactory.addCheckedCodeDefaults()}, CLIMB-to-top rule. For more details, see
+ * <a href="https://checkerframework.org/manual/#defaults">Default qualifier for the unannotated</a>
  *
  * <p>The {@link DefaultQualifier} annotation, which targets Java code elements, takes precedence
  * over {@code DefaultQualifierInHierarchy}.


### PR DESCRIPTION
> it applies if the programmer writes no explicit qualifier and no other default has been specified for the location.

"other default" is not very clear, so, I added a link to the manual for detailed description of how different default mechanisms applied on the unannotated