### PR TITLE
Increase timeouts for `Issue1438b` and `Issue1438c`

### DIFF
--- a/checker/jtreg/nullness/Issue1438b.java
+++ b/checker/jtreg/nullness/Issue1438b.java
@@ -2,7 +2,7 @@
  * @test
  * @summary Test case for issue #1438: https://github.com/typetools/checker-framework/issues/1438
  *
- * @compile/fail/timeout=105 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438b.java
+ * @compile/fail/timeout=110 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438b.java
  */
 
 import java.util.HashMap;

--- a/checker/jtreg/nullness/Issue1438b.java
+++ b/checker/jtreg/nullness/Issue1438b.java
@@ -2,7 +2,7 @@
  * @test
  * @summary Test case for issue #1438: https://github.com/typetools/checker-framework/issues/1438
  *
- * @compile/fail/timeout=100 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438b.java
+ * @compile/fail/timeout=105 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438b.java
  */
 
 import java.util.HashMap;

--- a/checker/jtreg/nullness/Issue1438b.java
+++ b/checker/jtreg/nullness/Issue1438b.java
@@ -2,7 +2,7 @@
  * @test
  * @summary Test case for issue #1438: https://github.com/typetools/checker-framework/issues/1438
  *
- * @compile/fail/timeout=90 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438b.java
+ * @compile/fail/timeout=100 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438b.java
  */
 
 import java.util.HashMap;

--- a/checker/jtreg/nullness/Issue1438c.java
+++ b/checker/jtreg/nullness/Issue1438c.java
@@ -2,7 +2,7 @@
  * @test
  * @summary Test case for issue #1438: https://github.com/typetools/checker-framework/issues/1438
  *
- * @compile/fail/timeout=40 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438c.java
+ * @compile/fail/timeout=50 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -Alint Issue1438c.java
  */
 
 import java.util.HashMap;


### PR DESCRIPTION
For CI stability, mostly on older JDKs.