### PR TITLE
Add information about the checker and visitor class to exception reports

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2711,6 +2711,10 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
                         " To see the full stack trace, don't invoke the compiler with"
                                 + " -AnoPrintErrorStack");
             } else {
+                msg.add("Checker: " + this.getClass());
+                if (this.visitor != null) {
+                    msg.add("Visitor: " + this.visitor.getClass());
+                }
                 if (this.currentRoot != null && this.currentRoot.getSourceFile() != null) {
                     msg.add("Compilation unit: " + this.currentRoot.getSourceFile().getName());
                 }


### PR DESCRIPTION
This is useful when it's sometimes not clear what checker/visitor is used, e.g. in CI.
Output in a meaningful order, which requires checking the visitor for null twice.