### PR TITLE
Temporarily disable JDK-25-ea from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,6 @@ jobs:
         # Install the requested JDK second, to make it the default on which everything else runs.
         java-version: ${{ matrix.java.version }}
         distribution: 'temurin'
-
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,10 @@ jobs:
         # Install the requested JDK second, to make it the default on which everything else runs.
         java-version: ${{ matrix.java.version }}
         distribution: 'temurin'
+
+    - name: Reset JAVA_HOME and PATH to JDK 21
+      run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> "$GITHUB_ENV" && echo "PATH=$JAVA_HOME_21_X64/bin:$PATH" >> "$GITHUB_ENV"   # ← prepend, not append
+
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,7 @@ jobs:
         # Install the requested JDK second, to make it the default on which everything else runs.
         java-version: ${{ matrix.java.version }}
         distribution: 'temurin'
-
-    - name: Reset JAVA_HOME and PATH to JDK 21
-      run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> "$GITHUB_ENV" && echo "PATH=$JAVA_HOME_21_X64/bin:$PATH" >> "$GITHUB_ENV"   # ← prepend, not append
+        check-latest: true
 
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,7 @@ jobs:
         java: [{version: '8', experimental: false},
           {version: '11', experimental: false},
           {version: '17', experimental: false},
-          {version: '24', experimental: false},
-          {version: '25-ea', experimental: true}]
+          {version: '24', experimental: false}]
         exclude:
           # JDK 8 does not allow toolchains, so testing 'cftests-junit-jdk21' is unnecessary.
           - script: 'cftests-junit-jdk21'
@@ -199,18 +198,6 @@ jobs:
         # Install the requested JDK second, to make it the default on which everything else runs.
         java-version: ${{ matrix.java.version }}
         distribution: 'temurin'
-
-    - name: Fallback to pinned EA build if bin/java is missing
-      if: |
-        matrix.java.experimental &&
-        env.JAVA_HOME_25_X64 != '' &&
-        ! (hashFiles(format('{0}/bin/java', env.JAVA_HOME_25_X64)))
-      uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 25.0.0-ea+20  # known working version
-        java-package: jdk
-        check-latest: false # stay on the pinned build
 
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,18 @@ jobs:
         # Install the requested JDK second, to make it the default on which everything else runs.
         java-version: ${{ matrix.java.version }}
         distribution: 'temurin'
-        check-latest: true
+
+    - name: Fallback to pinned EA build if bin/java is missing
+      if: |
+        matrix.java.experimental &&
+        env.JAVA_HOME_25_X64 != '' &&
+        ! (hashFiles(format('{0}/bin/java', env.JAVA_HOME_25_X64)))
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 25.0.0-ea+20  # known working version
+        java-package: jdk
+        check-latest: false # stay on the pinned build
 
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties


### PR DESCRIPTION
Temporarily fixes #1219 by removing JDK-25-ea testing until an upstream fix is pushed.