### PR TITLE
Improve stub file handling and JDK compatibility

### DIFF
--- a/checker/jtreg/nullness/stub-arg/EisopIssue608-bad.astub
+++ b/checker/jtreg/nullness/stub-arg/EisopIssue608-bad.astub
@@ -1,0 +1,7 @@
+package java.util;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface List<E> extends Bad<E> {
+  boolean contains(@Nullable Object o);
+}

--- a/checker/jtreg/nullness/stub-arg/EisopIssue608-badstub.out
+++ b/checker/jtreg/nullness/stub-arg/EisopIssue608-badstub.out
@@ -1,0 +1,5 @@
+- compiler.warn.proc.messager: EisopIssue608-bad.astub:(line 5,col 1): direct supertype Bad not found
+- compiler.warn.proc.messager: EisopIssue608-bad.astub:(line 5,col 1): stub file does not match bytecode: could not find direct superclass Bad<E> from type List<E extends Object>
+- compiler.err.warnings.and.werror
+1 error
+2 warnings

--- a/checker/jtreg/nullness/stub-arg/EisopIssue608-nostub.out
+++ b/checker/jtreg/nullness/stub-arg/EisopIssue608-nostub.out
@@ -1,0 +1,2 @@
+EisopIssue608.java:13:27: compiler.err.proc.messager: (argument.type.incompatible)
+1 error

--- a/checker/jtreg/nullness/stub-arg/EisopIssue608.java
+++ b/checker/jtreg/nullness/stub-arg/EisopIssue608.java
@@ -4,7 +4,7 @@
  *
  * @compile/fail/ref=EisopIssue608-nostub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror EisopIssue608.java
  * @compile/fail/ref=EisopIssue608-badstub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror -Astubs=EisopIssue608-bad.astub EisopIssue608.java
- * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror -Astubs=checker.jar/collection-object-parameters-may-be-null.astub EisopIssue608.java
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror -AstubNoWarnIfNotFound -Astubs=checker.jar/collection-object-parameters-may-be-null.astub EisopIssue608.java
  */
 import java.util.List;
 

--- a/checker/jtreg/nullness/stub-arg/EisopIssue608.java
+++ b/checker/jtreg/nullness/stub-arg/EisopIssue608.java
@@ -1,0 +1,15 @@
+/*
+ * @test
+ * @summary Test case for EISOP issue #608.
+ *
+ * @compile/fail/ref=EisopIssue608-nostub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror EisopIssue608.java
+ * @compile/fail/ref=EisopIssue608-badstub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror -Astubs=EisopIssue608-bad.astub EisopIssue608.java
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror -Astubs=checker.jar/collection-object-parameters-may-be-null.astub EisopIssue608.java
+ */
+import java.util.List;
+
+public class EisopIssue608 {
+    boolean go(List<String> l) {
+        return l.contains(null);
+    }
+}

--- a/checker/jtreg/stubs/issue1585/UnknownField.out
+++ b/checker/jtreg/stubs/issue1585/UnknownField.out
@@ -1,4 +1,4 @@
-- compiler.warn.proc.messager: UnknownField.astub:(line 5,col 19): Static field NonNull is not imported
-- compiler.warn.proc.messager: UnknownField.astub:(line 5,col 19): For annotation @DefaultQualifier(NonNull), could not add  value=NonNull  because variable NonNull not found
-- compiler.warn.proc.messager: UnknownField.astub:(line 5,col 1): Unknown annotation @DefaultQualifier(NonNull)
+- compiler.warn.proc.messager: UnknownField.astub:(line 5,col 19): static field NonNull is not imported
+- compiler.warn.proc.messager: UnknownField.astub:(line 5,col 19): for annotation @DefaultQualifier(NonNull), could not add  value=NonNull  because variable NonNull not found
+- compiler.warn.proc.messager: UnknownField.astub:(line 5,col 1): unknown annotation @DefaultQualifier(NonNull)
 3 warnings

--- a/checker/jtreg/stubs/issue2059/AnnoNotFound.out
+++ b/checker/jtreg/stubs/issue2059/AnnoNotFound.out
@@ -1,2 +1,2 @@
-- compiler.warn.proc.messager: AnnoNotFound.astub:(line 8,col 3): Unknown annotation @Nullable
+- compiler.warn.proc.messager: AnnoNotFound.astub:(line 8,col 3): unknown annotation @Nullable
 1 warning

