### PR TITLE
Also handle the `InitializationChecker` as upstream checker

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessSubchecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessSubchecker.java
@@ -28,9 +28,10 @@ public class InitializationFieldAccessSubchecker extends BaseTypeChecker {
     /** Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. */
     @Override
     public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
-        // Ensure field is initialized.
-        super.getUpstreamCheckerNames();
-        upstreamCheckerNames.add(InitializationChecker.class.getName());
+        if (upstreamCheckerNames == null) {
+            super.getUpstreamCheckerNames();
+            upstreamCheckerNames.add(InitializationChecker.class.getName());
+        }
         return upstreamCheckerNames;
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessSubchecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessSubchecker.java
@@ -1,7 +1,10 @@
 package org.checkerframework.checker.initialization;
 
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
+import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.common.basetype.BaseTypeChecker;
+
+import java.util.List;
 
 /**
  * Part of the freedom-before-commitment type system.
@@ -21,6 +24,15 @@ public class InitializationFieldAccessSubchecker extends BaseTypeChecker {
 
     /** Default constructor for InitializationFieldAccessSubchecker. */
     public InitializationFieldAccessSubchecker() {}
+
+    /** Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. */
+    @Override
+    public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
+        // Ensure field is initialized.
+        super.getUpstreamCheckerNames();
+        upstreamCheckerNames.add(InitializationChecker.class.getName());
+        return upstreamCheckerNames;
+    }
 
     // Suppress all errors and warnings, since they are also reported by the InitializationChecker
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/AnnotatedForNullnessTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/AnnotatedForNullnessTest.java
@@ -1,0 +1,33 @@
+package org.checkerframework.checker.test.junit;
+
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.List;
+
+/** Tests the conservative defaults for Initialization Checker and Nullness Checker. */
+public class AnnotatedForNullnessTest extends CheckerFrameworkPerDirectoryTest {
+
+    /**
+     * @param testFiles the files containing test code, which will be type-checked
+     */
+    public AnnotatedForNullnessTest(List<File> testFiles) {
+        super(
+                testFiles,
+                org.checkerframework.checker.nullness.NullnessChecker.class,
+                "nullness",
+                "-AuseConservativeDefaultsForUncheckedCode=source,bytecode");
+    }
+
+    /**
+     * This method returns the directories containing test code. Each directory will be type-checked
+     * with {@code -AuseConservativeDefaultsForUncheckedCode=source,bytecode}.
+     *
+     * @return the directories containing test code
+     */
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"nulless-conservative-defaults/annotatedfornullness"};
+    }
+}

--- a/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
+++ b/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
@@ -1,0 +1,55 @@
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.KeyForBottom;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
+public class AnnotatedForNullness {
+
+    @Initialized @NonNull Object initializedField = new Object();
+    @Initialized @KeyForBottom @NonNull Object initializedKeyForBottomField = new Object();
+
+    @AnnotatedFor("initialization")
+    // No errors because AnnotatedFor("initialization") does not change the default for nullness.
+    Object annotatedForInitialization(Object test) {
+        return null;
+    }
+
+    @AnnotatedFor("nullness")
+    Object annotatedForNullness(Object test) {
+        // ::error: (return.type.incompatible)
+        return null;
+    }
+
+    // Method annotatedFor with both `nullness` and `initialization` should behave the same as
+    // annotatedForNullness.
+    @AnnotatedFor({"nullness", "initialization"})
+    Object annotatedForNullnessAndInitialization(Object test) {
+        // ::error: (return.type.incompatible)
+        return null;
+    }
+
+    Object unannotatedFor(Object test) {
+        return null;
+    }
+
+    @AnnotatedFor("nullness")
+    void foo(@Initialized AnnotatedForNullness this) {
+        // Expect an error because conservative defaults are applied to `unannotatedFor` and it
+        // expects a @FBCBottom @KeyForBottom @Nonull Object.
+        // ::error: (argument.type.incompatible)
+        unannotatedFor(initializedField);
+        // Expect an error because conservative defaults are applied to `annotatedForInitialization`
+        // for hierarchies other than the Initialization Checker and
+        // it expects an @Initialized @KeyForBottom @Nonull Object.
+        // ::error: (argument.type.incompatible)
+        annotatedForInitialization(initializedField);
+        // Do not expect an error when conservative defaults are applied to
+        // `annotatedForInitialization` for hierarchies other than the Initialization Checker and
+        // it expects an @Initialized @KeyForBottom @Nonull Object.
+        annotatedForInitialization(initializedKeyForBottomField);
+        // Do not expect an error because these are AnnotatedFor("nullness") and these expect
+        // @Initialized @UnknownKeyFor @Nonnull Object.
+        annotatedForNullness(initializedField);
+        annotatedForNullnessAndInitialization(initializedField);
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,5 @@
-Version 3.42.0-eisop5 (July ?, 2024)
-------------------------------------
+Version 3.42.0-eisop5 (November ??, 2024)
+-----------------------------------------
 
 **User-visible changes:**
 
@@ -16,7 +16,8 @@ Make `SourceChecker#suppressWarningsString` protected to allow adaptation in sub
 
 **Closed issues:**
 
-eisop#413, eisop#777, eisop#782.
+eisop#413, eisop#777, eisop#782, eisop#982.
+
 
 Version 3.42.0-eisop4 (July 12, 2024)
 -------------------------------------

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -6010,10 +6010,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         List<String> annotatedForCheckers =
                 AnnotationUtils.getElementValueArray(
                         annotatedForAnno, annotatedForValueElement, String.class);
+        List<@FullyQualifiedName String> upstreamCheckerNames = checker.getUpstreamCheckerNames();
         for (String annoForChecker : annotatedForCheckers) {
-            if (checker.getUpstreamCheckerNames().contains(annoForChecker)
+            if (upstreamCheckerNames.contains(annoForChecker)
                     || CheckerMain.matchesFullyQualifiedProcessor(
-                            annoForChecker, checker.getUpstreamCheckerNames(), true)) {
+                            annoForChecker, upstreamCheckerNames, true)) {
                 return true;
             }
         }


### PR DESCRIPTION
To the `InitializationFieldAccessSubchecker`.

Fixes #982.