### PR TITLE
Skip jtreg tests that require old Class-File API on JDK >= 25

### DIFF
--- a/checker/bin-devel/git.pre-commit
+++ b/checker/bin-devel/git.pre-commit
@@ -9,7 +9,7 @@ set -e
 
 # Check formatting.  This is slow (3+ seconds).
 # Could instead do "spotlessApply", but then the changes don't appear in this commit.
-JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
+JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//' | sed 's/-beta//')
 [ "$JAVA_VER" = "8" ] || ./gradlew spotlessCheck -q
 
 CHANGED_JAVA_FILES=$(git diff --staged --name-only --diff-filter=ACM | grep '\.java$' | grep -v '/jdk/' | grep -v 'stubparser/' | grep -v '/nullness-javac-errors/' | grep -v 'dataflow/manual/examples/' | grep -v '/java17/' | grep -v 'records/') || true

--- a/checker/bin-devel/test-misc.sh
+++ b/checker/bin-devel/test-misc.sh
@@ -22,7 +22,7 @@ PLUME_SCRIPTS="$SCRIPTDIR/.plume-scripts"
 status=0
 
 ## Code style and formatting
-JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
+JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//' | sed 's/-beta//')
 if [ "${JAVA_VER}" != "8" ] ; then
   ./gradlew spotlessCheck --console=plain --warning-mode=all
 fi

--- a/checker/jtreg/nullness/defaultsPersist/Classes.java
+++ b/checker/jtreg/nullness/defaultsPersist/Classes.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test that defaulted types are stored in bytecode.
  *
+ * @requires jdk.version.major <= 24
  * @compile  ../PersistUtil.java Driver.java ReferenceInfoUtil.java Classes.java
  * @run main Driver Classes
  */

--- a/checker/jtreg/nullness/defaultsPersist/Constructors.java
+++ b/checker/jtreg/nullness/defaultsPersist/Constructors.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test that defaulted types are stored in bytecode.
  *
+ * @requires jdk.version.major <= 24
  * @compile ../PersistUtil.java Driver.java ReferenceInfoUtil.java Constructors.java
  * @run main Driver Constructors
  */

--- a/checker/jtreg/nullness/defaultsPersist/Fields.java
+++ b/checker/jtreg/nullness/defaultsPersist/Fields.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test that defaulted types are stored in bytecode.
  *
+ * @requires jdk.version.major <= 24
  * @compile ../PersistUtil.java Driver.java ReferenceInfoUtil.java Fields.java
  * @run main Driver Fields
  * @ignore This fails for Java 11. See Issue 2816.

--- a/checker/jtreg/nullness/defaultsPersist/Methods.java
+++ b/checker/jtreg/nullness/defaultsPersist/Methods.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test that defaulted types are stored in bytecode.
  *
+ * @requires jdk.version.major <= 24
  * @compile ../PersistUtil.java Driver.java ReferenceInfoUtil.java Methods.java
  * @run main Driver Methods
  */

--- a/checker/jtreg/nullness/inheritDeclAnnoPersist/Extends.java
+++ b/checker/jtreg/nullness/inheritDeclAnnoPersist/Extends.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test that inherited declaration annotations are stored in bytecode.
  *
+ * @requires jdk.version.major <= 24
  * @compile ../PersistUtil.java Driver.java ReferenceInfoUtil.java Extends.java Super.java
  * @run main Driver Extends
  */

--- a/checker/jtreg/nullness/inheritDeclAnnoPersist/Implements.java
+++ b/checker/jtreg/nullness/inheritDeclAnnoPersist/Implements.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test that inherited declaration annotations are stored in bytecode.
  *
+ * @requires jdk.version.major <= 24
  * @compile ../PersistUtil.java Driver.java ReferenceInfoUtil.java Implements.java AbstractClass.java
  * @run main Driver Implements
  */

--- a/docs/examples/BazelExample/Makefile
+++ b/docs/examples/BazelExample/Makefile
@@ -1,4 +1,4 @@
-JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
+JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//' | sed 's/-beta//')
 
 .PHONY: all clean
 

--- a/docs/examples/MavenExample/Makefile
+++ b/docs/examples/MavenExample/Makefile
@@ -1,4 +1,4 @@
-JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
+JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//' | sed 's/-beta//')
 
 .PHONY: all clean
 

--- a/docs/examples/errorprone/Makefile
+++ b/docs/examples/errorprone/Makefile
@@ -1,4 +1,4 @@
-JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
+JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//' | sed 's/-beta//')
 
 .PHONY: all clean
 

--- a/docs/examples/lombok/Makefile
+++ b/docs/examples/lombok/Makefile
@@ -1,4 +1,4 @@
-JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
+JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//' | sed 's/-beta//')
 
 .PHONY: all clean
 


### PR DESCRIPTION
Related to #1198. This just stops running the broken tests.

@thisisalexandercook The tests will need some restructuring to nicely separate the two versions of the tests while sharing as much common code as possible.