### PR TITLE
Fix bug in warning about redundant annotations

### DIFF
--- a/checker/tests/nullness-warnredundantannotations/AnnoOnTypeVariableCrashCase.java
+++ b/checker/tests/nullness-warnredundantannotations/AnnoOnTypeVariableCrashCase.java
@@ -1,0 +1,7 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class AnnoOnTypeVariableCrashCase {
+    <T> @Nullable T test() {
+        return (@Nullable T) null;
+    }
+}

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1568,9 +1568,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             throw new BugInCF("unexpected null tree argument!");
         }
 
-        AnnotatedTypeMirror defaultAtms = atypeFactory.getDefaultAnnotations(tree, type);
+        AnnotatedTypeMirror defaultType = atypeFactory.getDefaultAnnotations(tree, type);
         for (AnnotationMirror explicitAnno : explicitAnnos) {
-            AnnotationMirror defaultAM = defaultAtms.getAnnotationInHierarchy(explicitAnno);
+            AnnotationMirror defaultAM = defaultType.getAnnotationInHierarchy(explicitAnno);
             if (AnnotationUtils.areSame(defaultAM, explicitAnno)) {
                 checker.reportWarning(tree, "redundant.anno", defaultAM);
             }

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1555,7 +1555,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      *     this type and location.
      */
     protected void warnRedundantAnnotations(Tree tree, AnnotatedTypeMirror type) {
-        if (!warnRedundantAnnotations) {
+        // Type variable uses don't have default annotations. So, any explicit annotation is not
+        // redundant.
+        if (!warnRedundantAnnotations || (type.getKind() == TypeKind.TYPEVAR)) {
             return;
         }
         AnnotationMirrorSet explicitAnnos = type.getExplicitAnnotations();
@@ -1567,11 +1569,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
 
         AnnotatedTypeMirror defaultAtms = atypeFactory.getDefaultAnnotations(tree, type);
-        if (defaultAtms.getAnnotations().isEmpty()) {
-            // Type variable uses don't have default annotations. So, any explicit annotation is not
-            // redundant.
-            return;
-        }
         for (AnnotationMirror explicitAnno : explicitAnnos) {
             AnnotationMirror defaultAM = defaultAtms.getAnnotationInHierarchy(explicitAnno);
             if (AnnotationUtils.areSame(defaultAM, explicitAnno)) {

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1567,10 +1567,15 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
 
         AnnotatedTypeMirror defaultAtms = atypeFactory.getDefaultAnnotations(tree, type);
+        if (defaultAtms.getAnnotations().isEmpty()) {
+            // Type variable uses don't have default annotations. So, any explicit annotation is not
+            // redundant.
+            return;
+        }
         for (AnnotationMirror explicitAnno : explicitAnnos) {
-            AnnotationMirror defaultAtm = defaultAtms.getAnnotationInHierarchy(explicitAnno);
-            if (AnnotationUtils.areSame(defaultAtm, explicitAnno)) {
-                checker.reportWarning(tree, "redundant.anno", defaultAtm);
+            AnnotationMirror defaultAM = defaultAtms.getAnnotationInHierarchy(explicitAnno);
+            if (AnnotationUtils.areSame(defaultAM, explicitAnno)) {
+                checker.reportWarning(tree, "redundant.anno", defaultAM);
             }
         }
     }


### PR DESCRIPTION
Add one null check in the implementation.
If not, the attached testcase will fail.