### PR TITLE
Consistently use `errors and warnings`

### DIFF
--- a/checker/tests/README
+++ b/checker/tests/README
@@ -78,7 +78,7 @@ a comment at the top of the file, in this format:
   // @skip-test until the issue is fixed
 
 
-Specifying expected warnings and errors
+Specifying expected errors and warnings
 =======================================
 
 A test case is a Java file that uses stylized comments to indicate expected

--- a/docs/manual/constant-value-checker.tex
+++ b/docs/manual/constant-value-checker.tex
@@ -371,7 +371,7 @@ for range types, which gives smaller ranges to range types.}
 \end{figure}
 
 As with any unsound behavior in the Checker Framework, this option reduces
-the number of warnings and errors produced, and may reduce the number of
+the number of errors and warnings produced, and may reduce the number of
 \<@IntRange> qualifiers that you need to write in the source code.
 However, it is possible that at run time, an expression might evaluate to a
 value that is not in its \<@IntRange> qualifier.  You should either accept

--- a/docs/manual/faq.tex
+++ b/docs/manual/faq.tex
@@ -475,7 +475,7 @@ behavior:  behavior that will avoid exceptions.
 
 
 
-\sectionAndLabel{How to handle warnings and errors}{faq-warnings-section}
+\sectionAndLabel{How to handle errors and warnings}{faq-warnings-section}
 
 \subsectionAndLabel{What should I do if a checker issues a warning about my code?}{faq-handling-warnings}
 

--- a/docs/manual/warnings.tex
+++ b/docs/manual/warnings.tex
@@ -573,10 +573,10 @@ command-line option, see~\ref{askipdefs}).
 You can also use these options to affect entire packages or directories/folders.
 
 Set the \code{-AskipUses} command-line option to a
-regular expression that matches fully-qualified class names (not file names) for which warnings and errors
+regular expression that matches fully-qualified class names (not file names) for which errors and warnings
 should be suppressed.
 Or, set the \code{-AonlyUses} command-line option to a
-regular expression that matches fully-qualified class names (not file names) for which warnings and errors
+regular expression that matches fully-qualified class names (not file names) for which errors and warnings
 should be emitted; warnings about uses of all other classes will be suppressed.
 The regular expressions are unanchored, unless you anchor them yourself
 with ``\codesize\verb|^|'' and/or ``\codesize\verb|$|''.
@@ -625,7 +625,7 @@ see~\ref{askipuses}.)
 You can also use these options to affect entire packages or directories/folders.
 
 Set the \code{-AskipDefs} command-line option to a
-regular expression that matches fully-qualified class names (not file names) in whose definition warnings and errors
+regular expression that matches fully-qualified class names (not file names) in whose definition errors and warnings
 should be suppressed.
 Or, set the \code{-AonlyDefs} command-line option to a
 regular expression that matches fully-qualified class names (not file names) whose


### PR DESCRIPTION
I noticed the inconsistency in #1290 and `errors and warnings` occurred more frequently than `warnings and errors`.