--- a/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
@@ -129,7 +129,8 @@ public interface Deque<E> extends Queue<E> {
     boolean contains(@Nullable Object o);
 }
 
-public interface List<E> extends Collection<E> {
+// No `extends Collection<E>` to be compatible with both Java 17 and 21
+public interface List<E> {
     boolean contains(@Nullable Object o);
     boolean remove(@Nullable Object o);
     boolean containsAll(Collection<?> c);

--- a/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
@@ -129,7 +129,7 @@ public interface Deque<E> extends Queue<E> {
     boolean contains(@Nullable Object o);
 }
 
-// No `extends Collection<E>` to be compatible with both Java 17 and 21
+// No `extends Collection<E>` to be compatible with both Java above and below 21
 public interface List<E> {
     boolean contains(@Nullable Object o);
     boolean remove(@Nullable Object o);

--- a/checker/tests/nullness-stubfile/NullnessStubfileMerge.java
+++ b/checker/tests/nullness-stubfile/NullnessStubfileMerge.java
@@ -1,7 +1,7 @@
-// warning: stubfile1.astub:(line 16,col 6): Package-private method notReal(String) not found in
+// warning: stubfile1.astub:(line 16,col 6): package-private method notReal(String) not found in
 // type java.lang.String
-// warning: stubfile1.astub:(line 19,col 1): Type not found: java.lang.NotARealClass
-// warning: stubfile1.astub:(line 21,col 1): Type not found: not.real.NotARealClassInNotRealPackage
+// warning: stubfile1.astub:(line 19,col 1): type not found: java.lang.NotARealClass
+// warning: stubfile1.astub:(line 21,col 1): type not found: not.real.NotARealClassInNotRealPackage
 
 import org.checkerframework.checker.nullness.qual.*;
 

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -399,6 +399,14 @@ public class AnnotationFileElementTypes {
                         SourceChecker currentChecker = checker;
                         boolean findByParentCheckers = false;
                         while (currentChecker != null) {
+                            URL normalResource = currentChecker.getClass().getResource(path);
+                            if (normalResource != null) {
+                                // If the parent checker supports the stub file, there is no need
+                                // for a warning.
+                                findByParentCheckers = true;
+                                break;
+                            }
+                            // See whether the stub file is mis-placed and issue a helpful warning.
                             URL topLevelResource =
                                     currentChecker.getClass().getResource("/" + path);
                             if (topLevelResource != null) {

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -576,7 +576,7 @@ public class AnnotationFileParser {
                     if (importDecl.isStatic()) {
                         // Wildcard import of members of a type (class or interface)
                         TypeElement element =
-                                getTypeElement(imported, "Imported type not found", importDecl);
+                                getTypeElement(imported, "imported type not found", importDecl);
                         if (element != null) {
                             // Find nested annotations
                             // Find compile time constant fields, or values of an enum
@@ -604,7 +604,7 @@ public class AnnotationFileParser {
                     if (importType == null && !importDecl.isStatic()) {
                         // Class or nested class (according to JSL), but we can't resolve
 
-                        stubWarnNotFound(importDecl, "Imported type not found: " + imported);
+                        stubWarnNotFound(importDecl, "imported type not found: " + imported);
                     } else if (importType == null) {
                         // static import of field or method.
 
@@ -616,7 +616,7 @@ public class AnnotationFileParser {
                                 getTypeElement(
                                         type,
                                         String.format(
-                                                "Enclosing type of static field %s not found",
+                                                "enclosing type of static field %s not found",
                                                 fieldName),
                                         importDecl);
 
@@ -639,14 +639,14 @@ public class AnnotationFileParser {
                             putIfAbsent(result, annoElt.getSimpleName().toString(), annoElt);
                             importedTypes.put(annoElt.getSimpleName().toString(), annoElt);
                         } else {
-                            stubWarnNotFound(importDecl, "Could not load import: " + imported);
+                            stubWarnNotFound(importDecl, "could not load import: " + imported);
                         }
                     } else {
                         // Class or nested class
                         // TODO: Is this needed?
                         importedConstants.add(imported);
                         TypeElement element =
-                                getTypeElement(imported, "Imported type not found", importDecl);
+                                getTypeElement(imported, "imported type not found", importDecl);
                         importedTypes.put(element.getSimpleName().toString(), element);
                     }
                 }
@@ -1000,11 +1000,11 @@ public class AnnotationFileParser {
                             && !hasNoAnnotationFileParserWarning(typeDecl.getAnnotations())
                             && !hasNoAnnotationFileParserWarning(packageAnnos))) {
                 if (elements.getAllTypeElements(fqTypeName).isEmpty()) {
-                    stubWarnNotFound(typeDecl, "Type not found: " + fqTypeName);
+                    stubWarnNotFound(typeDecl, "type not found: " + fqTypeName);
                 } else {
                     stubWarnNotFound(
                             typeDecl,
-                            "Type not found uniquely: "
+                            "type not found uniquely: "
                                     + fqTypeName
                                     + " : "
                                     + elements.getAllTypeElements(fqTypeName));
@@ -1096,7 +1096,7 @@ public class AnnotationFileParser {
                         processEnumConstant((EnumConstantDeclaration) decl, (VariableElement) elt);
                     } else {
                         throw new BugInCF(
-                                "Unexpected decl type "
+                                "unexpected decl type "
                                         + decl.getClass()
                                         + " for ENUM_CONSTANT kind, original: "
                                         + decl);
@@ -1201,7 +1201,7 @@ public class AnnotationFileParser {
                         type,
                         type.getClass(),
                         typeBeingParsed);
-                stubDebug("Proceeding despite mismatched sizes");
+                stubDebug("proceeding despite mismatched sizes");
             }
         }
 
@@ -1267,7 +1267,7 @@ public class AnnotationFileParser {
                     warn(
                             typeDecl,
                             "stub file does not match bytecode: "
-                                    + "could not find superclass "
+                                    + "could not find direct superclass "
                                     + supertype
                                     + " from type "
                                     + type);
@@ -1284,7 +1284,7 @@ public class AnnotationFileParser {
                     warn(
                             typeDecl,
                             "stub file does not match bytecode: "
-                                    + "could not find superinterface "
+                                    + "could not find direct superinterface "
                                     + supertype
                                     + " from type "
                                     + type);
@@ -1522,7 +1522,7 @@ public class AnnotationFileParser {
         AnnotatedTypeMirror currentAtype = atype;
         while (typeDef.isArrayType()) {
             if (currentAtype.getKind() != TypeKind.ARRAY) {
-                warn(astNode, "Mismatched array lengths; atype: " + atype + "%n  type: " + type);
+                warn(astNode, "mismatched array lengths; atype: " + atype + "%n  type: " + type);
                 return;
             }
 
@@ -1537,7 +1537,7 @@ public class AnnotationFileParser {
             currentAtype = ((AnnotatedArrayType) currentAtype).getComponentType();
         }
         if (currentAtype.getKind() == TypeKind.ARRAY) {
-            warn(astNode, "Mismatched array lengths; atype: " + atype + "%n  type: " + type);
+            warn(astNode, "mismatched array lengths; atype: " + atype + "%n  type: " + type);
         }
     }
 
@@ -1614,7 +1614,7 @@ public class AnnotationFileParser {
                         warn(
                                 astNode,
                                 String.format(
-                                        "Mismatch in type argument size between %s (%d) and %s"
+                                        "mismatch in type argument size between %s (%d) and %s"
                                                 + " (%d)",
                                         declType,
                                         declType.getTypeArguments().get().size(),
@@ -1639,7 +1639,7 @@ public class AnnotationFileParser {
                     // on the very next line.
                     warn(
                             astNode,
-                            "Wildcard type <"
+                            "wildcard type <"
                                     + atype
                                     + "> does not match type in stubs file"
                                     + filename
@@ -1824,7 +1824,7 @@ public class AnnotationFileParser {
             } else {
                 // TODO: Maybe always warn here.  It's so easy to forget an import statement and
                 // have an annotation silently ignored.
-                stubWarnNotFound(astNode, "Unknown annotation " + annotation);
+                stubWarnNotFound(astNode, "unknown annotation " + annotation);
             }
         }
     }
@@ -1858,7 +1858,7 @@ public class AnnotationFileParser {
             } else {
                 // TODO: Maybe always warn here.  It's so easy to forget an import statement and
                 // have an annotation silently ignored.
-                stubWarnNotFound(astNode, String.format("Unknown annotation %s", annotation));
+                stubWarnNotFound(astNode, String.format("unknown annotation %s", annotation));
             }
         }
         String eltName = ElementUtils.getQualifiedName(elt);
@@ -1963,7 +1963,7 @@ public class AnnotationFileParser {
 
                         stubWarnNotFound(
                                 param,
-                                "Annotations on intersection types are not yet supported: "
+                                "annotations on intersection types are not yet supported: "
                                         + param);
                     }
                 }
@@ -2114,7 +2114,7 @@ public class AnnotationFileParser {
                 putIfAbsent(elementsToDecl, elt, member);
             }
         } else {
-            stubDebug("Ignoring element of type %s in %s", member.getClass(), typeDeclName);
+            stubDebug("ignoring element of type %s in %s", member.getClass(), typeDeclName);
         }
     }
 
@@ -2244,7 +2244,7 @@ public class AnnotationFileParser {
                                 javaParserType.asArrayType().getComponentType());
 
             default:
-                throw new BugInCF("Unhandled type %s of kind %s", javacType, javacType.getKind());
+                throw new BugInCF("unhandled type %s of kind %s", javacType, javacType.getKind());
         }
     }
 
@@ -2304,9 +2304,9 @@ public class AnnotationFileParser {
                 return supertype;
             }
         }
-        stubWarnNotFound(astNode, "Supertype " + typeString + " not found");
+        stubWarnNotFound(astNode, "direct supertype " + typeString + " not found");
         if (debugAnnotationFileParser) {
-            stubDebug("Supertypes that were searched:");
+            stubDebug("direct supertypes that were searched:");
             for (AnnotatedDeclaredType supertype : types) {
                 stubDebug("  %s", supertype);
             }
@@ -2335,9 +2335,9 @@ public class AnnotationFileParser {
 
         stubWarnNotFound(
                 ciDecl,
-                "Class/interface " + wantedClassOrInterfaceName + " not found in type " + typeElt);
+                "class/interface " + wantedClassOrInterfaceName + " not found in type " + typeElt);
         if (debugAnnotationFileParser) {
-            stubDebug("  Here are the type declarations of %s:", typeElt);
+            stubDebug("  type declarations of %s:", typeElt);
             for (TypeElement method : ElementFilter.typesIn(typeElt.getEnclosedElements())) {
                 stubDebug("    %s", method);
             }
@@ -2363,9 +2363,9 @@ public class AnnotationFileParser {
             }
         }
 
-        stubWarnNotFound(enumDecl, "Enum " + wantedEnumName + " not found in type " + typeElt);
+        stubWarnNotFound(enumDecl, "enum " + wantedEnumName + " not found in type " + typeElt);
         if (debugAnnotationFileParser) {
-            stubDebug("  Here are the type declarations of %s:", typeElt);
+            stubDebug("  type declarations of %s:", typeElt);
             for (TypeElement method : ElementFilter.typesIn(typeElt.getEnclosedElements())) {
                 stubDebug("    %s", method);
             }
@@ -2423,7 +2423,7 @@ public class AnnotationFileParser {
                 // omit the access specifier, but package-private methods aren't in the TypeElement.
                 stubWarnNotFound(
                         methodDecl,
-                        "Package-private method "
+                        "package-private method "
                                 + wantedMethodString
                                 + " not found in type "
                                 + typeElt
@@ -2434,9 +2434,9 @@ public class AnnotationFileParser {
             } else {
                 stubWarnNotFound(
                         methodDecl,
-                        "Method " + wantedMethodString + " not found in type " + typeElt);
+                        "method " + wantedMethodString + " not found in type " + typeElt);
                 if (debugAnnotationFileParser) {
-                    stubDebug("  Here are the methods of %s:", typeElt);
+                    stubDebug("  methods of %s:", typeElt);
                     for (ExecutableElement method :
                             ElementFilter.methodsIn(typeElt.getEnclosedElements())) {
                         stubDebug("    %s", method);
@@ -2478,7 +2478,7 @@ public class AnnotationFileParser {
 
         stubWarnNotFound(
                 constructorDecl,
-                "Constructor " + wantedMethodString + " not found in type " + typeElt);
+                "constructor " + wantedMethodString + " not found in type " + typeElt);
         if (debugAnnotationFileParser) {
             for (ExecutableElement method :
                     ElementFilter.constructorsIn(typeElt.getEnclosedElements())) {
@@ -2518,7 +2518,7 @@ public class AnnotationFileParser {
             }
         }
 
-        stubWarnNotFound(astNode, "Field " + fieldName + " not found in type " + typeElt);
+        stubWarnNotFound(astNode, "field " + fieldName + " not found in type " + typeElt);
         if (debugAnnotationFileParser) {
             for (VariableElement field : ElementFilter.fieldsIn(typeElt.getEnclosedElements())) {
                 stubDebug("  %s", field);
@@ -2572,7 +2572,7 @@ public class AnnotationFileParser {
     private PackageElement findPackage(String packageName, NodeWithRange<?> astNode) {
         PackageElement packageElement = elements.getPackageElement(packageName);
         if (packageElement == null) {
-            stubWarnNotFound(astNode, "Imported package not found: " + packageName);
+            stubWarnNotFound(astNode, "imported package not found: " + packageName);
         }
         return packageElement;
     }
@@ -2652,7 +2652,7 @@ public class AnnotationFileParser {
                     } catch (AnnotationFileParserException e) {
                         warn(
                                 exp,
-                                "For annotation %s, could not add  %s=%s  because %s",
+                                "for annotation %s, could not add  %s=%s  because %s",
                                 annotation,
                                 member,
                                 exp,
@@ -2671,7 +2671,7 @@ public class AnnotationFileParser {
             } catch (AnnotationFileParserException e) {
                 warn(
                         valExpr,
-                        "For annotation %s, could not add  value=%s  because %s",
+                        "for annotation %s, could not add  value=%s  because %s",
                         annotation,
                         valExpr,
                         e.getMessage());
@@ -2761,9 +2761,9 @@ public class AnnotationFileParser {
 
             return typeElement.asType();
         } else if (expr instanceof NullLiteralExpr) {
-            throw new AnnotationFileParserException("Illegal annotation value null, for " + name);
+            throw new AnnotationFileParserException("illegal annotation value null, for " + name);
         } else {
-            throw new AnnotationFileParserException("Unexpected annotation expression: " + expr);
+            throw new AnnotationFileParserException("unexpected annotation expression: " + expr);
         }
     }
 
@@ -2850,7 +2850,7 @@ public class AnnotationFileParser {
             case DOUBLE:
                 return number.doubleValue() * scalefactor;
             default:
-                throw new BugInCF("Unexpected expectedKind: " + expectedKind);
+                throw new BugInCF("unexpected expectedKind: " + expectedKind);
         }
     }
 
@@ -2935,7 +2935,7 @@ public class AnnotationFileParser {
         } else if (value instanceof VariableElement) {
             builder.setValue(name, (VariableElement) value);
         } else {
-            throw new BugInCF("Unexpected builder value: %s", value);
+            throw new BugInCF("unexpected builder value: %s", value);
         }
     }
 
@@ -2968,7 +2968,7 @@ public class AnnotationFileParser {
                         getTypeElement(
                                 typeName,
                                 String.format(
-                                        "Enclosing type of static import %s not found", fieldName),
+                                        "enclosing type of static import %s not found", fieldName),
                                 nexpr);
 
                 if (enclType == null) {
@@ -2987,7 +2987,7 @@ public class AnnotationFileParser {
                 // have warnings from above.
                 stubWarnNotFound(nexpr, nexpr.getName() + " was imported but not found");
             } else {
-                stubWarnNotFound(nexpr, "Static field " + nexpr.getName() + " is not imported");
+                stubWarnNotFound(nexpr, "static field " + nexpr.getName() + " is not imported");
             }
         }
 
@@ -3033,7 +3033,7 @@ public class AnnotationFileParser {
             }
 
             if (rcvElt == null) {
-                stubWarnNotFound(faexpr, "Type " + faexpr.getScope() + " not found");
+                stubWarnNotFound(faexpr, "type " + faexpr.getScope() + " not found");
                 return null;
             }
         }


### PR DESCRIPTION
Improve stub file warning messages.
Make stub file work on Java below and above 21, by not including `extends` clauses. Looking through the relevant [JDK commit](https://github.com/openjdk/jdk/commit/17ce0976e442d5fabb14daed40fa9a768989f02e) it looks like `List` is the only class that needs this change in the stub file.

Fixes #608.