### PR TITLE
Temporarily disable stricter size comparison

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -102,9 +102,10 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements A
             return true;
         }
 
-        if (annos.size() != hierarchy.getTopAnnotations().size()) {
-            return false;
-        }
+        // TODO: temporarily disable stricter size comparison.
+        // if (annos.size() != hierarchy.getTopAnnotations().size()) {
+        //     return false;
+        // }
 
         // The size of the set matches, but maybe it contains multiple annos of one
         // hierarchy and none of another.


### PR DESCRIPTION
#530 causes a failure in Guava tests, surprisingly.
I didn't manage to locally reproduce or minimize the issue.
This size comparison seems like the only difference in behavior to me, so let's see whether this fixes the issue.

File a follow-up issue to make this validation stricter.