### PR TITLE
Rename variable in Map Key Checker manual section

### DIFF
--- a/docs/manual/map-key-checker.tex
+++ b/docs/manual/map-key-checker.tex
@@ -2,8 +2,8 @@
 \chapterAndLabel{Map Key Checker}{map-key-checker}
 
 The Map Key Checker tracks which values are keys for which maps.  If variable
-\code{v} has type \code{@KeyFor("m")...}, then the value of \code{v} is a key
-in Map \code{m}.  That is, the expression \code{m.containsKey(v)} evaluates to
+\code{k} has type \code{@KeyFor("m")...}, then the value of \code{k} is a key
+in Map \code{m}.  That is, the expression \code{m.containsKey(k)} evaluates to
 \code{true}.
 
 Section~\ref{map-key-qualifiers} describes how \code{@KeyFor} annotations


### PR DESCRIPTION
Using `v` as the argument for `containsKey` seems odd. 

Brought up by Sam Huang when he tried to look at the manual for KeyFor checker. 