### PR TITLE
Handle the `InitializationChecker` as upstream checker

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
@@ -12,6 +12,7 @@ import org.checkerframework.checker.nullness.NullnessNoInitSubchecker;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 
 import java.util.ArrayList;
@@ -86,6 +87,16 @@ public abstract class InitializationChecker extends BaseTypeChecker {
      * @return the checker for the target type system.
      */
     public abstract Class<? extends BaseTypeChecker> getTargetCheckerClass();
+
+    /** Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. */
+    @Override
+    public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
+        if (upstreamCheckerNames == null) {
+            super.getUpstreamCheckerNames();
+            upstreamCheckerNames.add(InitializationChecker.class.getName());
+        }
+        return upstreamCheckerNames;
+    }
 
     @Override
     public NavigableSet<String> getSuppressWarningsPrefixes() {

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
@@ -90,7 +90,7 @@ public abstract class InitializationChecker extends BaseTypeChecker {
 
     /**
      * Also handle {@code AnnotatedFor} annotations for this checker. See {@link
-     * InitializationFieldAccessSubchecker#getUpstreamCheckerNames()} and the two implementation
+     * InitializationFieldAccessSubchecker#getUpstreamCheckerNames()} and the two implementations
      * should be kept in sync.
      */
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
@@ -12,6 +12,7 @@ import org.checkerframework.checker.nullness.NullnessNoInitSubchecker;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 
 import java.util.ArrayList;
@@ -87,15 +88,19 @@ public abstract class InitializationChecker extends BaseTypeChecker {
      */
     public abstract Class<? extends BaseTypeChecker> getTargetCheckerClass();
 
-    //    /** Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. */
-    //    @Override
-    //    public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
-    //        if (upstreamCheckerNames == null) {
-    //            super.getUpstreamCheckerNames();
-    //            upstreamCheckerNames.add(InitializationChecker.class.getName());
-    //        }
-    //        return upstreamCheckerNames;
-    //    }
+    /**
+     * Also handle {@code AnnotatedFor} annotations for this checker. See {@link
+     * InitializationFieldAccessSubchecker#getUpstreamCheckerNames()} and the two implementation
+     * should be kept in sync.
+     */
+    @Override
+    public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
+        if (upstreamCheckerNames == null) {
+            super.getUpstreamCheckerNames();
+            upstreamCheckerNames.add(InitializationChecker.class.getName());
+        }
+        return upstreamCheckerNames;
+    }
 
     @Override
     public NavigableSet<String> getSuppressWarningsPrefixes() {

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationChecker.java
@@ -12,7 +12,6 @@ import org.checkerframework.checker.nullness.NullnessNoInitSubchecker;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 
 import java.util.ArrayList;
@@ -88,15 +87,15 @@ public abstract class InitializationChecker extends BaseTypeChecker {
      */
     public abstract Class<? extends BaseTypeChecker> getTargetCheckerClass();
 
-    /** Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. */
-    @Override
-    public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
-        if (upstreamCheckerNames == null) {
-            super.getUpstreamCheckerNames();
-            upstreamCheckerNames.add(InitializationChecker.class.getName());
-        }
-        return upstreamCheckerNames;
-    }
+    //    /** Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. */
+    //    @Override
+    //    public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
+    //        if (upstreamCheckerNames == null) {
+    //            super.getUpstreamCheckerNames();
+    //            upstreamCheckerNames.add(InitializationChecker.class.getName());
+    //        }
+    //        return upstreamCheckerNames;
+    //    }
 
     @Override
     public NavigableSet<String> getSuppressWarningsPrefixes() {

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessSubchecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessSubchecker.java
@@ -25,7 +25,11 @@ public class InitializationFieldAccessSubchecker extends BaseTypeChecker {
     /** Default constructor for InitializationFieldAccessSubchecker. */
     public InitializationFieldAccessSubchecker() {}
 
-    /** Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. */
+    /**
+     * Also handle {@code AnnotatedFor} annotations for the {@link InitializationChecker}. See
+     * {@link InitializationChecker#getUpstreamCheckerNames()} and the two implementations should be
+     * kept in sync.
+     */
     @Override
     public List<@FullyQualifiedName String> getUpstreamCheckerNames() {
         if (upstreamCheckerNames == null) {

--- a/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
+++ b/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
@@ -34,12 +34,13 @@ public class AnnotatedForNullness {
 
     @AnnotatedFor("nullness")
     void foo(@Initialized AnnotatedForNullness this) {
-        // Expect two errors because conservative defaults are applied to `unannotatedFor` and it
-        // expects a @FBCBottom @KeyForBottom @Nonull Object.
+        // Expect two [argument.type.incompatible] errors in KeyForChecker and InitilizationChecker
+        // because conservative defaults are applied to `unannotatedFor` and it expects a @FBCBottom
+        // @KeyForBottom @Nonull Object.
         // ::error: (argument.type.incompatible)
         unannotatedFor(initializedField);
-        // Expect an error because conservative defaults are applied to `annotatedForInitialization`
-        // for hierarchies other than the Initialization Checker and
+        // Expect an error in KeyForChecker because conservative defaults are applied to
+        // `annotatedForInitialization` for hierarchies other than the Initialization Checker and
         // it expects an @Initialized @KeyForBottom @Nonull Object.
         // ::error: (argument.type.incompatible)
         annotatedForInitialization(initializedField);
@@ -55,13 +56,13 @@ public class AnnotatedForNullness {
 
     @AnnotatedFor("initialization")
     void bar() {
-        // Expect an error because conservative defaults are applied to `unannotatedFor` and it
-        // expects a @FBCBottom @UnknownKeyFor @Nonull Object.
+        // Expect an error in InitilizationChecker because conservative defaults are applied to
+        // `unannotatedFor` and it expects a @FBCBottom @UnknownKeyFor @Nonull Object.
         // ::error: (argument.type.incompatible)
         unannotatedFor(initializedField);
         // Do not expect an error because the warning is suppressed other than initialzation
-        // hierarchy when conservative defaults are applied to source code and
-        // it expects an @Initialized @KeyForBottom @Nonull Object.
+        // hierarchy when conservative defaults are applied to source code and it expects an
+        // @Initialized @KeyForBottom @Nonull Object.
         annotatedForInitialization(initializedField);
         // Do not expect an error when conservative defaults are applied to
         // `annotatedForInitialization` for hierarchies other than the Initialization Checker and

--- a/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
+++ b/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
@@ -59,8 +59,8 @@ public class AnnotatedForNullness {
         // expects a @FBCBottom @UnknownKeyFor @Nonull Object.
         // ::error: (argument.type.incompatible)
         unannotatedFor(initializedField);
-        // Do not expect an error because the warning is suppressed  other than initialzation
-        // hierarchy when conservative defaults are applied to source code.
+        // Do not expect an error because the warning is suppressed other than initialzation
+        // hierarchy when conservative defaults are applied to source code and
         // it expects an @Initialized @KeyForBottom @Nonull Object.
         annotatedForInitialization(initializedField);
         // Do not expect an error when conservative defaults are applied to

--- a/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
+++ b/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
@@ -52,4 +52,12 @@ public class AnnotatedForNullness {
         annotatedForNullness(initializedField);
         annotatedForNullnessAndInitialization(initializedField);
     }
+
+    @AnnotatedFor("initialization")
+    void bar() {
+        // Expect an error because conservative defaults are applied to `unannotatedFor` and it
+        // expects a @FBCBottom @UnknownKeyFor @Nonull Object.
+        // ::error: (argument.type.incompatible)
+        unannotatedFor(initializedField);
+    }
 }

--- a/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
+++ b/checker/tests/nulless-conservative-defaults/annotatedfornullness/AnnotatedForNullness.java
@@ -34,7 +34,7 @@ public class AnnotatedForNullness {
 
     @AnnotatedFor("nullness")
     void foo(@Initialized AnnotatedForNullness this) {
-        // Expect an error because conservative defaults are applied to `unannotatedFor` and it
+        // Expect two errors because conservative defaults are applied to `unannotatedFor` and it
         // expects a @FBCBottom @KeyForBottom @Nonull Object.
         // ::error: (argument.type.incompatible)
         unannotatedFor(initializedField);
@@ -59,5 +59,17 @@ public class AnnotatedForNullness {
         // expects a @FBCBottom @UnknownKeyFor @Nonull Object.
         // ::error: (argument.type.incompatible)
         unannotatedFor(initializedField);
+        // Do not expect an error because the warning is suppressed  other than initialzation
+        // hierarchy when conservative defaults are applied to source code.
+        // it expects an @Initialized @KeyForBottom @Nonull Object.
+        annotatedForInitialization(initializedField);
+        // Do not expect an error when conservative defaults are applied to
+        // `annotatedForInitialization` for hierarchies other than the Initialization Checker and
+        // it expects an @Initialized @KeyForBottom @Nonull Object.
+        annotatedForInitialization(initializedKeyForBottomField);
+        // Do not expect an error because these are AnnotatedFor("nullness") and these expect
+        // @Initialized @UnknownKeyFor @Nonnull Object.
+        annotatedForNullness(initializedField);
+        annotatedForNullnessAndInitialization(initializedField);
     }
 }


### PR DESCRIPTION
Also handles `InitializationChecker` in abstract `InitializationChecker` class.

If don't handle it here, I found the following case will issue error.

How to reproduce:
1. remove annotatedFor("nullness") and use AnnotatedFor("intialization") in the following two places. This should make sure the initialization don't use conservative defaults. https://github.com/eisop/jdk/blob/b073fe213273118a9997ce3fccd1f36e103f5b04/src/java.base/share/classes/java/lang/package-info.java#L71 
https://github.com/eisop/jdk/blob/b073fe213273118a9997ce3fccd1f36e103f5b04/src/java.base/share/classes/java/lang/Character.java#L194

2. test case
Command: `./checker/bin/javac -processor nullness -AuseConservativeDefaultsForUncheckedCode=bytecode,-source Test.java`

```
import org.checkerframework.framework.qual.AnnotatedFor;

public class Test {
    void foo(char s) {
        Character.toLowerCase(s);
    }
}
``` 

errors issued (The first one is expected but the second one is not):
```
Test.java:5: error: [argument.type.incompatible] incompatible argument for parameter arg0 of Character.toLowerCase.
        Character.toLowerCase(s);
                              ^
  found   : @UnknownKeyFor char
  required: @KeyForBottom char
Test.java:5: error: [argument.type.incompatible] incompatible argument for parameter arg0 of Character.toLowerCase.
        Character.toLowerCase(s);
                              ^
  found   : @Initialized char
  required: @FBCBottom char
2 errors
```

Root cause:

If do not add initialization checker as one of its upstream checker names, the upstream checker names for initializationAnnotatedTypeFactory is only the nullnessChecker, which will return false because it can not find a match for initialization. https://github.com/eisop/checker-framework/blob/175f3fa0c6c3d5cac134b8e49eec78cca21bc625/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java#L6015

I can't find a good test case to add because many JDK packages have added annotatedfor("nullness") but this fixes a lot of PICO's errors.