### PR TITLE
Consistently use `doLast`

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -283,18 +283,26 @@ checkCompilerMessages {
     }
 }
 
-task nullnessExtraTests(type: Exec, dependsOn: assembleForJavac, group: 'Verification') {
+task nullnessExtraTests(dependsOn: assembleForJavac, group: 'Verification') {
     description 'Run extra tests for the Nullness Checker.'
-    executable 'make'
-    environment JAVAC: "${projectDir}/bin/javac -AnoJreVersionCheck", JAVAP: 'javap'
-    args = ['-C', 'tests/nullness-extra/']
+    doLast{
+        exec{
+            executable 'make'
+            environment JAVAC: "${projectDir}/bin/javac -AnoJreVersionCheck", JAVAP: 'javap'
+            args = ['-C', 'tests/nullness-extra/']
+        }
+    }
 }
 
-task commandLineTests(type: Exec, dependsOn: assembleForJavac, group: 'Verification') {
+task commandLineTests(dependsOn: assembleForJavac, group: 'Verification') {
     description 'Run tests that need a special command line.'
-    executable 'make'
-    environment JAVAC: "${projectDir}/bin/javac -AnoJreVersionCheck"
-    args = ['-C', 'tests/command-line/']
+    doLast {
+        exec {
+            executable 'make'
+            environment JAVAC: "${projectDir}/bin/javac -AnoJreVersionCheck"
+            args = ['-C', 'tests/command-line/']
+        }
+    }
 }
 
 task tutorialTests(dependsOn: assembleForJavac, group: 'Verification') {
@@ -306,11 +314,15 @@ task tutorialTests(dependsOn: assembleForJavac, group: 'Verification') {
     }
 }
 
-task exampleTests(type: Exec, dependsOn: assembleForJavac, group: 'Verification') {
+task exampleTests(dependsOn: assembleForJavac, group: 'Verification') {
     description 'Run tests for the example programs.'
-    executable 'make'
-    environment JAVAC: "${projectDir}/bin/javac -AnoJreVersionCheck"
-    args = ['-C', '../docs/examples']
+    doLast{
+        exec{
+            executable 'make'
+            environment JAVAC: "${projectDir}/bin/javac -AnoJreVersionCheck"
+            args = ['-C', '../docs/examples']
+        }
+    }
 }
 
 task demosTests(dependsOn: assembleForJavac, group: 'Verification') {


### PR DESCRIPTION
This is motivate by failures in https://github.com/eisop/jdk/pull/97