### PR TITLE
Add implementation title and vendor information to Framework manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1031,6 +1031,8 @@ subprojects {
             manifest {
                 attributes('Implementation-Version': "${project.version}")
                 attributes('Implementation-URL': 'https://eisop.github.io/')
+                attributes('Implementation-Title': 'Checker Framework')
+                attributes('Implementation-Vendor': 'EISOP')
                 if (! archiveFileName.get().endsWith('source.jar') && ! archiveFileName.get().startsWith('checker-qual')) {
                     attributes('Automatic-Module-Name': 'org.checkerframework.' + project.name.replaceAll('-', '.'))
                 }


### PR DESCRIPTION
fixes #1111 by adding vendor and title information to the JAR metadata of the framework.