### PR TITLE
Use nullable type argument for `AtomicReference`

### DIFF
--- a/checker/tests/nullness/java8/Issue596.java
+++ b/checker/tests/nullness/java8/Issue596.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class Issue596 {
 
-    private static String getOrEmpty(AtomicReference<String> ref) {
+    private static String getOrEmpty(AtomicReference<@Nullable String> ref) {
         return Optional596.fromNullable(ref.get()).or("");
     }
 }


### PR DESCRIPTION
This should currently pass tests and will pass once https://github.com/eisop/jdk/pull/52 is merged.