### PR TITLE
Add an extra dependency when building the annotated JDK

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -111,7 +111,7 @@ task cloneAnnotatedJdk() {
 
 
 task copyAndMinimizeAnnotatedJdkFiles(dependsOn: cloneAnnotatedJdk, group: 'Build') {
-    dependsOn ':framework:compileJava'
+    dependsOn ':framework:compileJava', project(':javacutil').tasks.jar
     def inputDir = "${annotatedJdkHome}/src"
     def outputDir = "${buildDir}/generated/resources/annotated-jdk/"
 


### PR DESCRIPTION
When building the CF from an included build, I'm running into this exception:

````
Exception in thread "main" java.lang.NoClassDefFoundError: org/checkerframework/javacutil/BugInCF
        at org.checkerframework.framework.stub.JavaStubifier.process(JavaStubifier.java:73)
        at org.checkerframework.framework.stub.JavaStubifier.main(JavaStubifier.java:58)
Caused by: java.lang.ClassNotFoundException: org.checkerframework.javacutil.BugInCF
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
        ... 2 more
````

When looking at the value of https://github.com/eisop/checker-framework/blob/3764240d1c9fca1ba03c54e74fc208ec8fe55738/framework/build.gradle#L147 I see

````
framework/build/classes/java/main
framework/build/resources/main
dataflow/build/libs/dataflow-3.41.0-eisop2-SNAPSHOT.jar
javacutil/build/libs/javacutil-3.41.0-eisop2-SNAPSHOT.jar
....
````

However, the javacutil jar file does not exist at that point.
Adding this extra dependency makes sure the classes needed by JavaStubifier actually exist.