### PR TITLE
See whether an older plume-util works better in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ ext {
         junit           : '4.13.2',
         lombok          : '1.18.38',
         // plume-util includes a version of reflection-util. When updating ensure the versions are consistent.
-        plumeUtil       : '1.10.1',
+        plumeUtil       : '1.9.3',
         reflectionUtil  : '1.1.5',
     ]
 }


### PR DESCRIPTION
Out of all the recent commits, the update of plume-util seemed like the most likely source of #1193.
Alternative to #1195.