### PR TITLE
Work around EISOP Issue #1193

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
@@ -36,7 +36,10 @@ public class SubtypeIsSubsetQualifierHierarchy extends MostlyNoElementQualifierH
      * @param processingEnv processing environment
      * @param atypeFactory the associated type factory
      */
-    @SuppressWarnings("nullness:argument.type.incompatible") // TODO: EISOP Issue #1193
+    @SuppressWarnings({
+        "keyfor:argument.type.incompatible",
+        "nullness:argument.type.incompatible"
+    }) // TODO: EISOP Issue #1193
     public SubtypeIsSubsetQualifierHierarchy(
             Collection<Class<? extends Annotation>> qualifierClasses,
             ProcessingEnvironment processingEnv,

--- a/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
@@ -36,7 +36,7 @@ public class SubtypeIsSubsetQualifierHierarchy extends MostlyNoElementQualifierH
      * @param processingEnv processing environment
      * @param atypeFactory the associated type factory
      */
-    @SuppressWarnings("all:argument.type.incompatible") // TODO: EISOP Issue #1193
+    @SuppressWarnings("nullness:argument.type.incompatible") // TODO: EISOP Issue #1193
     public SubtypeIsSubsetQualifierHierarchy(
             Collection<Class<? extends Annotation>> qualifierClasses,
             ProcessingEnvironment processingEnv,

--- a/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
@@ -36,7 +36,7 @@ public class SubtypeIsSubsetQualifierHierarchy extends MostlyNoElementQualifierH
      * @param processingEnv processing environment
      * @param atypeFactory the associated type factory
      */
-    @SuppressWarnings("argument.type.incompatible") // TODO: EISOP Issue #1193
+    @SuppressWarnings("all:argument.type.incompatible") // TODO: EISOP Issue #1193
     public SubtypeIsSubsetQualifierHierarchy(
             Collection<Class<? extends Annotation>> qualifierClasses,
             ProcessingEnvironment processingEnv,

--- a/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java
@@ -36,6 +36,7 @@ public class SubtypeIsSubsetQualifierHierarchy extends MostlyNoElementQualifierH
      * @param processingEnv processing environment
      * @param atypeFactory the associated type factory
      */
+    @SuppressWarnings("argument.type.incompatible") // TODO: EISOP Issue #1193
     public SubtypeIsSubsetQualifierHierarchy(
             Collection<Class<? extends Annotation>> qualifierClasses,
             ProcessingEnvironment processingEnv,


### PR DESCRIPTION
I tried suppressing "argument.type.incompatible", "all:argument.type.incompatible", and "nullness:argument.type.incompatible", none of which suppressed all three warnings.
This is odd behavior, not how suppression should work.

When I try locally, I get:

````
./gradlew :framework:checkNullness

> Task :framework:checkNullness
checker-framework/framework/src/main/java/org/checkerframework/framework/type/SubtypeIsSubsetQualifierHierarchy.java:39: warning: [nullness:unneeded.suppression] warning suppression "nullness:argument.type.incompatible" is not used by NullnessChecker
    @SuppressWarnings("nullness:argument.type.incompatible") // TODO: EISOP Issue #1193
    ^
error: warnings found and -Werror specified
1 error
1 warning
````
