### PR TITLE
Adapt to javac signature change coming in Java 24

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,8 @@ framework-test: Added new class `DetailedTestDiagnostic` to directly represent t
 
 **Closed issues:**
 
+typetools#6704.
+
 
 Version 3.42.0-eisop3 (March 1, 2024)
 -------------------------------------


### PR DESCRIPTION
Fixes typetools 6704.

I tried building with OpenJDK 24-ea+6 locally.
Gradle 8.9 doesn't support Java 24 yet. After first compiling with Java 21 and then with 24-ea+6, I get this error:

````
> Task :javacutil:compileJava FAILED
An exception has occurred in the compiler (24-ea). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for org.plumelib.util.WeakIdentityHashMap not found

FAILURE: Build failed with an exception.
````

There is no use of `WeakIdentityHashMap` in `javacutil`, so that error is odd.

Merging this won't hurt and I'll look at Java 24 again with the next EA version.