### PR TITLE
Restore afu project property so Gradle can list tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,9 @@ ext {
     // As of 2025-04-28 (Lombok 1.18.38), delombok supports JDK 24-ea but not JDK 24 proper; see https://projectlombok.org/changelog .
     skipDelombok = (useJdkVersionInt >= 24)
 
-    // NO-AFU
-    // annotationTools = "${parentDir}/annotation-tools"
-    // afu = "${annotationTools}/annotation-file-utilities"
+    // NO-AFU - keep these variables live so tasks in checker/build.gradle configure without issue.
+    annotationTools = "${parentDir}/annotation-tools"
+    afu = "${annotationTools}/annotation-file-utilities"
 
     jtregHome = "${parentDir}/jtreg"
     gitScriptsHome = "${project(':checker').projectDir}/bin-devel/.git-scripts"

--- a/checker/bin-devel/test-misc.sh
+++ b/checker/bin-devel/test-misc.sh
@@ -73,3 +73,6 @@ git diff --exit-code docs/manual/contributors.tex || \
 
 # Check the definition of qualifiers in Checker Framework against the JDK
 ./checker/bin-devel/check-jdk-consistency.sh
+
+# Check gradle tasks are configured properly
+./gradlew tasks 


### PR DESCRIPTION
This PR fixes #1257 by restoring the `afu` project property, eliminating the “unknown property ‘afu’” errors that blocked Gradle’s configuration phase and prevented `./gradlew tasks` from completing. Because WPI is disabled in EISOP, the ainfer* tasks never run and the afu directory is never created.

This change minimizes our fork’s divergence from upstream by preserving the unused tasks instead of commenting them out or deleting them. To guard against future configuration regressions, especially for tools like the [Eclipse JDT Language Server](https://github.com/eclipse-jdtls/eclipse.jdt.ls) that depend on a healthy Gradle configuration—CI now includes a `./gradlew tasks` check.