### PR TITLE
Handle possible null return from URI.getPath

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -453,7 +453,11 @@ public class ElementUtils {
      * @return path to the source file containing {@code element}
      */
     public static String getSourceFilePath(TypeElement element) {
-        return ((ClassSymbol) element).sourcefile.toUri().getPath();
+        String path = ((ClassSymbol) element).sourcefile.toUri().getPath();
+        if (path == null) {
+            throw new BugInCF("Unexpected null path for TypeElement: " + element);
+        }
+        return path;
     }
 
     /**


### PR DESCRIPTION
Revealed by the improved annotations in https://github.com/eisop/jdk/pull/63