### PR TITLE
Fix rules for switch statement exhaustiveness

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -46,7 +46,6 @@ import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.SynchronizedTree;
 import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.TypeParameterTree;
@@ -2458,8 +2457,15 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
                     // build the default case last.
                     defaultIndex = i;
                 } else if (i == numCases - 1 && defaultIndex == -1) {
-                    // This is the last case, and it's not a default case.
-                    buildCase(caseTree, i, exhaustiveIgnoreDefault());
+                    // This is the last case, and there is no default case.
+                    // Switch statements without a default case are not exhaustive.
+                    // Note that even if all cases of an enum are covered, the enum class could add
+                    // more constants, leading to none of the cases matching. So a switch statement
+                    // without default case is not exhaustive.
+                    // Switch expressions are always exhaustive.
+                    // TODO: check exhaustiveness rules for null cases, binding patterns,
+                    // and deconstruction patterns.
+                    buildCase(caseTree, i, !TreeUtils.isSwitchStatement(switchTree));
                 } else {
                     buildCase(caseTree, i, false);
                 }
@@ -2671,50 +2677,6 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
             // Switch rules never fall through so add jump to the break target.
             assert breakTargetLC != null : "no target for case statement";
             extendWithExtendedNode(new UnconditionalJump(breakTargetLC.accessLabel()));
-        }
-
-        /**
-         * Returns true if the switch is exhaustive; ignoring any default case
-         *
-         * @return true if the switch is exhaustive; ignoring any default case
-         */
-        private boolean exhaustiveIgnoreDefault() {
-            // Switch expressions are always exhaustive, but they might have a default case, which
-            // is why the above loop is not fused with the below loop.
-            if (!TreeUtils.isSwitchStatement(switchTree)) {
-                return true;
-            }
-
-            int enumCaseLabels = 0;
-            for (CaseTree caseTree : caseTrees) {
-                for (Tree caseLabel : CaseUtils.getLabels(caseTree)) {
-                    // Java guarantees that if one of the cases is the null literal, the switch is
-                    // exhaustive.
-                    // Also if certain other constructs exist.
-                    if (caseLabel.getKind() == Kind.NULL_LITERAL
-                            || TreeUtils.isBindingPatternTree(caseLabel)
-                            || TreeUtils.isDeconstructionPatternTree(caseLabel)) {
-                        return true;
-                    }
-                    if (caseLabel.getKind() == Kind.IDENTIFIER) {
-                        enumCaseLabels++;
-                    }
-                }
-            }
-
-            TypeMirror selectorTypeMirror = TreeUtils.typeOf(selectorExprTree);
-            if (selectorTypeMirror.getKind() == TypeKind.DECLARED) {
-                DeclaredType declaredType = (DeclaredType) selectorTypeMirror;
-                TypeElement declaredTypeElement = (TypeElement) declaredType.asElement();
-                if (declaredTypeElement.getKind() == ElementKind.ENUM) {
-                    // The switch expression's type is an enumerated type.
-                    List<VariableElement> enumConstants =
-                            ElementUtils.getEnumConstants(declaredTypeElement);
-                    return enumConstants.size() == enumCaseLabels;
-                }
-            }
-
-            return false;
         }
     }
 

--- a/framework/tests/all-systems/EnumSwitch.java
+++ b/framework/tests/all-systems/EnumSwitch.java
@@ -1,0 +1,21 @@
+// Test case for EISOP issue #609:
+// https://github.com/eisop/checker-framework/issues/609
+enum EnumSwitch {
+    FOO;
+
+    EnumSwitch getIt() {
+        return FOO;
+    }
+
+    String go() {
+        EnumSwitch e = getIt();
+        switch (e) {
+            case FOO:
+                return "foo";
+        }
+        // This location is reachable in general: the enum could evolve and add a new constant.
+        // This cannot be the case here, because this code is in the enum declaration.
+        // javac does not special case this and I do not see a reason to do so here.
+        throw new AssertionError(e);
+    }
+}


### PR DESCRIPTION
The typetools fix for the issue corresponding to #609 is to remove dead code from the CFG.
I do not see a reason to call this location dead, so instead, this fixes the CFG construction for switch statements.

As future work, as noted in the TODO, we should check exhaustiveness rules for null cases, binding patterns, and deconstruction patterns. No tests fail, so we should also add corresponding tests.

Fixes #609.