### PR TITLE
Fix build for JDK 22+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -464,7 +464,7 @@ allprojects {
                 // TODO: Ignore this-escape for now, we may want to review and suppress each one later.
                 lint +=',-this-escape'
             }
-            if (useJdkCompiler >= 23) {
+            if (!isJava8 && useJdkCompiler >= 23) {
                 // TODO: Ignore dangling-doc-comments for now, we may want to fix them later.
                 lint +=',-dangling-doc-comments'
             }

--- a/build.gradle
+++ b/build.gradle
@@ -39,34 +39,6 @@ ext {
     // On a Java 8 JVM, use error-prone javac and source/target 8.
     // On a Java 9+ JVM, use the host javac, default source/target, and required module flags.
     isJava8 = JavaVersion.current() == JavaVersion.VERSION_1_8
-    isJava14 = JavaVersion.current() == JavaVersion.VERSION_14
-    isJava15 = JavaVersion.current() == JavaVersion.VERSION_15
-    isJava16 = JavaVersion.current() == JavaVersion.VERSION_16
-    isJava17 = JavaVersion.current() == JavaVersion.VERSION_17
-    isJava18 = JavaVersion.current() == JavaVersion.VERSION_18
-    isJava19 = JavaVersion.current() == JavaVersion.VERSION_19
-    isJava20 = JavaVersion.current() == JavaVersion.VERSION_20
-    isJava21 = JavaVersion.current() == JavaVersion.VERSION_21
-    isJava22 = JavaVersion.current() == JavaVersion.VERSION_22
-    isJava23 = JavaVersion.current() == JavaVersion.VERSION_23
-    isJava24 = JavaVersion.current() == JavaVersion.VERSION_24
-    isJava25 = JavaVersion.current() == JavaVersion.VERSION_25
-    isJava26 = JavaVersion.current() == JavaVersion.VERSION_26
-
-    isJava26plus = isJava26
-    isJava25plus = isJava25 || isJava26plus
-    isJava24plus = isJava24 || isJava25plus
-    isJava23plus = isJava23 || isJava24plus
-    isJava22plus = isJava22 || isJava23plus
-    isJava21plus = isJava21 || isJava22plus
-    isJava20plus = isJava20 || isJava21plus
-    isJava19plus = isJava19 || isJava20plus
-    isJava18plus = isJava18 || isJava19plus
-    isJava17plus = isJava17 || isJava18plus
-    isJava16plus = isJava16 || isJava17plus
-    isJava15plus = isJava15 || isJava16plus
-    isJava14plus = isJava14 || isJava15plus
-    isJava11plus = JavaVersion.current() >= JavaVersion.VERSION_11
 
     // As of 2023-09-23, delombok doesn't yet support JDK 22; see https://projectlombok.org/changelog .
     skipDelombok = JavaVersion.current() > JavaVersion.VERSION_21
@@ -471,7 +443,7 @@ allprojects {
                 // TODO: Ignore this-escape for now, we may want to review and suppress each one later.
                 lint +=',-this-escape'
             }
-            if (isJava23plus && !jdk17Compiler) {
+            if (useJdkCompiler >= 23) {
                 // TODO: Ignore dangling-doc-comments for now, we may want to fix them later.
                 lint +=',-dangling-doc-comments'
             }

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,18 @@ ext {
     isJava19 = JavaVersion.current() == JavaVersion.VERSION_19
     isJava20 = JavaVersion.current() == JavaVersion.VERSION_20
     isJava21 = JavaVersion.current() == JavaVersion.VERSION_21
+    isJava22 = JavaVersion.current() == JavaVersion.VERSION_22
+    isJava23 = JavaVersion.current() == JavaVersion.VERSION_23
+    isJava24 = JavaVersion.current() == JavaVersion.VERSION_24
+    isJava25 = JavaVersion.current() == JavaVersion.VERSION_25
+    isJava26 = JavaVersion.current() == JavaVersion.VERSION_26
 
-    isJava21plus = isJava21
+    isJava26plus = isJava26
+    isJava25plus = isJava25 || isJava26plus
+    isJava24plus = isJava24 || isJava25plus
+    isJava23plus = isJava23 || isJava24plus
+    isJava22plus = isJava22 || isJava23plus
+    isJava21plus = isJava21 || isJava22plus
     isJava20plus = isJava20 || isJava21plus
     isJava19plus = isJava19 || isJava20plus
     isJava18plus = isJava18 || isJava19plus
@@ -460,6 +470,10 @@ allprojects {
             if (isJava21plus && !jdk17Compiler) {
                 // TODO: Ignore this-escape for now, we may want to review and suppress each one later.
                 lint +=',-this-escape'
+            }
+            if (isJava23plus && !jdk17Compiler) {
+                // TODO: Ignore dangling-doc-comments for now, we may want to fix them later.
+                lint +=',-dangling-doc-comments'
             }
             options.compilerArgs += [
                 '-g',

--- a/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
@@ -510,7 +510,7 @@ public class OptionalVisitor
      * {@code x = Optional.of(Optional.of("baz"));}. However, the type of the right-hand side is
      * {@code Optional<? extends Object>}, not {@code Optional<Optional<String>>}. Therefore, to
      * fully check for improper types, it is necessary to examine, in the type checker, the argument
-     * to construction of an Optional. Method {@link handleNestedOptionalCreation} does so.
+     * to construction of an Optional. Method {@link #handleNestedOptionalCreation} does so.
      */
     private final class OptionalTypeValidator extends BaseTypeValidator {
 

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -9,6 +9,11 @@ dependencies {
 
     // Node implements org.plumelib.util.UniqueId, so this dependency must be "api".
     api "org.plumelib:plume-util:${versions.plumeUtil}"
+    // plume-util has an `implementation` dependency on hashmap-util.
+    // That follows Gradle's rules, but Gradle's rules are not entirely correct:
+    // https://github.com/gradle/gradle/issues/30054
+    // To build with JDK 22+, we need to redeclare that dependency here.
+    implementation "org.plumelib:hashmap-util:${versions.hashmapUtil}"
 
     // External dependencies:
     // If you add an external dependency, you must shadow its packages both in the dataflow-shaded

--- a/javacutil/build.gradle
+++ b/javacutil/build.gradle
@@ -17,6 +17,11 @@ dependencies {
     // https://mvnrepository.com/artifact/org.plumelib/plume-util
     implementation "org.plumelib:plume-util:${versions.plumeUtil}"
     implementation "org.plumelib:reflection-util:${versions.reflectionUtil}"
+    // plume-util has an `implementation` dependency on hashmap-util.
+    // That follows Gradle's rules, but Gradle's rules are not entirely correct:
+    // https://github.com/gradle/gradle/issues/30054
+    // To build with JDK 22+, we need to redeclare that dependency here.
+    implementation "org.plumelib:hashmap-util:${versions.hashmapUtil}"
 
     // External dependencies:
     // If you add an external dependency, you must shadow its packages both in checker.jar and


### PR DESCRIPTION
The dependency changes work around the Gradle issue identified in
https://github.com/eisop/checker-framework/pull/806.

The flag changes prepare for new javac warnings.

With this PR, my build with JDK 22 worked. My build with JDK 23
initially got far enough for me to encounter the new warnings but then
started failing with the kind of weirdly nondeterministic Gradle errors
we've seen before:

```
BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 67
```
