### PR TITLE
Use a fork of Daikon and use a fixed commit ID

### DIFF
--- a/checker/bin-devel/test-daikon-part1.sh
+++ b/checker/bin-devel/test-daikon-part1.sh
@@ -12,7 +12,7 @@ source "$SCRIPTDIR"/build.sh
 
 
 # daikon-typecheck: 15 minutes
-"$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon
+"$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon
 cd ../daikon
 git log | head -n 5
 make compile

--- a/checker/bin-devel/test-daikon-part2.sh
+++ b/checker/bin-devel/test-daikon-part2.sh
@@ -12,7 +12,7 @@ source "$SCRIPTDIR"/build.sh
 
 
 # daikon-typecheck: 15 minutes
-"$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon
+"$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon
 cd ../daikon
 git log | head -n 5
 make compile

--- a/checker/bin-devel/test-daikon.sh
+++ b/checker/bin-devel/test-daikon.sh
@@ -15,7 +15,7 @@ source "$SCRIPTDIR"/build.sh
 "$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon
 cd ../daikon
 # Use a known-working commit ID. Update this in a separate PR to confirm all tests pass.
-git checkout 3848b2f9459a5012a771ed2213f18336f1509866
+git reset --hard 3848b2f9459a5012a771ed2213f18336f1509866
 git log | head -n 5
 make compile
 if [ "$TRAVIS" = "true" ] ; then

--- a/checker/bin-devel/test-daikon.sh
+++ b/checker/bin-devel/test-daikon.sh
@@ -12,8 +12,10 @@ source "$SCRIPTDIR"/build.sh
 
 
 # daikon-typecheck: 15 minutes
-"$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon
+"$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon
 cd ../daikon
+# Use a known-working commit ID. Update this in a separate PR to confirm all tests pass.
+git checkout 3848b2f9459a5012a771ed2213f18336f1509866
 git log | head -n 5
 make compile
 if [ "$TRAVIS" = "true" ] ; then

--- a/checker/bin-devel/test-daikon.sh
+++ b/checker/bin-devel/test-daikon.sh
@@ -12,10 +12,10 @@ source "$SCRIPTDIR"/build.sh
 
 
 # daikon-typecheck: 15 minutes
-"$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon
+"$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon --depth 50
 cd ../daikon
 # Use a known-working commit ID. Update this in a separate PR to confirm all tests pass.
-git reset --hard 3848b2f9459a5012a771ed2213f18336f1509866
+git checkout 3848b2f9459a5012a771ed2213f18336f1509866
 git log | head -n 5
 make compile
 if [ "$TRAVIS" = "true" ] ; then

--- a/checker/bin-devel/test-daikon.sh
+++ b/checker/bin-devel/test-daikon.sh
@@ -12,7 +12,7 @@ source "$SCRIPTDIR"/build.sh
 
 
 # daikon-typecheck: 15 minutes
-"$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon --depth 50
+"$SCRIPTDIR/.plume-scripts/git-clone-related" eisop-codespecs daikon -q --single-branch --depth 50
 cd ../daikon
 # Use a known-working commit ID. Update this in a separate PR to confirm all tests pass.
 git checkout 3848b2f9459a5012a771ed2213f18336f1509866

--- a/docs/developer/release/README-release-process.html
+++ b/docs/developer/release/README-release-process.html
@@ -221,7 +221,7 @@ TreeAnnotator
   <li> <strong>Make Daikon use the latest Checker Framework version.</strong>
 
     Follow the  instructions in
-    <a href="https://github.com/codespecs/daikon/blob/master/java/lib/README">java/lib/README</a> to update the Checker Framework version number in Daikon.
+    <a href="https://github.com/eisop-codespecs/daikon/blob/master/java/lib/README">java/lib/README</a> to update the Checker Framework version number in Daikon.
   </li>
 </ol>
 
@@ -238,7 +238,7 @@ TreeAnnotator
     <li>Annotation File Utilities: <a href="https://dev.azure.com/eisop/annotation-tools/_build/latest?definitionId=2&branchName=master"><img src="https://dev.azure.com/eisop/annotation-tools/_apis/build/status/eisop.annotation-tools?branchName=master" alt="Azure Pipelines eisop/annotation-tools status"/></a></li>
     <li>Checker Framework: <a href="https://dev.azure.com/eisop/checker-framework/_build/latest?definitionId=2&branchName=master"><img src="https://dev.azure.com/eisop/checker-framework/_apis/build/status/eisop.checker-framework?branchName=master" alt="Azure Pipelines eisop/checker-framework status"/></a></li>
     <li>checker-framework.demos: <a href="https://travis-ci.org/eisop/checker-framework.demos/branches"><img src="https://travis-ci.org/eisop/checker-framework.demos.svg?branch=master" alt="Travis eisop/checker-framework.demos status"/></a></li>
-    <li>Daikon: <a href="https://dev.azure.com/codespecs/daikon/_build/latest?definitionId=1&branchName=master"><img src="https://dev.azure.com/codespecs/daikon/_apis/build/status/codespecs.daikon?branchName=master" alt="codespecs/daikon Azure Pipelines status"></a></li>
+    <li>Daikon: <a href="https://dev.azure.com/eisop-codespecs/daikon/_build/latest?definitionId=1&branchName=master"><img src="https://dev.azure.com/codespecs/daikon/_apis/build/status/codespecs.daikon?branchName=master" alt="codespecs/daikon Azure Pipelines status"></a></li>
     <li>guava-typecheck: <a href="https://travis-ci.org/typetests/guava-typecheck/branches"><img src="https://travis-ci.org/typetests/guava-typecheck.svg?branch=master" alt="Travis typetests/guava-typecheck status"/></a></li>
   </ul>
   </li>


### PR DESCRIPTION
This decouples eisop from Daikon changes and allows us to fix type checking problems in Daikon.