### PR TITLE
Array element nullable annotation warning

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitVisitor.java
@@ -348,7 +348,11 @@ public class NullnessNoInitVisitor extends BaseTypeVisitor<NullnessNoInitAnnotat
                     componentType.getAnnotations(),
                     type.toString());
         }
-
+        List<? extends AnnotationMirror> annotations =
+                TreeUtils.annotationsFromArrayCreation(tree, 0);
+        if (AnnotationUtils.containsSame(annotations, NULLABLE)) {
+            checker.reportWarning(tree, "new.array.nullable.ignored");
+        }
         return super.visitNewArray(tree, p);
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/nullness/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/messages.properties
@@ -22,6 +22,7 @@ nulltest.redundant=redundant test against null; "%s" is non-null
 instanceof.nullable=instanceof is only true for a non-null expression
 instanceof.nonnull.redundant=redundant @NonNull annotation on instanceof
 new.array.type.invalid=annotations %s may not be applied as component type for array "%s"
+new.array.nullable.ignored=nullable annotation on array element type ignored, must be nonnull
 new.class.type.invalid=the annotations %s do not need be applied in object creations
 nullness.on.constructor=do not write nullness annotations on a constructor, whose result is always non-null
 nullness.on.enum=do not write nullness annotations on an enum constant, which is always non-null


### PR DESCRIPTION
Addressing [Issue #90](https://github.com/eisop/checker-framework/issues/927), added a warning if the first dimension (element type) of array creation is annotated with nullable. Warning will inform user that this annotation has been ignored. Also added a new error message to support the warning.
