### PR TITLE
Add fwd ref into CF Manual

### DIFF
--- a/docs/manual/nullness-checker.tex
+++ b/docs/manual/nullness-checker.tex
@@ -12,7 +12,9 @@ The most important annotations supported by the Nullness Checker are
 \refqualclass{checker/nullness/qual}{Nullable}.
 \refqualclass{checker/nullness/qual}{NonNull} is rarely written, because it is
 the default.  All of the annotations are explained in
-Section~\ref{nullness-annotations}.
+Section~\ref{nullness-annotations}. Things are a bit more complicated
+(including the defaults) when one deals with a generic type, see
+Section~\ref{generics}.
 
 To run the Nullness Checker, supply the
 \code{-processor org.checkerframework.checker.nullness.NullnessChecker}


### PR DESCRIPTION
An intro of "Nullness Checker" section will reference "Generics and polymorphism" section to mention that defaults in the latter differs from defaults for a non-generic parameter, e.g. a Method argument.

That should help a new reader to catch the difference sooner. resolves: eisop/checker-framework#795