### PR TITLE
Fix initial store ignoring viewpoint adaption

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractAnalysis.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractAnalysis.java
@@ -72,8 +72,8 @@ public abstract class CFAbstractAnalysis<
         /** A field access that corresponds to the declaration of a field. */
         public final FieldAccess fieldDecl;
 
-        /** The value corresponding to the annotations on the declared type of the field. */
-        public final V declared;
+        /** The declared type of the field. */
+        public final AnnotatedTypeMirror declared;
 
         /** The value of the initializer of the field, or null if no initializer exists. */
         public final @Nullable V initializer;
@@ -82,12 +82,12 @@ public abstract class CFAbstractAnalysis<
          * Creates a new FieldInitialValue.
          *
          * @param fieldDecl a field access that corresponds to the declaration of a field
-         * @param declared value corresponding to the annotations on the declared type of {@code
-         *     field}
+         * @param declared declared type of {@code field}
          * @param initializer value of the initializer of {@code field}, or null if no initializer
          *     exists
          */
-        public FieldInitialValue(FieldAccess fieldDecl, V declared, @Nullable V initializer) {
+        public FieldInitialValue(
+                FieldAccess fieldDecl, AnnotatedTypeMirror declared, @Nullable V initializer) {
             this.fieldDecl = fieldDecl;
             this.declared = declared;
             this.initializer = initializer;

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -436,17 +436,20 @@ public abstract class CFAbstractTransfer<
                 // If it's a non-constructor object method,
                 // use the adapted type if the receiver of the method is
                 // fully initialized.
-                analysis.getTypeFactory().getAnnotatedType(fieldInitialValue.fieldDecl.getField());
-                AnnotatedTypeMirror receiverType =
-                        analysis.getTypeFactory().getSelfType(methodTree.getBody());
-                AnnotatedTypeMirror adaptedType =
-                        AnnotatedTypes.asMemberOf(
-                                analysis.getTypes(),
-                                analysis.getTypeFactory(),
-                                receiverType,
-                                fieldInitialValue.fieldDecl.getField());
-                store.insertValue(
-                        fieldInitialValue.fieldDecl, analysis.createAbstractValue(adaptedType));
+                if (!isNotFullyInitializedReceiver(methodTree)) {
+                    analysis.getTypeFactory()
+                            .getAnnotatedType(fieldInitialValue.fieldDecl.getField());
+                    AnnotatedTypeMirror receiverType =
+                            analysis.getTypeFactory().getSelfType(methodTree.getBody());
+                    AnnotatedTypeMirror adaptedType =
+                            AnnotatedTypes.asMemberOf(
+                                    analysis.getTypes(),
+                                    analysis.getTypeFactory(),
+                                    receiverType,
+                                    fieldInitialValue.fieldDecl.getField());
+                    store.insertValue(
+                            fieldInitialValue.fieldDecl, analysis.createAbstractValue(adaptedType));
+                }
             } else {
                 // If it's a static method, use the declared type.
                 store.insertValue(fieldInitialValue.fieldDecl, fieldInitialValue.declared);

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1459,7 +1459,6 @@ public abstract class GenericAnnotatedTypeFactory<
                             VariableTree vt = (VariableTree) m;
                             ExpressionTree initializer = vt.getInitializer();
                             AnnotatedTypeMirror declaredType = getAnnotatedTypeLhs(vt);
-                            Value declaredValue = analysis.createAbstractValue(declaredType);
                             FieldAccess fieldExpr =
                                     (FieldAccess) JavaExpression.fromVariableTree(vt);
                             // analyze initializer if present
@@ -1480,12 +1479,11 @@ public abstract class GenericAnnotatedTypeFactory<
                                 if (initializerValue != null) {
                                     fieldValues.add(
                                             new FieldInitialValue<>(
-                                                    fieldExpr, declaredValue, initializerValue));
+                                                    fieldExpr, declaredType, initializerValue));
                                     break;
                                 }
                             }
-                            fieldValues.add(
-                                    new FieldInitialValue<>(fieldExpr, declaredValue, null));
+                            fieldValues.add(new FieldInitialValue<>(fieldExpr, declaredType, null));
                             break;
                         case BLOCK:
                             BlockTree b = (BlockTree) m;

--- a/framework/src/test/java/viewpointtest/ViewpointTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/viewpointtest/ViewpointTestAnnotatedTypeFactory.java
@@ -7,12 +7,7 @@ import org.checkerframework.framework.type.AbstractViewpointAdapter;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
-import viewpointtest.quals.A;
-import viewpointtest.quals.B;
-import viewpointtest.quals.Bottom;
-import viewpointtest.quals.PolyVP;
-import viewpointtest.quals.ReceiverDependentQual;
-import viewpointtest.quals.Top;
+import viewpointtest.quals.*;
 
 public class ViewpointTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
