### PR TITLE
Remove duplicate code in AnnotatedTypeFactory and javacutil

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -82,14 +82,12 @@ import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
-import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypeKindUtils;
 import org.checkerframework.javacutil.TypeSystemError;
 import org.checkerframework.javacutil.TypesUtils;
 import org.checkerframework.javacutil.UserError;
 import org.checkerframework.javacutil.trees.DetachedVarSymbol;
 import org.plumelib.util.CollectionsPlume;
-import org.plumelib.util.ImmutableTypes;
 import org.plumelib.util.StringsPlume;
 
 import java.io.BufferedReader;
@@ -5921,10 +5919,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @return true if the type is immutable
      */
     public boolean isImmutable(TypeMirror type) {
-        if (type.getKind().isPrimitive()) {
-            return true;
-        }
-        return ImmutableTypes.isImmutable(TypeAnnotationUtils.unannotatedType(type).toString());
+        return TypesUtils.isImmutableTypeInJdk(type);
     }
 
     @Override

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypeKindUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypeKindUtils.java
@@ -1,6 +1,11 @@
 package org.checkerframework.javacutil;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.FullyQualifiedName;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
@@ -8,6 +13,21 @@ import javax.lang.model.type.TypeMirror;
 
 /** A utility class that helps with {@link TypeKind}s. */
 public final class TypeKindUtils {
+
+    private static final Map<@FullyQualifiedName String, TypeKind> boxedToPrimitiveType;
+
+    static {
+        Map<@FullyQualifiedName String, TypeKind> map = new LinkedHashMap<>();
+        map.put("java.lang.Byte", TypeKind.BYTE);
+        map.put("java.lang.Boolean", TypeKind.BOOLEAN);
+        map.put("java.lang.Character", TypeKind.CHAR);
+        map.put("java.lang.Double", TypeKind.DOUBLE);
+        map.put("java.lang.Float", TypeKind.FLOAT);
+        map.put("java.lang.Integer", TypeKind.INT);
+        map.put("java.lang.Long", TypeKind.LONG);
+        map.put("java.lang.Short", TypeKind.SHORT);
+        boxedToPrimitiveType = Collections.unmodifiableMap(map);
+    }
 
     /** This class cannot be instantiated. */
     private TypeKindUtils() {
@@ -85,32 +105,16 @@ public final class TypeKindUtils {
             return typeKind;
         }
 
-        if (!(type instanceof DeclaredType)) {
+        return boxedToTypeKind(type);
+    }
+
+    public static @Nullable TypeKind boxedToTypeKind(TypeMirror type) {
+        if (type.getKind() != TypeKind.DECLARED) {
             return null;
         }
 
-        final String typeString = TypesUtils.getQualifiedName((DeclaredType) type).toString();
-
-        switch (typeString) {
-            case "java.lang.Byte":
-                return TypeKind.BYTE;
-            case "java.lang.Boolean":
-                return TypeKind.BOOLEAN;
-            case "java.lang.Character":
-                return TypeKind.CHAR;
-            case "java.lang.Double":
-                return TypeKind.DOUBLE;
-            case "java.lang.Float":
-                return TypeKind.FLOAT;
-            case "java.lang.Integer":
-                return TypeKind.INT;
-            case "java.lang.Long":
-                return TypeKind.LONG;
-            case "java.lang.Short":
-                return TypeKind.SHORT;
-            default:
-                return null;
-        }
+        final String typeString = TypesUtils.getQualifiedName((DeclaredType) type);
+        return boxedToPrimitiveType.get(typeString);
     }
 
     // No overload that takes AnnotatedTypeMirror becasue javacutil cannot depend on framework.

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypeKindUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypeKindUtils.java
@@ -14,6 +14,7 @@ import javax.lang.model.type.TypeMirror;
 /** A utility class that helps with {@link TypeKind}s. */
 public final class TypeKindUtils {
 
+    /** Map of a boxed primitive type's fully-qualified name to its primitive {@link TypeKind}. */
     private static final Map<@FullyQualifiedName String, TypeKind> boxedToPrimitiveType;
 
     static {
@@ -108,6 +109,13 @@ public final class TypeKindUtils {
         return boxedToTypeKind(type);
     }
 
+    /**
+     * Given a boxed primitive type, return the corresponding primitive type kind. Otherwise, return
+     * null.
+     *
+     * @param type a boxed primitive type
+     * @return a primitive type kind, or null
+     */
     public static @Nullable TypeKind boxedToTypeKind(TypeMirror type) {
         if (type.getKind() != TypeKind.DECLARED) {
             return null;

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -355,6 +355,12 @@ public final class TypesUtils {
                 && getQualifiedName((DeclaredType) type).contentEquals(qualifiedName);
     }
 
+    /**
+     * Check if the {@code type} represents a boxed primitive type.
+     *
+     * @param type the type to check
+     * @return true iff type represents a boxed primitive type
+     */
     public static boolean isBoxedPrimitive(TypeMirror type) {
         return TypeKindUtils.boxedToTypeKind(type) != null;
     }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -328,8 +328,7 @@ public final class TypesUtils {
      * @return true iff type represents a boolean type
      */
     public static boolean isBooleanType(TypeMirror type) {
-        TypeKind kind = TypeKindUtils.primitiveOrBoxedToTypeKind(type);
-        return kind == TypeKind.BOOLEAN;
+        return type.getKind() == TypeKind.BOOLEAN || isDeclaredOfName(type, "java.lang.Boolean");
     }
 
     /**
@@ -340,8 +339,7 @@ public final class TypesUtils {
      * @return true iff type represents a character type
      */
     public static boolean isCharType(TypeMirror type) {
-        TypeKind kind = TypeKindUtils.primitiveOrBoxedToTypeKind(type);
-        return kind == TypeKind.CHAR;
+        return type.getKind() == TypeKind.CHAR || isDeclaredOfName(type, "java.lang.Character");
     }
 
     /**

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -14,17 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.BinaryName;
 import org.checkerframework.checker.signature.qual.CanonicalNameOrEmpty;
 import org.checkerframework.checker.signature.qual.DotSeparatedIdentifiers;
-import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.plumelib.util.CollectionsPlume;
 import org.plumelib.util.ImmutableTypes;
 import org.plumelib.util.StringsPlume;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.StringJoiner;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -138,8 +134,7 @@ public final class TypesUtils {
                 // BUG: need to compute a @ClassGetName, but this code computes a
                 // @CanonicalNameOrEmpty.  They are different for inner classes.
                 @SuppressWarnings("signature") // https://tinyurl.com/cfissue/658 for Names.toString
-                @DotSeparatedIdentifiers String typeString =
-                        TypesUtils.getQualifiedName((DeclaredType) typeMirror).toString();
+                @DotSeparatedIdentifiers String typeString = TypesUtils.getQualifiedName((DeclaredType) typeMirror);
                 if (typeString.equals("<nulltype>")) {
                     return void.class;
                 }
@@ -333,7 +328,8 @@ public final class TypesUtils {
      * @return true iff type represents a boolean type
      */
     public static boolean isBooleanType(TypeMirror type) {
-        return isDeclaredOfName(type, "java.lang.Boolean") || type.getKind() == TypeKind.BOOLEAN;
+        TypeKind kind = TypeKindUtils.primitiveOrBoxedToTypeKind(type);
+        return kind == TypeKind.BOOLEAN;
     }
 
     /**
@@ -344,7 +340,8 @@ public final class TypesUtils {
      * @return true iff type represents a character type
      */
     public static boolean isCharType(TypeMirror type) {
-        return isDeclaredOfName(type, "java.lang.Character") || type.getKind() == TypeKind.CHAR;
+        TypeKind kind = TypeKindUtils.primitiveOrBoxedToTypeKind(type);
+        return kind == TypeKind.CHAR;
     }
 
     /**
@@ -359,20 +356,7 @@ public final class TypesUtils {
     }
 
     public static boolean isBoxedPrimitive(TypeMirror type) {
-        if (type.getKind() != TypeKind.DECLARED) {
-            return false;
-        }
-
-        String qualifiedName = getQualifiedName((DeclaredType) type).toString();
-
-        return (qualifiedName.equals("java.lang.Boolean")
-                || qualifiedName.equals("java.lang.Byte")
-                || qualifiedName.equals("java.lang.Character")
-                || qualifiedName.equals("java.lang.Short")
-                || qualifiedName.equals("java.lang.Integer")
-                || qualifiedName.equals("java.lang.Long")
-                || qualifiedName.equals("java.lang.Double")
-                || qualifiedName.equals("java.lang.Float"));
+        return TypeKindUtils.boxedToTypeKind(type) != null;
     }
 
     /**
@@ -422,19 +406,7 @@ public final class TypesUtils {
      * @return whether the argument is a primitive type
      */
     public static boolean isPrimitive(TypeMirror type) {
-        switch (type.getKind()) {
-            case BOOLEAN:
-            case BYTE:
-            case CHAR:
-            case DOUBLE:
-            case FLOAT:
-            case INT:
-            case LONG:
-            case SHORT:
-                return true;
-            default:
-                return false;
-        }
+        return type.getKind().isPrimitive();
     }
 
     /**
@@ -444,31 +416,7 @@ public final class TypesUtils {
      * @return true if the argument is a primitive type or a boxed primitive type
      */
     public static boolean isPrimitiveOrBoxed(TypeMirror type) {
-        switch (type.getKind()) {
-            case BOOLEAN:
-            case BYTE:
-            case CHAR:
-            case DOUBLE:
-            case FLOAT:
-            case INT:
-            case LONG:
-            case SHORT:
-                return true;
-
-            case DECLARED:
-                String qualifiedName = getQualifiedName((DeclaredType) type).toString();
-                return (qualifiedName.equals("java.lang.Boolean")
-                        || qualifiedName.equals("java.lang.Byte")
-                        || qualifiedName.equals("java.lang.Character")
-                        || qualifiedName.equals("java.lang.Short")
-                        || qualifiedName.equals("java.lang.Integer")
-                        || qualifiedName.equals("java.lang.Long")
-                        || qualifiedName.equals("java.lang.Double")
-                        || qualifiedName.equals("java.lang.Float"));
-
-            default:
-                return false;
-        }
+        return isPrimitive(type) || isBoxedPrimitive(type);
     }
 
     /**
@@ -481,18 +429,6 @@ public final class TypesUtils {
         return TypeKindUtils.isNumeric(type.getKind());
     }
 
-    /** The fully-qualified names of the numeric boxed types. */
-    static final Set<@FullyQualifiedName String> numericBoxedTypes =
-            new HashSet<>(
-                    Arrays.asList(
-                            "java.lang.Byte",
-                            "java.lang.Character",
-                            "java.lang.Short",
-                            "java.lang.Integer",
-                            "java.lang.Long",
-                            "java.lang.Double",
-                            "java.lang.Float"));
-
     /**
      * Returns true iff the argument is a boxed numeric type.
      *
@@ -500,8 +436,8 @@ public final class TypesUtils {
      * @return true if the argument is a boxed numeric type
      */
     public static boolean isNumericBoxed(TypeMirror type) {
-        return type.getKind() == TypeKind.DECLARED
-                && numericBoxedTypes.contains(getQualifiedName((DeclaredType) type).toString());
+        TypeKind boxedPrimitiveKind = TypeKindUtils.boxedToTypeKind(type);
+        return boxedPrimitiveKind != null && TypeKindUtils.isNumeric(boxedPrimitiveKind);
     }
 
     /**
@@ -511,16 +447,7 @@ public final class TypesUtils {
      * @return whether the argument is an integral primitive type
      */
     public static boolean isIntegralPrimitive(TypeMirror type) {
-        switch (type.getKind()) {
-            case BYTE:
-            case CHAR:
-            case INT:
-            case LONG:
-            case SHORT:
-                return true;
-            default:
-                return false;
-        }
+        return TypeKindUtils.isIntegral(type.getKind());
     }
 
     /**
@@ -543,32 +470,8 @@ public final class TypesUtils {
      * @return true if {@code declaredType} is a box of {@code primitiveType}
      */
     public static boolean isBoxOf(TypeMirror declaredType, TypeMirror primitiveType) {
-        if (declaredType.getKind() != TypeKind.DECLARED) {
-            return false;
-        }
-
-        final String qualifiedName = getQualifiedName((DeclaredType) declaredType).toString();
-        switch (primitiveType.getKind()) {
-            case BOOLEAN:
-                return qualifiedName.equals("java.lang.Boolean");
-            case BYTE:
-                return qualifiedName.equals("java.lang.Byte");
-            case CHAR:
-                return qualifiedName.equals("java.lang.Character");
-            case DOUBLE:
-                return qualifiedName.equals("java.lang.Double");
-            case FLOAT:
-                return qualifiedName.equals("java.lang.Float");
-            case INT:
-                return qualifiedName.equals("java.lang.Integer");
-            case LONG:
-                return qualifiedName.equals("java.lang.Long");
-            case SHORT:
-                return qualifiedName.equals("java.lang.Short");
-
-            default:
-                return false;
-        }
+        TypeKind boxedPrimitiveKind = TypeKindUtils.boxedToTypeKind(declaredType);
+        return boxedPrimitiveKind == primitiveType.getKind();
     }
 
     /**
@@ -578,12 +481,8 @@ public final class TypesUtils {
      * @return whether the argument is a boxed floating point type
      */
     public static boolean isBoxedFloating(TypeMirror type) {
-        if (type.getKind() != TypeKind.DECLARED) {
-            return false;
-        }
-
-        String qualifiedName = getQualifiedName((DeclaredType) type).toString();
-        return qualifiedName.equals("java.lang.Double") || qualifiedName.equals("java.lang.Float");
+        TypeKind boxedPrimitiveKind = TypeKindUtils.boxedToTypeKind(type);
+        return boxedPrimitiveKind != null && TypeKindUtils.isFloatingPoint(boxedPrimitiveKind);
     }
 
     /**
@@ -593,13 +492,7 @@ public final class TypesUtils {
      * @return whether the argument is a primitive floating point type
      */
     public static boolean isFloatingPrimitive(TypeMirror type) {
-        switch (type.getKind()) {
-            case DOUBLE:
-            case FLOAT:
-                return true;
-            default:
-                return false;
-        }
+        return TypeKindUtils.isFloatingPoint(type.getKind());
     }
 
     /**

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -409,6 +409,7 @@ public final class TypesUtils {
     /**
      * Returns true iff the argument is a primitive type.
      *
+     * @param type a type
      * @return whether the argument is a primitive type
      */
     public static boolean isPrimitive(TypeMirror type) {

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -384,8 +384,7 @@ public final class TypesUtils {
     public static boolean isImmutableTypeInJdk(TypeMirror type) {
         return isPrimitive(type)
                 || (type.getKind() == TypeKind.DECLARED
-                        && ImmutableTypes.isImmutable(
-                                getQualifiedName((DeclaredType) type).toString()));
+                        && ImmutableTypes.isImmutable(getQualifiedName((DeclaredType) type)));
     }
 
     /**


### PR DESCRIPTION
- single source of truth for the mapping from a boxed primitive type's fully-qualified name to its type kind.
- removed redundant `toString` call on the result of `TypesUtils.getQualifiedName`
- call `TypesUtils.isImmutableTypeInJdk` in `AnnotatedTypeFactory`