### PR TITLE
Deprecate `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -190,7 +190,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
 
     /** Handles cases 1, 2, and 3. */
     @Override
-    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
+    protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         super.addComputedTypeAnnotations(tree, type);
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -190,8 +190,8 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
 
     /** Handles cases 1, 2, and 3. */
     @Override
-    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
-        super.addComputedTypeAnnotations(tree, type, iUseFlow);
+    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
+        super.addComputedTypeAnnotations(tree, type);
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,
         // "int i = 1; --i;" fails.)
@@ -203,7 +203,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
                 // checker's type factory is parsing.
                 && !ajavaTypes.isParsing()
                 && TreeUtils.isExpressionTree(tree)
-                && (iUseFlow || tree instanceof LiteralTree)) {
+                && (this.useFlow || tree instanceof LiteralTree)) {
             AnnotatedTypeMirror valueType = getValueAnnotatedTypeFactory().getAnnotatedType(tree);
             addLowerBoundTypeFromValueType(valueType, type);
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -203,7 +203,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
                 // checker's type factory is parsing.
                 && !ajavaTypes.isParsing()
                 && TreeUtils.isExpressionTree(tree)
-                && (super.getUseFlow() || tree instanceof LiteralTree)) {
+                && (getUseFlow() || tree instanceof LiteralTree)) {
             AnnotatedTypeMirror valueType = getValueAnnotatedTypeFactory().getAnnotatedType(tree);
             addLowerBoundTypeFromValueType(valueType, type);
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -203,7 +203,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
                 // checker's type factory is parsing.
                 && !ajavaTypes.isParsing()
                 && TreeUtils.isExpressionTree(tree)
-                && (this.useFlow || tree instanceof LiteralTree)) {
+                && (super.getUseFlow() || tree instanceof LiteralTree)) {
             AnnotatedTypeMirror valueType = getValueAnnotatedTypeFactory().getAnnotatedType(tree);
             addLowerBoundTypeFromValueType(valueType, type);
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -260,7 +260,10 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,
         // "int i = 1; --i;" fails.)
-        if (useFlow && tree != null && !ajavaTypes.isParsing() && TreeUtils.isExpressionTree(tree)) {
+        if (useFlow
+                && tree != null
+                && !ajavaTypes.isParsing()
+                && TreeUtils.isExpressionTree(tree)) {
             AnnotatedTypeMirror valueType = getValueAnnotatedTypeFactory().getAnnotatedType(tree);
             addUpperBoundTypeFromValueType(valueType, type);
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -260,7 +260,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,
         // "int i = 1; --i;" fails.)
-        if (useFlow
+        if (this.useFlow
                 && tree != null
                 && !ajavaTypes.isParsing()
                 && TreeUtils.isExpressionTree(tree)) {

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -255,7 +255,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
     }
 
     @Override
-    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
+    protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         super.addComputedTypeAnnotations(tree, type);
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -255,15 +255,12 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
     }
 
     @Override
-    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
-        super.addComputedTypeAnnotations(tree, type, iUseFlow);
+    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
+        super.addComputedTypeAnnotations(tree, type);
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,
         // "int i = 1; --i;" fails.)
-        if (iUseFlow
-                && tree != null
-                && !ajavaTypes.isParsing()
-                && TreeUtils.isExpressionTree(tree)) {
+        if (useFlow && tree != null && !ajavaTypes.isParsing() && TreeUtils.isExpressionTree(tree)) {
             AnnotatedTypeMirror valueType = getValueAnnotatedTypeFactory().getAnnotatedType(tree);
             addUpperBoundTypeFromValueType(valueType, type);
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -260,7 +260,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,
         // "int i = 1; --i;" fails.)
-        if (this.useFlow
+        if (super.getUseFlow()
                 && tree != null
                 && !ajavaTypes.isParsing()
                 && TreeUtils.isExpressionTree(tree)) {

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -260,7 +260,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
         // If dataflow shouldn't be used to compute this type, then do not use the result from
         // the Value Checker, because dataflow is used to compute that type.  (Without this,
         // "int i = 1; --i;" fails.)
-        if (super.getUseFlow()
+        if (getUseFlow()
                 && tree != null
                 && !ajavaTypes.isParsing()
                 && TreeUtils.isExpressionTree(tree)) {

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -359,7 +359,7 @@ public class InitializationVisitor extends BaseTypeVisitor<InitializationAnnotat
         // declaration.
         boolean errorAtField = staticFields || TreeUtils.isSynthetic((MethodTree) tree);
 
-        @CompilerMessageKey String errorMsg =
+        String errorMsg =
                 (staticFields
                         ? "initialization.static.field.uninitialized"
                         : errorAtField

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -359,7 +359,7 @@ public class InitializationVisitor extends BaseTypeVisitor<InitializationAnnotat
         // declaration.
         boolean errorAtField = staticFields || TreeUtils.isSynthetic((MethodTree) tree);
 
-        String errorMsg =
+        @CompilerMessageKey String errorMsg =
                 (staticFields
                         ? "initialization.static.field.uninitialized"
                         : errorAtField

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -699,7 +699,7 @@ public class LockAnnotatedTypeFactory
     }
 
     @Override
-    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
+    protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         if (tree.getKind() == Tree.Kind.VARIABLE) {
             translateJcipAndJavaxAnnotations(
                     TreeUtils.elementFromDeclaration((VariableTree) tree), type);

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -699,13 +699,13 @@ public class LockAnnotatedTypeFactory
     }
 
     @Override
-    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type, boolean useFlow) {
+    public void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         if (tree.getKind() == Tree.Kind.VARIABLE) {
             translateJcipAndJavaxAnnotations(
                     TreeUtils.elementFromDeclaration((VariableTree) tree), type);
         }
 
-        super.addComputedTypeAnnotations(tree, type, useFlow);
+        super.addComputedTypeAnnotations(tree, type);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
@@ -138,31 +138,12 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         } else if (!isComputingAnnotatedTypeMirrorOfLhs()) {
             addSignedPositiveAnnotation(tree, type);
         }
+        super.addComputedTypeAnnotations(tree, type);
     }
 
     /**
      * Refines an integer expression to @SignedPositive if its value is within the signed positive
      * range (i.e. its MSB is zero). Does not refine the type of cast expressions. True when the
-     * AnnotatedTypeMirror currently being computed is the left hand side of an assignment or
-     * pseudo-assignment.
-     *
-     * @see #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)
-     * @see #getAnnotatedTypeLhs(Tree)
-     */
-    private boolean computingAnnotatedTypeMirrorOfLHS = false;
-
-    @Override
-    public AnnotatedTypeMirror getAnnotatedTypeLhs(Tree lhsTree) {
-        boolean oldComputingAnnotatedTypeMirrorOfLHS = computingAnnotatedTypeMirrorOfLHS;
-        computingAnnotatedTypeMirrorOfLHS = true;
-        AnnotatedTypeMirror result = super.getAnnotatedTypeLhs(lhsTree);
-        computingAnnotatedTypeMirrorOfLHS = oldComputingAnnotatedTypeMirrorOfLHS;
-        return result;
-    }
-
-    /**
-     * Refines an integer expression to @SignednessGlb if its value is within the signed positive
-     * range (i.e. its MSB is zero).
      *
      * @param tree an AST node, whose type may be refined
      * @param type the type of the tree

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
@@ -119,8 +119,7 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    protected void addComputedTypeAnnotations(
-            Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
+    protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         Tree.Kind treeKind = tree.getKind();
         if (treeKind == Tree.Kind.INT_LITERAL) {
             int literalValue = (int) ((LiteralTree) tree).getValue();
@@ -139,13 +138,31 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         } else if (!isComputingAnnotatedTypeMirrorOfLhs()) {
             addSignedPositiveAnnotation(tree, type);
         }
-
-        super.addComputedTypeAnnotations(tree, type, iUseFlow);
     }
 
     /**
      * Refines an integer expression to @SignedPositive if its value is within the signed positive
-     * range (i.e. its MSB is zero). Does not refine the type of cast expressions.
+     * range (i.e. its MSB is zero). Does not refine the type of cast expressions. True when the
+     * AnnotatedTypeMirror currently being computed is the left hand side of an assignment or
+     * pseudo-assignment.
+     *
+     * @see #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)
+     * @see #getAnnotatedTypeLhs(Tree)
+     */
+    private boolean computingAnnotatedTypeMirrorOfLHS = false;
+
+    @Override
+    public AnnotatedTypeMirror getAnnotatedTypeLhs(Tree lhsTree) {
+        boolean oldComputingAnnotatedTypeMirrorOfLHS = computingAnnotatedTypeMirrorOfLHS;
+        computingAnnotatedTypeMirrorOfLHS = true;
+        AnnotatedTypeMirror result = super.getAnnotatedTypeLhs(lhsTree);
+        computingAnnotatedTypeMirrorOfLHS = oldComputingAnnotatedTypeMirrorOfLHS;
+        return result;
+    }
+
+    /**
+     * Refines an integer expression to @SignednessGlb if its value is within the signed positive
+     * range (i.e. its MSB is zero).
      *
      * @param tree an AST node, whose type may be refined
      * @param type the type of the tree

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
@@ -143,7 +143,7 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     /**
      * Refines an integer expression to @SignedPositive if its value is within the signed positive
-     * range (i.e. its MSB is zero). Does not refine the type of cast expressions. True when the
+     * range (i.e. its MSB is zero). Does not refine the type of cast expressions.
      *
      * @param tree an AST node, whose type may be refined
      * @param type the type of the tree

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,11 +5,12 @@ Version 3.42.0-eisop4 (April ?, 2024)
 
 **Implementation details:**
 
+New method `GenericAnnotatedTypeFactory#addComputedTypeAnnotationsWithoutFlow(Tree, AnnotatedTypeMirror)` that sets
+`useFlow` to `false` before calling `addComputedTypeAnnotations`. Subclasses should override method
+`GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)` instead.
 Deprecated the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload.
-Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and
-call `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)`.
-Add `GenericAnnotatedTypeFactory#addComputedTypeAnnotationsWithoutFlow(Tree, AnnotatedTypeMirror)` for the old behavior,
-subclasses can only call this method but not override it.
+Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and call
+`GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)`.
 
 Improvements in `framework-test` to more consistently handle tests that do not use
 `-Anomsgtext`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ Version 3.42.0-eisop4 (April ?, 2024)
 
 **Implementation details:**
 
+Removed iUseFlow parameter in `GenericAnnotatedTypeFactory#addComputedTypeAnnotations`.
+
 Improvements in `framework-test` to more consistently handle tests that do not use
 `-Anomsgtext`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ Version 3.42.0-eisop4 (April ?, 2024)
 Deprecated the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload.
 Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and
 call `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)`.
+Add `GenericAnnotatedTypeFactory#addComputedTypeAnnotationsWithoutFlow(Tree, AnnotatedTypeMirror)` for the old behavior,
+subclasses can only call this method but not override it.
 
 Improvements in `framework-test` to more consistently handle tests that do not use
 `-Anomsgtext`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,6 @@ New method `GenericAnnotatedTypeFactory#addComputedTypeAnnotationsWithoutFlow(Tr
 `useFlow` to `false` before calling `addComputedTypeAnnotations`. Subclasses should override method
 `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)` instead.
 Deprecated the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload.
-Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and call
-`GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)`.
 
 Improvements in `framework-test` to more consistently handle tests that do not use
 `-Anomsgtext`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ Version 3.42.0-eisop4 (April ?, 2024)
 
 **Implementation details:**
 
-Removed the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload. Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and call `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror`.
+Removed the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload. Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and call `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)`.
 
 Improvements in `framework-test` to more consistently handle tests that do not use
 `-Anomsgtext`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ Version 3.42.0-eisop4 (April ?, 2024)
 
 **Implementation details:**
 
-Removed iUseFlow parameter in `GenericAnnotatedTypeFactory#addComputedTypeAnnotations`.
+Removed the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload. Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and call `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror`.
 
 Improvements in `framework-test` to more consistently handle tests that do not use
 `-Anomsgtext`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,9 @@ Version 3.42.0-eisop4 (April ?, 2024)
 
 **Implementation details:**
 
