### PR TITLE
Improve performance of `var` variable declarations

### DIFF
--- a/checker/jtreg/nullness/Issue6373.java
+++ b/checker/jtreg/nullness/Issue6373.java
@@ -3,7 +3,7 @@
  * @summary Test case for issue #6373: https://github.com/typetools/checker-framework/issues/6373
  *
  * @requires jdk.version.major >= 10
- * @compile/timeout=120 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue6373.java
+ * @compile/timeout=140 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue6373.java
  */
 public class Issue6373 {
 

--- a/checker/jtreg/nullness/Issue6373.java
+++ b/checker/jtreg/nullness/Issue6373.java
@@ -1,0 +1,127 @@
+/*
+ * @test
+ * @summary Test case for issue #6373: https://github.com/typetools/checker-framework/issues/6373
+ *
+ * @requires jdk.version.major >= 10
+ * @compile/fail/timeout=120 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue6373.java
+ */
+public class Issue6373 {
+
+    abstract static class C1<
+                    C extends C1<C, Q, B, D, CR>,
+                    Q extends C2<C, Q, B, D, CR>,
+                    B extends C3<C, Q, B, D, CR>,
+                    D extends C4<C, Q, B, D, CR>,
+                    CR extends C5<CR>>
+            extends C6 {}
+
+    static class C6 {}
+
+    abstract static class C2<
+                    C extends C1<C, Q, B, D, RT>,
+                    Q extends C2<C, Q, B, D, RT>,
+                    B extends C3<C, Q, B, D, RT>,
+                    D extends C4<C, Q, B, D, RT>,
+                    RT extends C5<RT>>
+            implements C7 {}
+
+    abstract static class C3<
+            C extends C1<C, Q, B, D, R>,
+            Q extends C2<C, Q, B, D, R>,
+            B extends C3<C, Q, B, D, R>,
+            D extends C4<C, Q, B, D, R>,
+            R extends C5<R>> {}
+
+    abstract static class C4<
+            C extends C1<C, Q, B, D, R>,
+            Q extends C2<C, Q, B, D, R>,
+            B extends C3<C, Q, B, D, R>,
+            D extends C4<C, Q, B, D, R>,
+            R extends C5<R>> {
+        interface I<T> {}
+    }
+
+    abstract static class C5<R2 extends C5<R2>> implements C7 {}
+
+    interface C7 {}
+
+    abstract static class C8<
+            C extends C1<C, Q, B, D, CR>,
+            Q extends C2<C, Q, B, D, CR>,
+            B extends C3<C, Q, B, D, CR>,
+            D extends C4<C, Q, B, D, CR>,
+            CR extends C5<CR>,
+            RpT extends C5<RpT>> {
+
+        public static <
+                        C extends C1<C, Q, B, D, CR>,
+                        Q extends C2<C, Q, B, D, CR>,
+                        B extends C3<C, Q, B, D, CR>,
+                        D extends C4<C, Q, B, D, CR>,
+                        CR extends C5<CR>,
+                        RpT extends C5<RpT>>
+                Builder<C, Q, B, D, CR, RpT> n(Q q) {
+            throw new AssertionError();
+        }
+
+        abstract static class Builder<
+                C extends C1<C, Q, B, D, CR>,
+                Q extends C2<C, Q, B, D, CR>,
+                B extends C3<C, Q, B, D, CR>,
+                D extends C4<C, Q, B, D, CR>,
+                CR extends C5<CR>,
+                RpT extends C5<RpT>> {
+
+            public abstract Builder<C, Q, B, D, CR, RpT> f(C9<?> x);
+
+            public C8<C, Q, B, D, CR, RpT> b() {
+                throw new AssertionError();
+            }
+        }
+    }
+
+    abstract static class C9<W extends C9<W>> {}
+
+    static final class C10 extends C9<C10> {}
+
+    abstract static class C11<W extends C9<W>, B extends C11<W, B>> {}
+
+    static final class C12 extends C11<C10, C12> {
+
+        public C10 b() {
+            throw new AssertionError();
+        }
+    }
+
+    static class C13 {
+
+        public static final C12 n() {
+            return new C12();
+        }
+
+        static final class C14 extends C1<C14, C15, C16, C17, C18> {}
+
+        static final class C15 extends C2<C14, C15, C16, C17, C18> {}
+
+        static final class C18 extends C5<C18> {}
+
+        static class C17 extends C4<C14, C15, C16, C17, C18> implements C4.I<Long>, C19 {}
+
+        static final class C16 extends C3<C14, C15, C16, C17, C18> {
+
+            public C15 b() {
+                throw new AssertionError();
+            }
+        }
+
+        static final C16 q() {
+            throw new AssertionError();
+        }
+    }
+
+    interface C19 {}
+
+    void f() {
+        var x = C8.n(C13.q().b()).f(C13.n().b()).b();
+    }
+}

--- a/checker/jtreg/nullness/Issue6373.java
+++ b/checker/jtreg/nullness/Issue6373.java
@@ -3,7 +3,7 @@
  * @summary Test case for issue #6373: https://github.com/typetools/checker-framework/issues/6373
  *
  * @requires jdk.version.major >= 10
- * @compile/timeout=140 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue6373.java
+ * @compile/timeout=70 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue6373.java
  */
 public class Issue6373 {
 
@@ -72,7 +72,7 @@ public class Issue6373 {
                 CR extends C5<CR>,
                 RpT extends C5<RpT>> {
 
-            public abstract Builder<C, Q, B, D, CR, RpT> f(C9<?> x);
+            public abstract Builder<C, Q, B, D, CR, RpT> f(C9<?> p);
 
             public C8<C, Q, B, D, CR, RpT> b() {
                 throw new AssertionError();
@@ -123,5 +123,17 @@ public class Issue6373 {
 
     void f() {
         var x = C8.n(C13.q().b()).f(C13.n().b()).b();
+        var y = x;
+        x = y;
+        x = y;
+        x = y;
+    }
+
+    void g() {
+        Object x = C8.n(C13.q().b()).f(C13.n().b()).b();
+        Object y = x;
+        x = y;
+        x = y;
+        x = y;
     }
 }

--- a/checker/jtreg/nullness/Issue6373.java
+++ b/checker/jtreg/nullness/Issue6373.java
@@ -3,7 +3,7 @@
  * @summary Test case for issue #6373: https://github.com/typetools/checker-framework/issues/6373
  *
  * @requires jdk.version.major >= 10
- * @compile/fail/timeout=120 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue6373.java
+ * @compile/timeout=120 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue6373.java
  */
 public class Issue6373 {
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ Version 3.41.0-eisop2 (December ?, 2023)
 
 **Closed issues:**
 
+typetools#6373.
+
 
 Version 3.41.0-eisop1 (December 5, 2023)
 ----------------------------------------

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -111,7 +111,7 @@ task cloneAnnotatedJdk() {
 
 
 task copyAndMinimizeAnnotatedJdkFiles(dependsOn: cloneAnnotatedJdk, group: 'Build') {
-    dependsOn ':framework:compileJava'
+    dependsOn ':framework:compileJava', project(':javacutil').tasks.jar
     def inputDir = "${annotatedJdkHome}/src"
     def outputDir = "${buildDir}/generated/resources/annotated-jdk/"
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1650,8 +1650,14 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             commonAssignmentCheck(
                     tree, tree.getInitializer(), "enum.declaration.type.incompatible");
         } else if (tree.getInitializer() != null) {
-            // If there's no assignment in this variable declaration, skip it.
-            commonAssignmentCheck(tree, tree.getInitializer(), "assignment.type.incompatible");
+            if (!TreeUtils.isVariableTreeDeclaredUsingVar(tree)) {
+                // If there is no assignment in this variable declaration or it is declared using
+                // `var`, skip it.
+                // For a `var` declaration, TypeFromMemberVisitor#visitVariable already uses the
+                // type of the initializer for the variable type, so it would be redundant to check
+                // for compatibility here.
+                commonAssignmentCheck(tree, tree.getInitializer(), "assignment.type.incompatible");
+            }
         } else {
             // commonAssignmentCheck validates the type of `tree`,
             // so only validate if commonAssignmentCheck wasn't called

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1466,11 +1466,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         addComputedTypeAnnotations(tree, type);
 
-        if (TreeUtils.isClassTree(tree) || tree.getKind() == Tree.Kind.METHOD) {
+        if (shouldCache && (TreeUtils.isClassTree(tree) || tree.getKind() == Tree.Kind.METHOD)) {
             // Don't cache VARIABLE
-            if (shouldCache) {
-                classAndMethodTreeCache.put(tree, type.deepCopy());
-            }
+            classAndMethodTreeCache.put(tree, type.deepCopy());
         } else {
             // No caching otherwise
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1832,7 +1832,32 @@ public abstract class GenericAnnotatedTypeFactory<
         AnnotatedTypeMirror res;
         switch (lhsTree.getKind()) {
             case VARIABLE:
+                boolean isVarTree =
+                        TreeUtils.isVariableTreeDeclaredUsingVar((VariableTree) lhsTree);
+                if (isVarTree) {
+                    // If this variable is declared using `var`, re-enable caching to avoid
+                    // re-computing the initializer expression type.
+                    shouldCache = oldShouldCache;
+                }
+                res = getAnnotatedType(lhsTree);
+                // Value of shouldCache no longer used below, so no need to reset.
+                break;
             case IDENTIFIER:
+                Element elt = TreeUtils.elementFromTree(lhsTree);
+                if (elt != null) {
+                    Tree decl = declarationFromElement(elt);
+                    if (decl != null
+                            && decl.getKind() == Tree.Kind.VARIABLE
+                            && TreeUtils.isVariableTreeDeclaredUsingVar((VariableTree) decl)) {
+                        // If this identifier accesses a variable that was declared using `var`,
+                        // re-enable caching to avoid re-computing the initializer expression type.
+                        shouldCache = oldShouldCache;
+                    }
+                }
+                res = getAnnotatedType(lhsTree);
+                // Value of shouldCache no longer used below, so no need to reset.
+                break;
+
             case MEMBER_SELECT:
             case ARRAY_ACCESS:
                 res = getAnnotatedType(lhsTree);

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -43,13 +43,14 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
         // Skip propagation of annotations when initializer can be null.
         // E.g.
         // for (var i : list) {}
-        if (TreeUtils.isVariableTreeDeclaredUsingVar(variableTree)
-                && variableTree.getInitializer() != null) {
+        if (variableTree.getInitializer() != null
+                && TreeUtils.isVariableTreeDeclaredUsingVar(variableTree)) {
+            // BaseTypeVisitor#visitVariable does not need to check the type of `var` declarations.
             result = f.getAnnotatedType(variableTree.getInitializer());
             // Let normal defaulting happen for the primary annotation.
             result.clearAnnotations();
-        } else if (TreeUtils.isVariableTreeDeclaredUsingVar(variableTree)
-                || variableTree.getType() == null) {
+        } else if (variableTree.getType() == null
+                || TreeUtils.isVariableTreeDeclaredUsingVar(variableTree)) {
             // VariableTree#getType returns null for binding variables from a
             // DeconstructionPatternTree.
             result = f.type(variableTree);
@@ -78,14 +79,12 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
                 // Annotations on enum constants are not in the TypeMirror and always apply to the
                 // innermost type, so handle them in the else block.
                 elt.getKind() != ElementKind.ENUM_CONSTANT) {
-
             // Decode the annotations from the type mirror because the annotations are already in
             // the correct place for enclosing types.  The annotations in
-            // variableTree.getModifiers()
-            // might apply to the enclosing type or the type itself. For example, @Tainted
-            // Outer.Inner y and @Tainted
-            // Inner x.  @Tainted is stored in variableTree.getModifiers() of the variable tree
-            // corresponding to both x and y, but @Tainted applies to different types.
+            // variableTree.getModifiers() might apply to the enclosing type or the type itself.
+            // For example, @Tainted Outer.Inner y and @Tainted Inner x.
+            // @Tainted is stored in variableTree.getModifiers() of the variable tree corresponding
+            // to both x and y, but @Tainted applies to different types.
             AnnotatedDeclaredType annotatedDeclaredType = (AnnotatedDeclaredType) result;
             // The underlying type of result does not have all annotations, but the TypeMirror of
             // variableTree.getType() does.


### PR DESCRIPTION
Some timing:

Before this PR:
- using `var`, with init: 165s
- using `var`, assume init: 90s
- using `Object`, with init: 50s
- using `Object`, assume init: 33s

After this PR:
- using `var`, with init: 105s
- using `var`, assume init: 60s
- using `Object`, with init: 45s
- using `Object`, assume init: 30s

There is still a large difference between using `var` and using `Object`, which we should investigate more.

typetools, at https://github.com/typetools/checker-framework/commit/f58c9d93d562c923d2fea17fec978eb2b8040858 (commit before https://github.com/typetools/checker-framework/commit/dc0e62c36818cf76762a4357bbb597d559cbbb28):
- using `var`: 43s
- using `Object`: 42s

typetools, at https://github.com/typetools/checker-framework/commit/dc0e62c36818cf76762a4357bbb597d559cbbb28:
- using `var`: 90s
- using `Object`: 42s

typetools, at https://github.com/typetools/checker-framework/commit/ccec69e53393e3c6dbbbc7bc53f8ad60be6fd679 (this test case crashes on typetools HEAD):
- using `var`: 115s
- using `Object`: 43s

So, this PR gets eisop in line with typetools (which is good, given eisop splits init and nullness), but doesn't undo the performance hit from improved `var` support.

Co-authored-by: Liam Miller-Cushon <cushon@google.com>