### PR TITLE
Output JSpecify conformance test details

### DIFF
--- a/checker/bin-devel/test-jspecify-reference-checker.sh
+++ b/checker/bin-devel/test-jspecify-reference-checker.sh
@@ -23,4 +23,4 @@ rm -r ../jdk
 
 cd ../jspecify-reference-checker
 git switch main-eisop
-./gradlew build conformanceTests demoTest --console=plain --include-build "$CHECKERFRAMEWORK"
+JSPECIFY_CONFORMANCE_TEST_MODE=details ./gradlew build conformanceTests demoTest --console=plain --include-build "$CHECKERFRAMEWORK"


### PR DESCRIPTION
This will allow us to see that the test actually runs in a PR and, if we merge it, why it fails on `master`.