### PR TITLE
Directly get adapted parameter type

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2038,9 +2038,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 tree.getTypeArguments(),
                 methodName,
                 invokedMethod.getTypeVariables());
-        List<AnnotatedTypeMirror> params =
-                AnnotatedTypes.adaptParameters(
-                        atypeFactory, invokedMethod, tree.getArguments(), null);
+        List<AnnotatedTypeMirror> params = invokedMethod.getParameterTypes();
         checkArguments(params, tree.getArguments(), methodName, method.getParameters());
         checkVarargs(invokedMethod, tree);
 


### PR DESCRIPTION
The method parameters are adapted at https://github.com/eisop/checker-framework/blob/e5589987c57f0d6a60f97bcfd520bdad182a8bb4/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java#L2540.

Adapt it again will cause error and we directly get the parameter type after adaptation in this change.