### PR TITLE
Added command line argument support for LiveVariablePlayground

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/playground/LiveVariablePlayground.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/playground/LiveVariablePlayground.java
@@ -19,26 +19,26 @@ public class LiveVariablePlayground {
      * @param args command-line arguments, not used
      */
     public static void main(String[] args) {
-	if (args.length == 0) {
-		printUsage();
-		System.exit(1);
-	}
-	String input = args[0];
-	File file = new File(input);
-	if (!file.canRead()) {
-		printError("Cannot read input file: " + file.getAbsolutePath());
-		printUsage();
-		System.exit(1);
-	}
+        if (args.length == 0) {
+            printUsage();
+            System.exit(1);
+        }
+        String input = args[0];
+        File file = new File(input);
+        if (!file.canRead()) {
+            printError("Cannot read input file: " + file.getAbsolutePath());
+            printUsage();
+            System.exit(1);
+        }
 
-	String method = "test";
-	String clas = "Test";
-	String output = ".";
-	boolean pdf = false;
-	boolean error = false;
-	boolean verbose = false;
+        String method = "test";
+        String clas = "Test";
+        String output = ".";
+        boolean pdf = false;
+        boolean error = false;
+        boolean verbose = false;
 
-	for (int i = 1; i < args.length; i++) {
+        for (int i = 1; i < args.length; i++) {
             switch (args[i]) {
                 case "--outputdir":
                     if (i >= args.length - 1) {
@@ -76,12 +76,11 @@ public class LiveVariablePlayground {
                     break;
             }
         }
-	
 
         if (error) {
-		System.exit(1);
-	}
-	
+            System.exit(1);
+        }
+
         LiveVarTransfer transfer = new LiveVarTransfer();
         BackwardAnalysis<UnusedAbstractValue, LiveVarStore, LiveVarTransfer> backwardAnalysis =
                 new BackwardAnalysisImpl<>(transfer);
@@ -90,11 +89,20 @@ public class LiveVariablePlayground {
     }
 
     private static void printUsage() {
-	System.out.println(
+        System.out.println(
+                "Generate the control flow graph of a Java method, represented as a DOT or String"
+                        + " graph.");
+        System.out.println(
                 "Parameters: <inputfile> [--outputdir <outputdir>] [--method <name>] [--class"
                         + " <name>] [--pdf] [--verbose] [--string]");
         System.out.println(
                 "    --outputdir: The output directory for the generated files (defaults to '.').");
+        System.out.println(
+                "    --method:    The method to generate the CFG for (defaults to 'test').");
+        System.out.println(
+                "    --class:     The class in which to find the method (defaults to 'Test').");
+        System.out.println("    --pdf:       Also generate the PDF by invoking 'dot'.");
+        System.out.println("    --verbose:   Show the verbose output (defaults to 'false').");
     }
 
     private static void printError(@Nullable String string) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/playground/LiveVariablePlayground.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/playground/LiveVariablePlayground.java
@@ -1,11 +1,14 @@
 package org.checkerframework.dataflow.cfg.playground;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.BackwardAnalysis;
 import org.checkerframework.dataflow.analysis.BackwardAnalysisImpl;
 import org.checkerframework.dataflow.analysis.UnusedAbstractValue;
 import org.checkerframework.dataflow.cfg.visualize.CFGVisualizeLauncher;
 import org.checkerframework.dataflow.livevariable.LiveVarStore;
 import org.checkerframework.dataflow.livevariable.LiveVarTransfer;
+
+import java.io.File;
 
 /** The playground of live variable analysis. */
 public class LiveVariablePlayground {
@@ -16,18 +19,85 @@ public class LiveVariablePlayground {
      * @param args command-line arguments, not used
      */
     public static void main(String[] args) {
+	if (args.length == 0) {
+		printUsage();
+		System.exit(1);
+	}
+	String input = args[0];
+	File file = new File(input);
+	if (!file.canRead()) {
+		printError("Cannot read input file: " + file.getAbsolutePath());
+		printUsage();
+		System.exit(1);
+	}
 
-        /* Configuration: change as appropriate */
-        String inputFile = "Test.java"; // input file name and path
-        String outputDir = "cfg"; // output directory
-        String method = "test"; // name of the method to analyze
-        String clazz = "Test"; // name of the class to consider
+	String method = "test";
+	String clas = "Test";
+	String output = ".";
+	boolean pdf = false;
+	boolean error = false;
+	boolean verbose = false;
 
-        // Run the analysis and create a PDF file
+	for (int i = 1; i < args.length; i++) {
+            switch (args[i]) {
+                case "--outputdir":
+                    if (i >= args.length - 1) {
+                        printError("Did not find <outputdir> after --outputdir.");
+                        continue;
+                    }
+                    i++;
+                    output = args[i];
+                    break;
+                case "--pdf":
+                    pdf = true;
+                    break;
+                case "--method":
+                    if (i >= args.length - 1) {
+                        printError("Did not find <name> after --method.");
+                        continue;
+                    }
+                    i++;
+                    method = args[i];
+                    break;
+                case "--class":
+                    if (i >= args.length - 1) {
+                        printError("Did not find <name> after --class.");
+                        continue;
+                    }
+                    i++;
+                    clas = args[i];
+                    break;
+                case "--verbose":
+                    verbose = true;
+                    break;
+                default:
+                    printError("Unknown command line argument: " + args[i]);
+                    error = true;
+                    break;
+            }
+        }
+	
+
+        if (error) {
+		System.exit(1);
+	}
+	
         LiveVarTransfer transfer = new LiveVarTransfer();
         BackwardAnalysis<UnusedAbstractValue, LiveVarStore, LiveVarTransfer> backwardAnalysis =
                 new BackwardAnalysisImpl<>(transfer);
         CFGVisualizeLauncher.generateDOTofCFG(
-                inputFile, outputDir, method, clazz, true, true, backwardAnalysis);
+                input, output, method, clas, pdf, verbose, backwardAnalysis);
+    }
+
+    private static void printUsage() {
+	System.out.println(
+                "Parameters: <inputfile> [--outputdir <outputdir>] [--method <name>] [--class"
+                        + " <name>] [--pdf] [--verbose] [--string]");
+        System.out.println(
+                "    --outputdir: The output directory for the generated files (defaults to '.').");
+    }
+
+    private static void printError(@Nullable String string) {
+        System.err.println("ERROR: " + string);
     }
 }


### PR DESCRIPTION
Reused code from CFGVisualizeLauncher.java. LiveVariablePlayground can now be launched from the command line.

Questions:
- I removed the --string flag, as it is not an argument for generateDOTofCFG. Is that okay?
- Is there any other flag that needs to be included/excluded?
- Are --pdf and --verbose tags necessary? We currently default to both. Do we want the additional flexibility?
- Should there be any changes to the contents of printUsage()?

Thank you in advance for the review!