### PR TITLE
Fix misc dependency 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,9 @@ jobs:
     - name: Install misc dependencies
       if: ${{ matrix.script == 'misc' }}
       run: |
-        sudo apt install -y shellcheck devscripts python3-pip \
+        sudo apt-get update
+        sudo apt-get install -y --fix-missing \
+          shellcheck devscripts python3-pip \
           texlive-latex-base texlive-latex-extra latexmk librsvg2-bin \
           autoconf dia hevea latexmk libasound2-dev rsync pdf2svg \
           libcups2-dev libfontconfig1-dev libx11-dev libxext-dev \


### PR DESCRIPTION
CI currently constantly fails for https://github.com/eisop/checker-framework/pull/788 and https://github.com/eisop/checker-framework/pull/1068. 

This code change should be able to have more robust installation behavior.

People have the same problem.
https://github.com/actions/runner-images/issues/9039