### PR TITLE
Fix CI config for concurrency in master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 # See: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master/')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
 
 jobs:
   # Basic sanity tests on JDK 21.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 # Configure GitHub Actions cancel in progress workflow to avoid redundant runs in pull requests.
 # See: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
-  concurrency:
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'heads/master')}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ on:
 
 # Configure GitHub Actions cancel in progress workflow to avoid redundant runs in pull requests.
 # See: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
-concurrency:
+  concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'heads/master')}}
 
 jobs:
   # Basic sanity tests on JDK 21.

--- a/.github/workflows/dependency-generate-and-upload.yml
+++ b/.github/workflows/dependency-generate-and-upload.yml
@@ -8,7 +8,7 @@ on:
 # See: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master/')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
 
 permissions:
   contents: read # 'write' permission is not available

--- a/.github/workflows/dependency-generate-and-upload.yml
+++ b/.github/workflows/dependency-generate-and-upload.yml
@@ -8,7 +8,7 @@ on:
 # See: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'heads/master')}}
 
 permissions:
   contents: read # 'write' permission is not available

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,7 +8,7 @@ on:
 # See: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master/')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,7 +8,7 @@ on:
 # See: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'heads/master')}}
 
 permissions:
   contents: read


### PR DESCRIPTION
I checked the cancelled job, the name of reference for master branch is `CI tests-refs/heads/master' exists`. So instead of using `master/`, we should use `master`