### PR TITLE
Fix inference of generic exception types

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
@@ -73,7 +73,7 @@ public class CheckedExceptionsUtil {
             if (result == null) {
                 result = new ArrayList<>();
             }
-            TypeMirror type = TreeUtils.typeOf(node);
+            TypeMirror type = TreeUtils.typeOf(node.getExpression());
             if (isCheckedException(type, context)) {
                 result.add(type);
             }
@@ -162,7 +162,7 @@ public class CheckedExceptionsUtil {
      */
     private static boolean isCheckedException(TypeMirror type, Java8InferenceContext context) {
         TypeMirror runtimeEx = context.runtimeEx;
-        return context.env.getTypeUtils().isSubtype(type, runtimeEx);
+        return !context.env.getTypeUtils().isSubtype(type, runtimeEx);
     }
 
     /**
@@ -215,7 +215,7 @@ public class CheckedExceptionsUtil {
             if (result == null) {
                 result = new ArrayList<>();
             }
-            AnnotatedTypeMirror type = context.typeFactory.getAnnotatedType(node);
+            AnnotatedTypeMirror type = context.typeFactory.getAnnotatedType(node.getExpression());
             if (isCheckedException(type, context)) {
                 result.add(type);
             }
@@ -314,6 +314,6 @@ public class CheckedExceptionsUtil {
     private static boolean isCheckedException(
             AnnotatedTypeMirror type, Java8InferenceContext context) {
         TypeMirror runtimeEx = context.runtimeEx;
-        return context.env.getTypeUtils().isSubtype(type.getUnderlyingType(), runtimeEx);
+        return !context.env.getTypeUtils().isSubtype(type.getUnderlyingType(), runtimeEx);
     }
 }

--- a/framework/tests/all-systems/java8inference/ExceptionInLambdaTest.java
+++ b/framework/tests/all-systems/java8inference/ExceptionInLambdaTest.java
@@ -1,0 +1,21 @@
+public final class ExceptionInLambdaTest {
+
+    public static void exceptionInLambda() {
+        try {
+            runLambda(new Object(), obj -> {
+                throw new Exception();
+            });
+        } catch (Exception e) {
+        }
+    }
+
+    public static <T, E extends Throwable> void runLambda(
+            T t, ConsumerWithException<T, E> lambda) throws E {
+        lambda.run(t);
+    }
+
+    public static interface ConsumerWithException<T, E extends Throwable> {
+
+        void run(T element) throws E;
+    }
+}

--- a/framework/tests/all-systems/java8inference/ExceptionInLambdaTest.java
+++ b/framework/tests/all-systems/java8inference/ExceptionInLambdaTest.java
@@ -2,15 +2,17 @@ public final class ExceptionInLambdaTest {
 
     public static void exceptionInLambda() {
         try {
-            runLambda(new Object(), obj -> {
-                throw new Exception();
-            });
+            runLambda(
+                    new Object(),
+                    obj -> {
+                        throw new Exception();
+                    });
         } catch (Exception e) {
         }
     }
 
-    public static <T, E extends Throwable> void runLambda(
-            T t, ConsumerWithException<T, E> lambda) throws E {
+    public static <T, E extends Throwable> void runLambda(T t, ConsumerWithException<T, E> lambda)
+            throws E {
         lambda.run(t);
     }
 


### PR DESCRIPTION
Fixes #1174 , which was caused by a few typos in type inference of generic exception types.

Specifically, the framework, upon encountering a statement `throw e;` attempted to get the type of the entire statement instead of the type of `e`, causing an NPE. Also, run-time exceptions were inferred as non-run-time exceptions and vice versa.