### PR TITLE
Add root folder to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 version: 2
 updates:
 - package-ecosystem: "gradle"
+  directory: "/"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "gradle"
   directory: "/docs/examples/errorprone/"
   schedule:
     interval: "daily"


### PR DESCRIPTION
https://github.com/eisop/checker-framework/blob/dff6bd53633d8cb00ecb873a2f46de12a1573982/build.gradle#L21 hasn't been updated, even though a new version has been out for over a month.
Let's try whether this change helps.