### PR TITLE
Make `SourceChecker#suppressWarningsString` protected to allow adaptation in subclasses

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ Use `-ApermitMissingJdk` instead.
 
 **Implementation details:**
 
+Make `SourceChecker#suppressWarningsString` protected to allow adaptation in subclasses.
+
 **Closed issues:**
 
 

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1519,7 +1519,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
      * @param messageKey the simple, checker-specific error message key
      * @return the most specific SuppressWarnings string for the warning/error being printed
      */
-    private String suppressWarningsString(String messageKey) {
+    protected String suppressWarningsString(String messageKey) {
         Collection<String> prefixes = this.getSuppressWarningsPrefixes();
         prefixes.remove(SUPPRESS_ALL_PREFIX);
         if (showSuppressWarningsStrings) {


### PR DESCRIPTION
Fixes #815.