-Removed the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload. Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and call `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)`.
+Deprecated the `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)` overload.
+Instead, set `GenericAnnotatedTypeFactory#useFlow` appropriately and
+call `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)`.
 
 Improvements in `framework-test` to more consistently handle tests that do not use
 `-Anomsgtext`.

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -1356,8 +1356,8 @@ which is the Checker Framework's representation of an annotated type.
   Create a subclass of \refclass{framework/type}{AnnotatedTypeFactory} and
   override two \<addComputedTypeAnnotations> methods:
   \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(com.sun.source.tree.Tree,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotations(Tree,AnnotatedTypeMirror)}
-  (use \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(com.sun.source.tree.Tree,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotationsWithoutFlow(Tree,AnnotatedTypeMirror)
-  in subclasses of \refclass{framework/type}{GenericAnnotatedTypeFactory} if you want to add computed type annotations to a type without using flow information.)
+  (use \refmethodanchortext{framework/type}{GenericAnnotatedTypeFactory}{addComputedTypeAnnotationsWithoutFlow}{(com.sun.source.tree.Tree,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotationsWithoutFlow(Tree,AnnotatedTypeMirror)}
+  in subclasses of \code{GenericAnnotatedTypeFactory} if you want to add computed type annotations to a type without using flow information.)
   and
   \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(javax.lang.model.element.Element,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotations(Element,AnnotatedTypeMirror)}.
   The methods can make arbitrary changes to the annotations on a type.

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -1356,9 +1356,6 @@ which is the Checker Framework's representation of an annotated type.
   Create a subclass of \refclass{framework/type}{AnnotatedTypeFactory} and
   override two \<addComputedTypeAnnotations> methods:
   \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(com.sun.source.tree.Tree,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotations(Tree,AnnotatedTypeMirror)}
-  (or
-  \refmethodanchortext{framework/type}{GenericAnnotatedTypeFactory}{addComputedTypeAnnotations}{(com.sun.source.tree.Tree,org.checkerframework.framework.type.AnnotatedTypeMirror,boolean)}{addComputedTypeAnnotations(Tree,AnnotatedTypeMirror,boolean)}
-  if extending \code{GenericAnnotatedTypeFactory})
   and
   \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(javax.lang.model.element.Element,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotations(Element,AnnotatedTypeMirror)}.
   The methods can make arbitrary changes to the annotations on a type.

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -1356,6 +1356,8 @@ which is the Checker Framework's representation of an annotated type.
   Create a subclass of \refclass{framework/type}{AnnotatedTypeFactory} and
   override two \<addComputedTypeAnnotations> methods:
   \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(com.sun.source.tree.Tree,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotations(Tree,AnnotatedTypeMirror)}
+  (use \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(com.sun.source.tree.Tree,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotationsWithoutFlow(Tree,AnnotatedTypeMirror)
+  in subclasses of \refclass{framework/type}{GenericAnnotatedTypeFactory} if you want to add computed type annotations to a type without using flow information.)
   and
   \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{(javax.lang.model.element.Element,org.checkerframework.framework.type.AnnotatedTypeMirror)}{addComputedTypeAnnotations(Element,AnnotatedTypeMirror)}.
   The methods can make arbitrary changes to the annotations on a type.

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1901,10 +1901,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * <p>Subclasses that override this method should also override {@link
      * #addComputedTypeAnnotations(Element, AnnotatedTypeMirror)}.
      *
-     * <p>In classes that extend {@link GenericAnnotatedTypeFactory}, override {@link
-     * GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} instead of
-     * this method.
-     *
      * @param tree an AST node
      * @param type the type obtained from {@code tree}
      */

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1902,8 +1902,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * #addComputedTypeAnnotations(Element, AnnotatedTypeMirror)}.
      *
      * <p>In classes that extend {@link GenericAnnotatedTypeFactory}, override {@link
-     * GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror, boolean)}
-     * instead of this method.
+     * GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} instead of
+     * this method.
      *
      * @param tree an AST node
      * @param type the type obtained from {@code tree}

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2733,11 +2733,13 @@ public abstract class GenericAnnotatedTypeFactory<
         TypeMirror defaultValueTM = TreeUtils.typeOf(defaultValueTree);
         AnnotatedTypeMirror defaultValueATM =
                 AnnotatedTypeMirror.createType(defaultValueTM, this, false);
-        boolean oldUseflow = useFlow;
-        useFlow = false;
-        addComputedTypeAnnotations(defaultValueTree, defaultValueATM);
-        useFlow = oldUseflow;
-
+        boolean previousUseFlow = this.useFlow;
+        try {
+            this.useFlow = false;
+            addComputedTypeAnnotations(defaultValueTree, defaultValueATM);
+        } finally {
+            this.useFlow = previousUseFlow;
+        }
         return defaultValueATM;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2005,6 +2005,24 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * @param tree an AST node
      * @param type the type obtained from tree
+     * @param iUseFlow whether to use information from dataflow analysis
+     * @deprecated use {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} instead
+     */
+    @Deprecated
+    protected void addComputedTypeAnnotations(
+            Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
+        boolean oldUseflow = useFlow;
+        useFlow = iUseFlow;
+        addComputedTypeAnnotations(tree, type);
+        useFlow = oldUseflow;
+    }
+
+    /**
+     * Like {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)}. Overriding
+     * implementations typically simply pass the boolean to calls to super.
+     *
+     * @param tree an AST node
+     * @param type the type obtained from tree
      */
     @Override
     protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1992,8 +1992,10 @@ public abstract class GenericAnnotatedTypeFactory<
     public AnnotatedTypeMirror getDefaultAnnotations(Tree tree, AnnotatedTypeMirror type) {
         AnnotatedTypeMirror copy = type.deepCopy();
         copy.removeAnnotations(type.getAnnotations());
-        this.useFlow = false;
+        boolean oldUseflow = useFlow;
+        useFlow = false;
         addComputedTypeAnnotations(tree, copy);
+        useFlow = oldUseflow;
         return copy;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -402,7 +402,7 @@ public abstract class GenericAnnotatedTypeFactory<
     /**
      * Returns the boolean value whether the analysis should be flow-sensitive or not.
      *
-     * @return useFlow field.
+     * @return boolean value of useFlow field.
      */
     protected boolean getUseFlow() {
         return useFlow;

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -403,6 +403,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * Determines whether flow-sensitive type refinement should be used or not.
      *
      * @return whether flow-sensitive type refinement should be used or not
+     * @see #useFlow
      */
     protected boolean getUseFlow() {
         return useFlow;

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -207,7 +207,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * @see #getAnnotatedTypeLhs(Tree)
      */
-    public boolean useFlow;
+    protected boolean useFlow;
 
     /** Is this type factory configured to use flow-sensitive type refinement? */
     private final boolean everUseFlow;

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -400,9 +400,9 @@ public abstract class GenericAnnotatedTypeFactory<
     }
 
     /**
-     * Returns the boolean value whether the analysis should be flow-sensitive or not.
+     * Determines whether flow-sensitive type refinement should be used or not.
      *
-     * @return boolean value of useFlow field.
+     * @return whether flow-sensitive type refinement should be used or not
      */
     protected boolean getUseFlow() {
         return useFlow;
@@ -2025,12 +2025,11 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * @param tree an AST node
      * @param type the type obtained from tree
-     * @param iUseFlow whether to use information from dataflow analysis
      */
     private void addComputedTypeAnnotationsWithoutFlow(
-            Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
+            Tree tree, AnnotatedTypeMirror type) {
         boolean oldUseflow = useFlow;
-        useFlow = iUseFlow;
+        useFlow = false;
         addComputedTypeAnnotations(tree, type);
         useFlow = oldUseflow;
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2001,7 +2001,7 @@ public abstract class GenericAnnotatedTypeFactory<
     public AnnotatedTypeMirror getDefaultAnnotations(Tree tree, AnnotatedTypeMirror type) {
         AnnotatedTypeMirror copy = type.deepCopy();
         copy.removeAnnotations(type.getAnnotations());
-        addComputedTypeAnnotationsWithoutFlow(tree, copy, false);
+        addComputedTypeAnnotationsWithoutFlow(tree, copy);
         return copy;
     }
 
@@ -2015,9 +2015,10 @@ public abstract class GenericAnnotatedTypeFactory<
      * @deprecated use {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} instead
      */
     @Deprecated
+    @SuppressWarnings("unused")
     protected void addComputedTypeAnnotations(
             Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
-        addComputedTypeAnnotationsWithoutFlow(tree, type, iUseFlow);
+        addComputedTypeAnnotationsWithoutFlow(tree, type);
     }
 
     /**
@@ -2026,7 +2027,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param tree an AST node
      * @param type the type obtained from tree
      */
-    private void addComputedTypeAnnotationsWithoutFlow(
+    protected final void addComputedTypeAnnotationsWithoutFlow(
             Tree tree, AnnotatedTypeMirror type) {
         boolean oldUseflow = useFlow;
         useFlow = false;
@@ -2764,7 +2765,7 @@ public abstract class GenericAnnotatedTypeFactory<
         TypeMirror defaultValueTM = TreeUtils.typeOf(defaultValueTree);
         AnnotatedTypeMirror defaultValueATM =
                 AnnotatedTypeMirror.createType(defaultValueTM, this, false);
-        addComputedTypeAnnotationsWithoutFlow(defaultValueTree, defaultValueATM, false);
+        addComputedTypeAnnotationsWithoutFlow(defaultValueTree, defaultValueATM);
         return defaultValueATM;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2017,13 +2017,6 @@ public abstract class GenericAnnotatedTypeFactory<
         useFlow = oldUseflow;
     }
 
-    /**
-     * Like {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)}. Overriding
-     * implementations typically simply pass the boolean to calls to super.
-     *
-     * @param tree an AST node
-     * @param type the type obtained from tree
-     */
     @Override
     protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         if (this.getRoot() == null && ajavaTypes.isParsing()) {

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2045,7 +2045,7 @@ public abstract class GenericAnnotatedTypeFactory<
     /**
      * {@inheritDoc}
      *
-     * <p>This method implement defaulting and inference with flow-sensitive type refinement.
+     * <p>This method adds defaults and flow-sensitive type refinements.
      *
      * @see #addComputedTypeAnnotationsWithoutFlow(Tree, AnnotatedTypeMirror)
      */

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2025,8 +2025,8 @@ public abstract class GenericAnnotatedTypeFactory<
     /**
      * A helper method to add computed type annotations to a type without using flow information.
      *
-     * This method is final; override {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)}
-     * instead.
+     * <p>This method is final; override {@link #addComputedTypeAnnotations(Tree,
+     * AnnotatedTypeMirror)} instead.
      *
      * @param tree an AST node
      * @param type the type obtained from tree

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2013,7 +2013,9 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param tree an AST node
      * @param type the type obtained from tree
      * @param iUseFlow whether to use information from dataflow analysis
-     * @deprecated use {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} instead
+     * @deprecated use {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} or {@link
+     *     #addComputedTypeAnnotationsWithoutFlow(Tree, AnnotatedTypeMirror)} if you want to add
+     *     computed type annotations without using flow information
      */
     @Deprecated // 2024-07-07
     @SuppressWarnings("unused")
@@ -2040,6 +2042,13 @@ public abstract class GenericAnnotatedTypeFactory<
         useFlow = oldUseflow;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This method implement defaulting and inference with flow-sensitive type refinement.
+     *
+     * @see #addComputedTypeAnnotationsWithoutFlow(Tree, AnnotatedTypeMirror)
+     */
     @Override
     protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         if (this.getRoot() == null && ajavaTypes.isParsing()) {

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1992,6 +1992,7 @@ public abstract class GenericAnnotatedTypeFactory<
     public AnnotatedTypeMirror getDefaultAnnotations(Tree tree, AnnotatedTypeMirror type) {
         AnnotatedTypeMirror copy = type.deepCopy();
         copy.removeAnnotations(type.getAnnotations());
+        this.useFlow = false;
         addComputedTypeAnnotations(tree, copy);
         return copy;
     }
@@ -2733,13 +2734,10 @@ public abstract class GenericAnnotatedTypeFactory<
         TypeMirror defaultValueTM = TreeUtils.typeOf(defaultValueTree);
         AnnotatedTypeMirror defaultValueATM =
                 AnnotatedTypeMirror.createType(defaultValueTM, this, false);
-        boolean previousUseFlow = this.useFlow;
-        try {
-            this.useFlow = false;
-            addComputedTypeAnnotations(defaultValueTree, defaultValueATM);
-        } finally {
-            this.useFlow = previousUseFlow;
-        }
+        boolean oldUseflow = useFlow;
+        useFlow = false;
+        addComputedTypeAnnotations(defaultValueTree, defaultValueATM);
+        useFlow = oldUseflow;
         return defaultValueATM;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2015,7 +2015,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param iUseFlow whether to use information from dataflow analysis
      * @deprecated use {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} instead
      */
-    @Deprecated
+    @Deprecated // 2024-07-07
     @SuppressWarnings("unused")
     protected void addComputedTypeAnnotations(
             Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
@@ -2025,8 +2025,12 @@ public abstract class GenericAnnotatedTypeFactory<
     /**
      * A helper method to add computed type annotations to a type without using flow information.
      *
+     * This method is final; override {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)}
+     * instead.
+     *
      * @param tree an AST node
      * @param type the type obtained from tree
+     * @see #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)
      */
     protected final void addComputedTypeAnnotationsWithoutFlow(
             Tree tree, AnnotatedTypeMirror type) {

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -207,7 +207,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * @see #getAnnotatedTypeLhs(Tree)
      */
-    protected boolean useFlow;
+    private boolean useFlow;
 
     /** Is this type factory configured to use flow-sensitive type refinement? */
     private final boolean everUseFlow;
@@ -397,6 +397,15 @@ public abstract class GenericAnnotatedTypeFactory<
 
         // Every subclass must call postInit, but it must be called after
         // all other initialization is finished.
+    }
+
+    /**
+     * Returns the boolean value whether the analysis should be flow-sensitive or not.
+     *
+     * @return useFlow field.
+     */
+    protected boolean getUseFlow() {
+        return useFlow;
     }
 
     @Override
@@ -1992,10 +2001,7 @@ public abstract class GenericAnnotatedTypeFactory<
     public AnnotatedTypeMirror getDefaultAnnotations(Tree tree, AnnotatedTypeMirror type) {
         AnnotatedTypeMirror copy = type.deepCopy();
         copy.removeAnnotations(type.getAnnotations());
-        boolean oldUseflow = useFlow;
-        useFlow = false;
-        addComputedTypeAnnotations(tree, copy);
-        useFlow = oldUseflow;
+        addComputedTypeAnnotationsWithoutFlow(tree, copy, false);
         return copy;
     }
 
@@ -2010,6 +2016,18 @@ public abstract class GenericAnnotatedTypeFactory<
      */
     @Deprecated
     protected void addComputedTypeAnnotations(
+            Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
+        addComputedTypeAnnotationsWithoutFlow(tree, type, iUseFlow);
+    }
+
+    /**
+     * A helper method to add computed type annotations to a type without using flow information.
+     *
+     * @param tree an AST node
+     * @param type the type obtained from tree
+     * @param iUseFlow whether to use information from dataflow analysis
+     */
+    private void addComputedTypeAnnotationsWithoutFlow(
             Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
         boolean oldUseflow = useFlow;
         useFlow = iUseFlow;
@@ -2747,10 +2765,7 @@ public abstract class GenericAnnotatedTypeFactory<
         TypeMirror defaultValueTM = TreeUtils.typeOf(defaultValueTree);
         AnnotatedTypeMirror defaultValueATM =
                 AnnotatedTypeMirror.createType(defaultValueTM, this, false);
-        boolean oldUseflow = useFlow;
-        useFlow = false;
-        addComputedTypeAnnotations(defaultValueTree, defaultValueATM);
-        useFlow = oldUseflow;
+        addComputedTypeAnnotationsWithoutFlow(defaultValueTree, defaultValueATM, false);
         return defaultValueATM;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -207,7 +207,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * @see #getAnnotatedTypeLhs(Tree)
      */
-    private boolean useFlow;
+    public boolean useFlow;
 
     /** Is this type factory configured to use flow-sensitive type refinement? */
     private final boolean everUseFlow;
@@ -1982,17 +1982,6 @@ public abstract class GenericAnnotatedTypeFactory<
     }
 
     /**
-     * This method is final; override {@link #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror,
-     * boolean)} instead.
-     *
-     * <p>{@inheritDoc}
-     */
-    @Override
-    protected final void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
-        addComputedTypeAnnotations(tree, type, this.useFlow);
-    }
-
-    /**
      * Removes all primary annotations on a copy of the type and calculates the default annotations
      * that apply to the copied type, without type refinements.
      *
@@ -2003,7 +1992,7 @@ public abstract class GenericAnnotatedTypeFactory<
     public AnnotatedTypeMirror getDefaultAnnotations(Tree tree, AnnotatedTypeMirror type) {
         AnnotatedTypeMirror copy = type.deepCopy();
         copy.removeAnnotations(type.getAnnotations());
-        addComputedTypeAnnotations(tree, copy, false);
+        addComputedTypeAnnotations(tree, copy);
         return copy;
     }
 
@@ -2013,10 +2002,9 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * @param tree an AST node
      * @param type the type obtained from tree
-     * @param iUseFlow whether to use information from dataflow analysis
      */
-    protected void addComputedTypeAnnotations(
-            Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
+    @Override
+    protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
         if (this.getRoot() == null && ajavaTypes.isParsing()) {
             return;
         }
@@ -2038,7 +2026,7 @@ public abstract class GenericAnnotatedTypeFactory<
         }
         log(
                 "%s GATF.addComputedTypeAnnotations#1(%s, %s, %s)%n",
-                thisClass, treeString, type, iUseFlow);
+                thisClass, treeString, type, this.useFlow);
         if (!TreeUtils.isExpressionTree(tree)) {
             // Don't apply defaults to expressions. Their types may be computed from subexpressions
             // in treeAnnotator.
@@ -2063,7 +2051,7 @@ public abstract class GenericAnnotatedTypeFactory<
         defaults.annotate(tree, type);
         log("%s GATF.addComputedTypeAnnotations#7(%s, %s)%n", thisClass, treeString, type);
 
-        if (iUseFlow) {
+        if (this.useFlow) {
             Value inferred = getInferredValueFor(tree);
             if (inferred != null) {
                 applyInferredAnnotations(type, inferred);
@@ -2074,7 +2062,7 @@ public abstract class GenericAnnotatedTypeFactory<
         }
         log(
                 "%s GATF.addComputedTypeAnnotations#9(%s, %s, %s) done%n",
-                thisClass, treeString, type, iUseFlow);
+                thisClass, treeString, type, this.useFlow);
     }
 
     /**
@@ -2745,7 +2733,11 @@ public abstract class GenericAnnotatedTypeFactory<
         TypeMirror defaultValueTM = TreeUtils.typeOf(defaultValueTree);
         AnnotatedTypeMirror defaultValueATM =
                 AnnotatedTypeMirror.createType(defaultValueTM, this, false);
-        addComputedTypeAnnotations(defaultValueTree, defaultValueATM, false);
+        boolean oldUseflow = useFlow;
+        useFlow = false;
+        addComputedTypeAnnotations(defaultValueTree, defaultValueATM);
+        useFlow = oldUseflow;
+
         return defaultValueATM;
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
@@ -58,9 +58,8 @@ public class H1H2AnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    protected void addComputedTypeAnnotations(
-            Tree tree, AnnotatedTypeMirror type, boolean iUseFlow) {
-        super.addComputedTypeAnnotations(tree, type, iUseFlow);
+    protected void addComputedTypeAnnotations(Tree tree, AnnotatedTypeMirror type) {
+        super.addComputedTypeAnnotations(tree, type);
         if (tree.getKind() == Tree.Kind.VARIABLE
                 && ((VariableTree) tree).getName().toString().contains("addH1S2")) {
             type.replaceAnnotation(H1S2);


### PR DESCRIPTION
Cherry-pick from https://github.com/opprop/checker-framework/pull/215, we can close that PR after merge this one.