@@ -26,6 +21,7 @@ public class ViewpointTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
         return getBundledTypeQualifiers(
                 A.class,
                 B.class,
+                C.class,
                 Bottom.class,
                 PolyVP.class,
                 ReceiverDependentQual.class,

--- a/framework/src/test/java/viewpointtest/ViewpointTestViewpointAdapter.java
+++ b/framework/src/test/java/viewpointtest/ViewpointTestViewpointAdapter.java
@@ -8,12 +8,14 @@ import org.checkerframework.javacutil.AnnotationUtils;
 
 import javax.lang.model.element.AnnotationMirror;
 
+import viewpointtest.quals.A;
+import viewpointtest.quals.C;
 import viewpointtest.quals.ReceiverDependentQual;
 import viewpointtest.quals.Top;
 
 public class ViewpointTestViewpointAdapter extends AbstractViewpointAdapter {
 
-    private final AnnotationMirror TOP, RECEIVERDEPENDENTQUAL;
+    private final AnnotationMirror TOP, RECEIVERDEPENDENTQUAL, A, C;
 
     /**
      * The class constructor.
@@ -26,6 +28,8 @@ public class ViewpointTestViewpointAdapter extends AbstractViewpointAdapter {
         RECEIVERDEPENDENTQUAL =
                 AnnotationBuilder.fromClass(
                         atypeFactory.getElementUtils(), ReceiverDependentQual.class);
+        A = AnnotationBuilder.fromClass(atypeFactory.getElementUtils(), A.class);
+        C = AnnotationBuilder.fromClass(atypeFactory.getElementUtils(), C.class);
     }
 
     @Override
@@ -39,7 +43,14 @@ public class ViewpointTestViewpointAdapter extends AbstractViewpointAdapter {
 
         if (AnnotationUtils.areSame(declaredAnnotation, RECEIVERDEPENDENTQUAL)) {
             return receiverAnnotation;
+        } else if (AnnotationUtils.areSame(declaredAnnotation, C)) {
+            if (AnnotationUtils.areSame(receiverAnnotation, TOP)) {
+                return TOP;
+            } else {
+                return C;
+            }
+        } else {
+            return declaredAnnotation;
         }
-        return declaredAnnotation;
     }
 }

--- a/framework/src/test/java/viewpointtest/quals/C.java
+++ b/framework/src/test/java/viewpointtest/quals/C.java
@@ -1,8 +1,6 @@
 package viewpointtest.quals;
 
-import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
-import org.checkerframework.framework.qual.TypeUseLocation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -10,9 +8,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Unlike {@link A} and {@link B}, this qualifier is adapted to {@link Top} whenever it appears on a
+ * field of a {@link Top} receiver. In all other cases, it stays {@code C}.
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@SubtypeOf({A.class, B.class, C.class, ReceiverDependentQual.class})
-@DefaultFor(TypeUseLocation.LOWER_BOUND)
-public @interface Bottom {}
+@SubtypeOf({Top.class})
+public @interface C {}

--- a/framework/tests/viewpointtest/ReceiverAdaption.java
+++ b/framework/tests/viewpointtest/ReceiverAdaption.java
@@ -1,0 +1,40 @@
+import viewpointtest.quals.*;
+
+public class ReceiverAdaption {
+
+    @ReceiverDependentQual Object dependent;
+
+    @C Object c;
+
+    void testA(@A ReceiverAdaption this) {
+        @A Object varA = dependent;
+        // :: error: (assignment.type.incompatible)
+        @B Object varB = dependent;
+        @C Object varC = c;
+        // :: error: (assignment.type.incompatible)
+        @A Object varAc = c;
+        // :: error: (assignment.type.incompatible)
+        @B Object varBc = c;
+    }
+
+    void testB(@B ReceiverAdaption this) {
+        // :: error: (assignment.type.incompatible)
+        @A Object varA = dependent;
+        @B Object varB = dependent;
+        @C Object varC = c;
+        // :: error: (assignment.type.incompatible)
+        @A Object varAc = c;
+        // :: error: (assignment.type.incompatible)
+        @B Object varBc = c;
+    }
+
+    void testTop(@Top ReceiverAdaption this) {
+        // :: error: (assignment.type.incompatible)
+        @A Object varA = dependent;
+        // :: error: (assignment.type.incompatible)
+        @B Object varB = dependent;
+        // :: error: (assignment.type.incompatible)
+        @C Object varC = c;
+        @Top Object varT = c;
+    }
+}


### PR DESCRIPTION
This branch fixes a bug where the initial store contains a field's unadapted type in some cases.

The bug only surfaces when the field's declared type is adapted to a more general type.

For example, consider a partial hierarchy `@Top <: @A` , `@Top <: @C` where for a field of declared type `@C Object c`, the access `this.c` has type `@Top` if `this` is `@Top`, and type `@C` otherwise, as in the following listing.

```
public class ReceiverAdaption {

    @C Object c;

    void testTop(@Top ReceiverAdaption this) {
        // this.c has the adapted type @Top ◀ @C = @Top, so this should throw an error
        // but the initial store contains the unadapted type @C for c
        @C Object varC = this.c;
    }
}
```