### PR TITLE
Renaming throw type and exception parameter err msg to incompatible 

### DIFF
--- a/checker/tests/fenum/CatchFenumUnqualified.java
+++ b/checker/tests/fenum/CatchFenumUnqualified.java
@@ -4,12 +4,12 @@ public class CatchFenumUnqualified {
     void method() {
         try {
         } catch (
-                // :: error: (exception.parameter.invalid)
+                // :: error: (exception.parameter.incompatible)
                 @Fenum("A") RuntimeException e) {
 
         }
         try {
-            // :: error: (exception.parameter.invalid)
+            // :: error: (exception.parameter.incompatible)
         } catch (@Fenum("A") NullPointerException | @Fenum("A") ArrayIndexOutOfBoundsException e) {
 
         }

--- a/checker/tests/guieffect/ThrowCatchTest.java
+++ b/checker/tests/guieffect/ThrowCatchTest.java
@@ -17,15 +17,15 @@ public class ThrowCatchTest {
     // Type var test
     <E extends @UI PolyUIException> void throwTypeVarUI1(E ex1, @UI E ex2) throws PolyUIException {
         if (flag) {
-            // :: error: (throw.type.invalid)
+            // :: error: (throw.type.incompatible)
             throw ex1;
         }
-        // :: error: (throw.type.invalid)
+        // :: error: (throw.type.incompatible)
         throw ex2;
     }
 
     <@UI E extends @UI PolyUIException> void throwTypeVarUI2(E ex1) throws PolyUIException {
-        // :: error: (throw.type.invalid)
+        // :: error: (throw.type.incompatible)
         throw ex1;
     }
 
@@ -48,7 +48,7 @@ public class ThrowCatchTest {
     <@AlwaysSafe E extends @UI PolyUIException> void throwTypeVarMixed(E ex1, @AlwaysSafe E ex2)
             throws PolyUIException {
         if (flag) {
-            // :: error: (throw.type.invalid)
+            // :: error: (throw.type.incompatible)
             throw ex1;
         }
         throw ex2;
@@ -75,7 +75,7 @@ public class ThrowCatchTest {
 
     void throwDeclared() {
         try {
-            // :: error: (throw.type.invalid)
+            // :: error: (throw.type.incompatible)
             throw ui;
         } catch (@UI PolyUIException UIParam) {
 

--- a/checker/tests/lock/TestTreeKinds.java
+++ b/checker/tests/lock/TestTreeKinds.java
@@ -335,7 +335,7 @@ public class TestTreeKinds {
         // throwing a guarded object - when throwing an exception, it must be @GuardedBy({}). Even
         // @GuardedByUnknown is not allowed.
         try {
-            // :: error: (throw.type.invalid)
+            // :: error: (throw.type.incompatible)
             throw exception;
         } catch (Exception e) {
         }

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3039,7 +3039,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             AnnotationMirror found = excParamType.getAnnotationInHierarchy(required);
             assert found != null;
             if (!typeHierarchy.isSubtypeShallowEffective(required, excParamType)) {
-                checker.reportError(excParamTree, "exception.parameter.invalid", found, required);
+                checker.reportError(excParamTree, "exception.parameter.incompatible", found, required);
             }
 
             if (excParamType.getKind() == TypeKind.UNION) {
@@ -3050,7 +3050,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                                 alternativeType.getAnnotationInHierarchy(required);
                         checker.reportError(
                                 excParamTree,
-                                "exception.parameter.invalid",
+                                "exception.parameter.incompatible",
                                 alternativeAnno,
                                 required);
                     }
@@ -3102,7 +3102,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 if (!typeHierarchy.isSubtypeShallowEffective(throwType, required)) {
                     AnnotationMirrorSet found = throwType.getEffectiveAnnotations();
                     checker.reportError(
-                            tree.getExpression(), "throw.type.invalid", found, required);
+                            tree.getExpression(), "throw.type.incompatible", found, required);
                 }
                 break;
 
@@ -3111,7 +3111,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 AnnotationMirrorSet foundPrimary = unionType.getAnnotations();
                 if (!qualHierarchy.isSubtypeShallow(foundPrimary, required, throwTM)) {
                     checker.reportError(
-                            tree.getExpression(), "throw.type.invalid", foundPrimary, required);
+                            tree.getExpression(), "throw.type.incompatible", foundPrimary, required);
                 }
                 for (AnnotatedTypeMirror altern : unionType.getAlternatives()) {
                     TypeMirror alternTM = altern.getUnderlyingType();
@@ -3119,7 +3119,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                             altern.getAnnotations(), required, alternTM)) {
                         checker.reportError(
                                 tree.getExpression(),
-                                "throw.type.invalid",
+                                "throw.type.incompatible",
                                 altern.getAnnotations(),
                                 required);
                     }

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -31,8 +31,8 @@ type.invalid.super.wildcard=bounds must have the same annotations.%nsuper bound 
 cast.unsafe=cast from "%s" to "%s" cannot be statically verified
 invariant.cast.unsafe=cannot cast from "%s" to "%s"
 cast.unsafe.constructor.invocation=constructor invocation cast from "%s" to "%s" cannot be statically verified
-exception.parameter.invalid=invalid type in catch argument.%nfound   : %s%nrequired: %s
-throw.type.invalid=invalid type thrown.%nfound   : %s%nrequired: %s
+exception.parameter.incompatible=incompatible type in catch argument.%nfound   : %s%nrequired: %s
+throw.type.incompatible=incompatible type thrown.%nfound   : %s%nrequired: %s
 expression.unparsable.type.invalid=Expression invalid in dependent type annotation: %s
 explicit.annotation.ignored=The qualifier %s is ignored in favor of %s. Either delete %s or change it to %s.
 

--- a/framework/tests/aliasing/CatchTest.java
+++ b/framework/tests/aliasing/CatchTest.java
@@ -8,7 +8,7 @@ public class CatchTest {
             // :: error: (unique.leaked)
             throw exVar;
 
-            // :: error: (exception.parameter.invalid)
+            // :: error: (exception.parameter.incompatible)
         } catch (@Unique Exception e) {
             // exVar and e points to the same object, therefore catch clauses
             // are not allowed to have a @Unique parameter.

--- a/framework/tests/flowexpression/Standardize.java
+++ b/framework/tests/flowexpression/Standardize.java
@@ -32,7 +32,7 @@ public class Standardize {
             @FlowExp("field") Object o7 = in;
             @FlowExp("this.field") Object o8 = in;
         } catch (
-                @SuppressWarnings("exception.parameter.invalid")
+                @SuppressWarnings("exception.parameter.incompatible")
                 @FlowExp("field") Exception ex) {
             @FlowExp("field") Object o9 = ex;
             @FlowExp("this.field") Object o10 = ex;

--- a/framework/tests/h1h2checker/Catch.java
+++ b/framework/tests/h1h2checker/Catch.java
@@ -28,7 +28,7 @@ public class Catch {
     void explictlyNotTopUnionType() throws Throwable {
         try {
             throw new Throwable();
-            // :: error: (exception.parameter.invalid)
+            // :: error: (exception.parameter.incompatible)
         } catch (@H1S1 @H2Top IndexOutOfBoundsException | @H1S1 @H2Top NullPointerException ex) {
 
         }
@@ -45,7 +45,7 @@ public class Catch {
     void explictlyNotTopDeclaredType() throws Throwable {
         try {
             throw new Throwable();
-            // :: error: (exception.parameter.invalid)
+            // :: error: (exception.parameter.incompatible)
         } catch (@H1S1 @H2Top RuntimeException ex) {
 
         }


### PR DESCRIPTION
I will do the two renaming first as they are the most related to our changes in #436.