### PR TITLE
Do not add annotations that are already on the copied type

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -66,12 +66,9 @@ public class TypeVariableSubstitutor {
     protected AnnotatedTypeMirror substituteTypeVariable(
             AnnotatedTypeMirror argument, AnnotatedTypeVariable use) {
         AnnotatedTypeMirror substitute = argument.deepCopy(true);
-        substitute.addAnnotations(argument.getAnnotationsField());
-
         if (!use.getAnnotationsField().isEmpty()) {
             substitute.replaceAnnotations(use.getAnnotations());
         }
-
         return substitute;
     }
 


### PR DESCRIPTION
It is confusing that the annotations from the copied type are added to the copy again. This just redundantly added the annotations to the set again, being a no-op.