### PR TITLE
Reapply optimization of `ConditionalTransferResult` out of method invocation with fix

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nonempty/NonEmptyTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/nonempty/NonEmptyTransfer.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.nonempty;
 
 import org.checkerframework.checker.nonempty.qual.NonEmpty;
+import org.checkerframework.dataflow.analysis.ConditionalTransferResult;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.node.CaseNode;
@@ -68,6 +69,9 @@ public class NonEmptyTransfer extends CFTransfer {
             EqualToNode n, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitEqualTo(n, in);
 
+        // Expand the input store into conditional store if it's regular store
+        result = regularCheck(result);
+
         // The equality holds.
         strengthenAnnotationSizeEquals(
                 in, n.getLeftOperand(), n.getRightOperand(), result.getThenStore());
@@ -86,6 +90,9 @@ public class NonEmptyTransfer extends CFTransfer {
             NotEqualNode n, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitNotEqual(n, in);
 
+        // Expand the input store into conditional store if it's regular store
+        result = regularCheck(result);
+
         refineNotEqual(n.getLeftOperand(), n.getRightOperand(), result.getThenStore());
         refineNotEqual(n.getRightOperand(), n.getLeftOperand(), result.getThenStore());
 
@@ -99,6 +106,9 @@ public class NonEmptyTransfer extends CFTransfer {
     public TransferResult<CFValue, CFStore> visitLessThan(
             LessThanNode n, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitLessThan(n, in);
+
+        // Expand the input store into conditional store if it's regular store
+        result = regularCheck(result);
 
         // A < B is equivalent to B > A.
         refineGT(n.getRightOperand(), n.getLeftOperand(), result.getThenStore());
@@ -114,6 +124,9 @@ public class NonEmptyTransfer extends CFTransfer {
             LessThanOrEqualNode n, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitLessThanOrEqual(n, in);
 
+        // Expand the input store into conditional store if it's regular store
+        result = regularCheck(result);
+
         // A <= B is equivalent to B >= A.
         // This handles the case where n <= container.size()
         refineGTE(n.getRightOperand(), n.getLeftOperand(), result.getThenStore());
@@ -128,6 +141,9 @@ public class NonEmptyTransfer extends CFTransfer {
             GreaterThanNode n, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitGreaterThan(n, in);
 
+        // Expand the input store into conditional store if it's regular store
+        result = regularCheck(result);
+
         refineGT(n.getLeftOperand(), n.getRightOperand(), result.getThenStore());
 
         return result;
@@ -138,6 +154,9 @@ public class NonEmptyTransfer extends CFTransfer {
             GreaterThanOrEqualNode n, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitGreaterThanOrEqual(n, in);
 
+        // Expand the input store into conditional store if it's regular store
+        result = regularCheck(result);
+
         refineGTE(n.getLeftOperand(), n.getRightOperand(), result.getThenStore());
 
         return result;
@@ -147,6 +166,10 @@ public class NonEmptyTransfer extends CFTransfer {
     public TransferResult<CFValue, CFStore> visitCase(
             CaseNode n, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitCase(n, in);
+
+        // Expand the input store into conditional store if it's regular store
+        result = regularCheck(result);
+
         List<Node> caseOperands = n.getCaseOperands();
         Node switchOpNode = n.getSwitchOperand().getExpression();
 
@@ -369,5 +392,14 @@ public class NonEmptyTransfer extends CFTransfer {
         } else {
             return null;
         }
+    }
+
+    private TransferResult<CFValue, CFStore> regularCheck(TransferResult<CFValue, CFStore> result) {
+        if (!result.containsTwoStores()) {
+            CFStore thenStore = result.getThenStore();
+            CFStore elseStore = result.getElseStore();
+            return new ConditionalTransferResult<>(result.getResultValue(), thenStore, elseStore);
+        }
+        return result;
     }
 }

--- a/checker/tests/nullness-extra/issue5174/Issue5174.out
+++ b/checker/tests/nullness-extra/issue5174/Issue5174.out
@@ -89,13 +89,7 @@ Before: InitializationStore#14(
 (this).<init>()   [ MethodInvocation ]    > CFAV{@UnderInitialization, Object}
 
 16:
-Before: then=InitializationStore#15(
-  f > CFAV{, S}
-  this > CFAV{@UnderInitialization, Issue5174Super}
-  Issue5174Super<S>.sf > CFAV{@Initialized, Object}
-  this.<init>() > CFAV{@UnderInitialization, Object}
-  initialized fields = [sf]),
-else=InitializationStore#16(
+Before: InitializationStore#15(
   f > CFAV{, S}
   this > CFAV{@UnderInitialization, Issue5174Super}
   Issue5174Super<S>.sf > CFAV{@Initialized, Object}
@@ -110,7 +104,7 @@ this.f = f   [ Assignment ]    > CFAV{, S}
 expression statement this.f = f   [ ExpressionStatement ]
 
 12:
-Before: InitializationStore#17(
+Before: InitializationStore#16(
   f > CFAV{, S}
   this > CFAV{@UnderInitialization, Issue5174Super}
   Issue5174Super<S>.sf > CFAV{@Initialized, Object}
@@ -119,7 +113,7 @@ Before: InitializationStore#17(
 <exceptional-exit>
 
 11:
-Before: InitializationStore#22(
+Before: InitializationStore#19(
   f > CFAV{, S}
   this > CFAV{@UnderInitialization, Issue5174Super}
   Issue5174Super<S>.sf > CFAV{@Initialized, Object}
@@ -131,7 +125,7 @@ Before: InitializationStore#22(
 3 -> 0
 
 2:
-Before: NullnessNoInitStore#32(
+Before: NullnessNoInitStore#27(
 
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -139,7 +133,7 @@ Before: NullnessNoInitStore#32(
 <entry>
 
 3:
-Before: NullnessNoInitStore#32(
+Before: NullnessNoInitStore#27(
 
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -148,7 +142,7 @@ Before: NullnessNoInitStore#32(
 (this).sf = ""   [ Assignment ]    > NV{@NonNull, String, poly nn/n=f/f}
 
 0:
-Before: NullnessNoInitStore#33(
+Before: NullnessNoInitStore#28(
   Issue5174Super<S>.sf > NV{@NonNull, String, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -158,7 +152,7 @@ Before: NullnessNoInitStore#33(
 8 -> 5
 
 7:
-Before: NullnessNoInitStore#37(
+Before: NullnessNoInitStore#32(
   in > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -169,7 +163,7 @@ Before: NullnessNoInitStore#37(
 <entry>
 
 8:
-Before: NullnessNoInitStore#37(
+Before: NullnessNoInitStore#32(
   in > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -181,7 +175,7 @@ in   [ LocalVariable ]    > NV{, S, poly nn/n=f/f}
 return in   [ Return ]    > NV{@NonNull, boolean, poly nn/n=f/f}
 
 5:
-Before: NullnessNoInitStore#38(
+Before: NullnessNoInitStore#33(
   in > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -198,7 +192,7 @@ Before: NullnessNoInitStore#38(
 16 -> 11
 
 13:
-Before: NullnessNoInitStore#42(
+Before: NullnessNoInitStore#37(
   f > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -208,7 +202,7 @@ Before: NullnessNoInitStore#42(
 <entry>
 
 14:
-Before: NullnessNoInitStore#42(
+Before: NullnessNoInitStore#37(
   f > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -219,7 +213,7 @@ Before: NullnessNoInitStore#42(
 (this).<init>   [ MethodAccess ]    > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
 
 15:
-Before: NullnessNoInitStore#43(
+Before: NullnessNoInitStore#38(
   f > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -229,14 +223,7 @@ Before: NullnessNoInitStore#43(
 (this).<init>()   [ MethodInvocation ]    > NV{@NonNull, Object, poly nn/n=f/f}
 
 16:
-Before: then=NullnessNoInitStore#44(
-  f > NV{, S, poly nn/n=f/f}
-  this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
-  Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
-  this.<init>() > NV{@NonNull, Object, poly nn/n=f/f}
-  isPolyNullNonNull = false
-  isPolyNullNull = false),
-else=NullnessNoInitStore#45(
+Before: NullnessNoInitStore#39(
   f > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -252,7 +239,7 @@ this.f = f   [ Assignment ]    > NV{, S, poly nn/n=f/f}
 expression statement this.f = f   [ ExpressionStatement ]
 
 12:
-Before: NullnessNoInitStore#46(
+Before: NullnessNoInitStore#40(
   f > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -262,7 +249,7 @@ Before: NullnessNoInitStore#46(
 <exceptional-exit>
 
 11:
-Before: NullnessNoInitStore#51(
+Before: NullnessNoInitStore#43(
   f > NV{, S, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
   Issue5174Super<S>.sf > NV{@NonNull, Object, poly nn/n=f/f}
@@ -279,7 +266,7 @@ Before: NullnessNoInitStore#51(
 23 -> 18
 
 20:
-Before: InitializationStore#63(
+Before: InitializationStore#53(
   f > CFAV{, T}
   this > CFAV{@UnderInitialization(Issue5174Super.class), Issue5174Sub}
   initialized fields = [])
@@ -287,7 +274,7 @@ Before: InitializationStore#63(
 <entry>
 
 21:
-Before: InitializationStore#63(
+Before: InitializationStore#53(
   f > CFAV{, T}
   this > CFAV{@UnderInitialization(Issue5174Super.class), Issue5174Sub}
   initialized fields = [])
@@ -297,7 +284,7 @@ Before: InitializationStore#63(
 f   [ LocalVariable ]    > CFAV{, T}
 
 22:
-Before: InitializationStore#64(
+Before: InitializationStore#54(
   f > CFAV{, T}
   this > CFAV{@UnderInitialization(Issue5174Super.class), Issue5174Sub}
   initialized fields = [])
@@ -305,11 +292,7 @@ Before: InitializationStore#64(
 (this).<init>(f)   [ MethodInvocation ]    > CFAV{@UnderInitialization, Issue5174Super}
 
 23:
-Before: then=InitializationStore#65(
-  f > CFAV{, T}
-  this > CFAV{@UnderInitialization(Issue5174Super.class), Issue5174Sub}
-  initialized fields = [f, sf]),
-else=InitializationStore#66(
+Before: InitializationStore#55(
   f > CFAV{, T}
   this > CFAV{@UnderInitialization(Issue5174Super.class), Issue5174Sub}
   initialized fields = [f, sf])
@@ -317,7 +300,7 @@ else=InitializationStore#66(
 expression statement super(f)   [ ExpressionStatement ]
 
 19:
-Before: InitializationStore#67(
+Before: InitializationStore#58(
   f > CFAV{, T}
   this > CFAV{@UnderInitialization(Issue5174Super.class), Issue5174Sub}
   initialized fields = [])
@@ -325,7 +308,7 @@ Before: InitializationStore#67(
 <exceptional-exit>
 
 18:
-Before: InitializationStore#72(
+Before: InitializationStore#61(
   f > CFAV{, T}
   this > CFAV{@UnderInitialization(Issue5174Super.class), Issue5174Sub}
   initialized fields = [f, sf])
@@ -339,7 +322,7 @@ Before: InitializationStore#72(
 30 -> 25
 
 27:
-Before: InitializationStore#79(
+Before: InitializationStore#68(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -347,7 +330,7 @@ Before: InitializationStore#79(
 <entry>
 
 28:
-Before: InitializationStore#79(
+Before: InitializationStore#68(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -358,7 +341,7 @@ o   [ VariableDeclaration ]
 in   [ LocalVariable ]    > CFAV{, T}
 
 29:
-Before: InitializationStore#80(
+Before: InitializationStore#69(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -366,11 +349,7 @@ Before: InitializationStore#80(
 (this).methodInner(in)   [ MethodInvocation ]    > CFAV{, T}
 
 30:
-Before: then=InitializationStore#81(
-  in > CFAV{, T}
-  this > CFAV{@Initialized, Issue5174Sub}
-  initialized fields = []),
-else=InitializationStore#82(
+Before: InitializationStore#70(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -378,7 +357,7 @@ else=InitializationStore#82(
 o = (this).methodInner(in)   [ Assignment ]    > CFAV{, T}
 
 26:
-Before: InitializationStore#83(
+Before: InitializationStore#71(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -386,7 +365,7 @@ Before: InitializationStore#83(
 <exceptional-exit>
 
 25:
-Before: InitializationStore#88(
+Before: InitializationStore#74(
   in > CFAV{, T}
   o > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
@@ -401,7 +380,7 @@ Before: InitializationStore#88(
 37 -> 32
 
 34:
-Before: InitializationStore#95(
+Before: InitializationStore#81(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -409,7 +388,7 @@ Before: InitializationStore#95(
 <entry>
 
 35:
-Before: InitializationStore#95(
+Before: InitializationStore#81(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -420,7 +399,7 @@ this.methodInner   [ MethodAccess ]
 in   [ LocalVariable ]    > CFAV{, T}
 
 36:
-Before: InitializationStore#96(
+Before: InitializationStore#82(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -428,11 +407,7 @@ Before: InitializationStore#96(
 this.methodInner(in)   [ MethodInvocation ]    > CFAV{, T}
 
 37:
-Before: then=InitializationStore#97(
-  in > CFAV{, T}
-  this > CFAV{@Initialized, Issue5174Sub}
-  initialized fields = []),
-else=InitializationStore#98(
+Before: InitializationStore#83(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -440,7 +415,7 @@ else=InitializationStore#98(
 o = this.methodInner(in)   [ Assignment ]    > CFAV{, T}
 
 33:
-Before: InitializationStore#99(
+Before: InitializationStore#84(
   in > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -448,7 +423,7 @@ Before: InitializationStore#99(
 <exceptional-exit>
 
 32:
-Before: InitializationStore#104(
+Before: InitializationStore#87(
   in > CFAV{, T}
   o > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
@@ -459,14 +434,14 @@ Before: InitializationStore#104(
 42 -> 39
 
 41:
-Before: InitializationStore#111(
+Before: InitializationStore#94(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
 <entry>
 
 42:
-Before: InitializationStore#111(
+Before: InitializationStore#94(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
@@ -476,7 +451,7 @@ o   [ VariableDeclaration ]
 o = (this).f   [ Assignment ]    > CFAV{, T}
 
 39:
-Before: InitializationStore#112(
+Before: InitializationStore#95(
   o > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -486,14 +461,14 @@ Before: InitializationStore#112(
 47 -> 44
 
 46:
-Before: InitializationStore#116(
+Before: InitializationStore#99(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
 <entry>
 
 47:
-Before: InitializationStore#116(
+Before: InitializationStore#99(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
@@ -503,7 +478,7 @@ this.f   [ FieldAccess ]    > CFAV{, T}
 o = this.f   [ Assignment ]    > CFAV{, T}
 
 44:
-Before: InitializationStore#117(
+Before: InitializationStore#100(
   o > CFAV{, T}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -531,14 +506,14 @@ Before: InitializationStore#117(
 58 -> 49
 
 51:
-Before: InitializationStore#121(
+Before: InitializationStore#104(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
 <entry>
 
 52:
-Before: InitializationStore#121(
+Before: InitializationStore#104(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
@@ -546,14 +521,14 @@ o   [ VariableDeclaration ]
 o   [ LocalVariable ]
 
 53:
-Before: InitializationStore#122(
+Before: InitializationStore#105(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
 Issue5174Super   [ ClassName ]
 
 54:
-Before: InitializationStore#123(
+Before: InitializationStore#106(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
@@ -563,14 +538,14 @@ expression statement o = sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 50:
-Before: InitializationStore#124(
+Before: InitializationStore#107(
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
 ~~~~~~~~~
 <exceptional-exit>
 
 55:
-Before: InitializationStore#131(
+Before: InitializationStore#114(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -578,7 +553,7 @@ Before: InitializationStore#131(
 Issue5174Sub   [ ClassName ]    > CFAV{@Initialized, Issue5174Sub}
 
 56:
-Before: InitializationStore#132(
+Before: InitializationStore#115(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -589,7 +564,7 @@ expression statement o = Issue5174Sub.sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 57:
-Before: InitializationStore#141(
+Before: InitializationStore#124(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -597,7 +572,7 @@ Before: InitializationStore#141(
 Issue5174Super   [ ClassName ]    > CFAV{@Initialized, Issue5174Super}
 
 58:
-Before: InitializationStore#142(
+Before: InitializationStore#125(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -607,7 +582,7 @@ o = Issue5174Super.sf   [ Assignment ]    > CFAV{@Initialized, Object}
 expression statement o = Issue5174Super.sf   [ ExpressionStatement ]
 
 49:
-Before: InitializationStore#151(
+Before: InitializationStore#134(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, Issue5174Sub}
   initialized fields = [])
@@ -621,14 +596,14 @@ Before: InitializationStore#151(
 65 -> 60
 
 62:
-Before: InitializationStore#162(
+Before: InitializationStore#145(
   this > CFAV{@UnderInitialization, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 <entry>
 
 63:
-Before: InitializationStore#162(
+Before: InitializationStore#145(
   this > CFAV{@UnderInitialization, SubNested}
   initialized fields = [])
 ~~~~~~~~~
@@ -636,18 +611,14 @@ Before: InitializationStore#162(
 (this).<init>   [ MethodAccess ]    > CFAV{@UnderInitialization(Issue5174Sub.SubNested.class), SubNested}
 
 64:
-Before: InitializationStore#163(
+Before: InitializationStore#146(
   this > CFAV{@UnderInitialization, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 (this).<init>()   [ MethodInvocation ]    > CFAV{@UnderInitialization, Object}
 
 65:
-Before: then=InitializationStore#164(
-  this > CFAV{@UnderInitialization, SubNested}
-  this.<init>() > CFAV{@UnderInitialization, Object}
-  initialized fields = []),
-else=InitializationStore#165(
+Before: InitializationStore#147(
   this > CFAV{@UnderInitialization, SubNested}
   this.<init>() > CFAV{@UnderInitialization, Object}
   initialized fields = [])
@@ -655,14 +626,14 @@ else=InitializationStore#165(
 expression statement super()   [ ExpressionStatement ]
 
 61:
-Before: InitializationStore#166(
+Before: InitializationStore#148(
   this > CFAV{@UnderInitialization, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 <exceptional-exit>
 
 60:
-Before: InitializationStore#171(
+Before: InitializationStore#151(
   this > CFAV{@UnderInitialization, SubNested}
   this.<init>() > CFAV{@UnderInitialization, Object}
   initialized fields = [])
@@ -676,7 +647,7 @@ Before: InitializationStore#171(
 72 -> 67
 
 69:
-Before: InitializationStore#178(
+Before: InitializationStore#158(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -684,7 +655,7 @@ Before: InitializationStore#178(
 <entry>
 
 70:
-Before: InitializationStore#178(
+Before: InitializationStore#158(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -695,7 +666,7 @@ o   [ VariableDeclaration ]
 in   [ LocalVariable ]    > CFAV{, T}
 
 71:
-Before: InitializationStore#179(
+Before: InitializationStore#159(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -703,11 +674,7 @@ Before: InitializationStore#179(
 (this).methodInner(in)   [ MethodInvocation ]    > CFAV{, T}
 
 72:
-Before: then=InitializationStore#180(
-  in > CFAV{, T}
-  this > CFAV{@Initialized, SubNested}
-  initialized fields = []),
-else=InitializationStore#181(
+Before: InitializationStore#160(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -715,7 +682,7 @@ else=InitializationStore#181(
 o = (this).methodInner(in)   [ Assignment ]    > CFAV{, T}
 
 68:
-Before: InitializationStore#182(
+Before: InitializationStore#161(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -723,7 +690,7 @@ Before: InitializationStore#182(
 <exceptional-exit>
 
 67:
-Before: InitializationStore#187(
+Before: InitializationStore#164(
   in > CFAV{, T}
   o > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
@@ -748,7 +715,7 @@ Before: InitializationStore#187(
 85 -> 74
 
 76:
-Before: InitializationStore#194(
+Before: InitializationStore#171(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -756,7 +723,7 @@ Before: InitializationStore#194(
 <entry>
 
 77:
-Before: InitializationStore#194(
+Before: InitializationStore#171(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -764,7 +731,7 @@ Before: InitializationStore#194(
 o   [ VariableDeclaration ]
 
 78:
-Before: InitializationStore#195(
+Before: InitializationStore#172(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -772,7 +739,7 @@ Before: InitializationStore#195(
 Issue5174Sub   [ ClassName ]    > CFAV{@Initialized, Issue5174Sub}
 
 80:
-Before: InitializationStore#196(
+Before: InitializationStore#173(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -780,7 +747,7 @@ Before: InitializationStore#196(
 Issue5174Sub.this   [ FieldAccess ]    > CFAV{@Initialized, Issue5174Sub}
 
 75:
-Before: InitializationStore#197(
+Before: InitializationStore#174(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -788,7 +755,7 @@ Before: InitializationStore#197(
 <exceptional-exit>
 
 82:
-Before: InitializationStore#204(
+Before: InitializationStore#181(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -796,7 +763,7 @@ Before: InitializationStore#204(
 Issue5174Sub.this.methodInner   [ MethodAccess ]
 
 83:
-Before: InitializationStore#207(
+Before: InitializationStore#184(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -804,7 +771,7 @@ Before: InitializationStore#207(
 in   [ LocalVariable ]    > CFAV{, T}
 
 84:
-Before: InitializationStore#210(
+Before: InitializationStore#187(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -812,11 +779,7 @@ Before: InitializationStore#210(
 Issue5174Sub.this.methodInner(in)   [ MethodInvocation ]    > CFAV{, T}
 
 85:
-Before: then=InitializationStore#211(
-  in > CFAV{, T}
-  this > CFAV{@Initialized, SubNested}
-  initialized fields = []),
-else=InitializationStore#212(
+Before: InitializationStore#188(
   in > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -824,7 +787,7 @@ else=InitializationStore#212(
 o = Issue5174Sub.this.methodInner(in)   [ Assignment ]    > CFAV{, T}
 
 74:
-Before: InitializationStore#219(
+Before: InitializationStore#193(
   in > CFAV{, T}
   o > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
@@ -835,14 +798,14 @@ Before: InitializationStore#219(
 90 -> 87
 
 89:
-Before: InitializationStore#230(
+Before: InitializationStore#204(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 <entry>
 
 90:
-Before: InitializationStore#230(
+Before: InitializationStore#204(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
@@ -852,7 +815,7 @@ o   [ VariableDeclaration ]
 o = (this).f   [ Assignment ]    > CFAV{, T}
 
 87:
-Before: InitializationStore#231(
+Before: InitializationStore#205(
   o > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -872,56 +835,56 @@ Before: InitializationStore#231(
 101 -> 92
 
 94:
-Before: InitializationStore#235(
+Before: InitializationStore#209(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 <entry>
 
 95:
-Before: InitializationStore#235(
+Before: InitializationStore#209(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 o   [ VariableDeclaration ]
 
 96:
-Before: InitializationStore#236(
+Before: InitializationStore#210(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 Issue5174Sub   [ ClassName ]    > CFAV{@Initialized, Issue5174Sub}
 
 98:
-Before: InitializationStore#237(
+Before: InitializationStore#211(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 Issue5174Sub.this   [ FieldAccess ]    > CFAV{@Initialized, Issue5174Sub}
 
 93:
-Before: InitializationStore#238(
+Before: InitializationStore#212(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 <exceptional-exit>
 
 100:
-Before: InitializationStore#245(
+Before: InitializationStore#219(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 Issue5174Sub.this.f   [ FieldAccess ]    > CFAV{, T}
 
 101:
-Before: InitializationStore#248(
+Before: InitializationStore#222(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 o = Issue5174Sub.this.f   [ Assignment ]    > CFAV{, T}
 
 92:
-Before: InitializationStore#251(
+Before: InitializationStore#225(
   o > CFAV{, T}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -949,14 +912,14 @@ Before: InitializationStore#251(
 112 -> 103
 
 105:
-Before: InitializationStore#260(
+Before: InitializationStore#234(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 <entry>
 
 106:
-Before: InitializationStore#260(
+Before: InitializationStore#234(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
@@ -964,14 +927,14 @@ o   [ VariableDeclaration ]
 o   [ LocalVariable ]
 
 107:
-Before: InitializationStore#261(
+Before: InitializationStore#235(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 Issue5174Super   [ ClassName ]
 
 108:
-Before: InitializationStore#262(
+Before: InitializationStore#236(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
@@ -981,14 +944,14 @@ expression statement o = sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 104:
-Before: InitializationStore#263(
+Before: InitializationStore#237(
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
 ~~~~~~~~~
 <exceptional-exit>
 
 109:
-Before: InitializationStore#270(
+Before: InitializationStore#244(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -996,7 +959,7 @@ Before: InitializationStore#270(
 Issue5174Sub   [ ClassName ]    > CFAV{@Initialized, Issue5174Sub}
 
 110:
-Before: InitializationStore#271(
+Before: InitializationStore#245(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -1007,7 +970,7 @@ expression statement o = Issue5174Sub.sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 111:
-Before: InitializationStore#280(
+Before: InitializationStore#254(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -1015,7 +978,7 @@ Before: InitializationStore#280(
 Issue5174Super   [ ClassName ]    > CFAV{@Initialized, Issue5174Super}
 
 112:
-Before: InitializationStore#281(
+Before: InitializationStore#255(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -1025,7 +988,7 @@ o = Issue5174Super.sf   [ Assignment ]    > CFAV{@Initialized, Object}
 expression statement o = Issue5174Super.sf   [ ExpressionStatement ]
 
 103:
-Before: InitializationStore#290(
+Before: InitializationStore#264(
   o > CFAV{@Initialized, Object}
   this > CFAV{@Initialized, SubNested}
   initialized fields = [])
@@ -1039,7 +1002,7 @@ Before: InitializationStore#290(
 23 -> 18
 
 20:
-Before: NullnessNoInitStore#301(
+Before: NullnessNoInitStore#275(
   f > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1048,7 +1011,7 @@ Before: NullnessNoInitStore#301(
 <entry>
 
 21:
-Before: NullnessNoInitStore#301(
+Before: NullnessNoInitStore#275(
   f > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1059,7 +1022,7 @@ Before: NullnessNoInitStore#301(
 f   [ LocalVariable ]    > NV{, T, poly nn/n=f/f}
 
 22:
-Before: NullnessNoInitStore#302(
+Before: NullnessNoInitStore#276(
   f > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1068,12 +1031,7 @@ Before: NullnessNoInitStore#302(
 (this).<init>(f)   [ MethodInvocation ]    > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
 
 23:
-Before: then=NullnessNoInitStore#303(
-  f > NV{, T, poly nn/n=f/f}
-  this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
-  isPolyNullNonNull = false
-  isPolyNullNull = false),
-else=NullnessNoInitStore#304(
+Before: NullnessNoInitStore#277(
   f > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1082,7 +1040,7 @@ else=NullnessNoInitStore#304(
 expression statement super(f)   [ ExpressionStatement ]
 
 19:
-Before: NullnessNoInitStore#305(
+Before: NullnessNoInitStore#278(
   f > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1091,7 +1049,7 @@ Before: NullnessNoInitStore#305(
 <exceptional-exit>
 
 18:
-Before: NullnessNoInitStore#310(
+Before: NullnessNoInitStore#281(
   f > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1106,7 +1064,7 @@ Before: NullnessNoInitStore#310(
 30 -> 25
 
 27:
-Before: NullnessNoInitStore#317(
+Before: NullnessNoInitStore#288(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1115,7 +1073,7 @@ Before: NullnessNoInitStore#317(
 <entry>
 
 28:
-Before: NullnessNoInitStore#317(
+Before: NullnessNoInitStore#288(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1127,7 +1085,7 @@ o   [ VariableDeclaration ]
 in   [ LocalVariable ]    > NV{, T, poly nn/n=f/f}
 
 29:
-Before: NullnessNoInitStore#318(
+Before: NullnessNoInitStore#289(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1136,12 +1094,7 @@ Before: NullnessNoInitStore#318(
 (this).methodInner(in)   [ MethodInvocation ]    > NV{, T, poly nn/n=f/f}
 
 30:
-Before: then=NullnessNoInitStore#319(
-  in > NV{, T, poly nn/n=f/f}
-  this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
-  isPolyNullNonNull = false
-  isPolyNullNull = false),
-else=NullnessNoInitStore#320(
+Before: NullnessNoInitStore#290(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1150,7 +1103,7 @@ else=NullnessNoInitStore#320(
 o = (this).methodInner(in)   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 26:
-Before: NullnessNoInitStore#321(
+Before: NullnessNoInitStore#291(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1159,7 +1112,7 @@ Before: NullnessNoInitStore#321(
 <exceptional-exit>
 
 25:
-Before: NullnessNoInitStore#326(
+Before: NullnessNoInitStore#294(
   in > NV{, T, poly nn/n=f/f}
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1175,7 +1128,7 @@ Before: NullnessNoInitStore#326(
 37 -> 32
 
 34:
-Before: NullnessNoInitStore#333(
+Before: NullnessNoInitStore#301(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1184,7 +1137,7 @@ Before: NullnessNoInitStore#333(
 <entry>
 
 35:
-Before: NullnessNoInitStore#333(
+Before: NullnessNoInitStore#301(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1196,7 +1149,7 @@ this.methodInner   [ MethodAccess ]
 in   [ LocalVariable ]    > NV{, T, poly nn/n=f/f}
 
 36:
-Before: NullnessNoInitStore#334(
+Before: NullnessNoInitStore#302(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1205,12 +1158,7 @@ Before: NullnessNoInitStore#334(
 this.methodInner(in)   [ MethodInvocation ]    > NV{, T, poly nn/n=f/f}
 
 37:
-Before: then=NullnessNoInitStore#335(
-  in > NV{, T, poly nn/n=f/f}
-  this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
-  isPolyNullNonNull = false
-  isPolyNullNull = false),
-else=NullnessNoInitStore#336(
+Before: NullnessNoInitStore#303(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1219,7 +1167,7 @@ else=NullnessNoInitStore#336(
 o = this.methodInner(in)   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 33:
-Before: NullnessNoInitStore#337(
+Before: NullnessNoInitStore#304(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1228,7 +1176,7 @@ Before: NullnessNoInitStore#337(
 <exceptional-exit>
 
 32:
-Before: NullnessNoInitStore#342(
+Before: NullnessNoInitStore#307(
   in > NV{, T, poly nn/n=f/f}
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1240,7 +1188,7 @@ Before: NullnessNoInitStore#342(
 42 -> 39
 
 41:
-Before: NullnessNoInitStore#349(
+Before: NullnessNoInitStore#314(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1248,7 +1196,7 @@ Before: NullnessNoInitStore#349(
 <entry>
 
 42:
-Before: NullnessNoInitStore#349(
+Before: NullnessNoInitStore#314(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1259,7 +1207,7 @@ o   [ VariableDeclaration ]
 o = (this).f   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 39:
-Before: NullnessNoInitStore#350(
+Before: NullnessNoInitStore#315(
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1270,7 +1218,7 @@ Before: NullnessNoInitStore#350(
 47 -> 44
 
 46:
-Before: NullnessNoInitStore#354(
+Before: NullnessNoInitStore#319(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1278,7 +1226,7 @@ Before: NullnessNoInitStore#354(
 <entry>
 
 47:
-Before: NullnessNoInitStore#354(
+Before: NullnessNoInitStore#319(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1289,7 +1237,7 @@ this.f   [ FieldAccess ]    > NV{, T, poly nn/n=f/f}
 o = this.f   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 44:
-Before: NullnessNoInitStore#355(
+Before: NullnessNoInitStore#320(
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1318,7 +1266,7 @@ Before: NullnessNoInitStore#355(
 58 -> 49
 
 51:
-Before: NullnessNoInitStore#359(
+Before: NullnessNoInitStore#324(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1326,7 +1274,7 @@ Before: NullnessNoInitStore#359(
 <entry>
 
 52:
-Before: NullnessNoInitStore#359(
+Before: NullnessNoInitStore#324(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1335,7 +1283,7 @@ o   [ VariableDeclaration ]
 o   [ LocalVariable ]
 
 53:
-Before: NullnessNoInitStore#360(
+Before: NullnessNoInitStore#325(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1343,7 +1291,7 @@ Before: NullnessNoInitStore#360(
 Issue5174Super   [ ClassName ]
 
 54:
-Before: NullnessNoInitStore#361(
+Before: NullnessNoInitStore#326(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1354,7 +1302,7 @@ expression statement o = sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 50:
-Before: NullnessNoInitStore#362(
+Before: NullnessNoInitStore#327(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1362,7 +1310,7 @@ Before: NullnessNoInitStore#362(
 <exceptional-exit>
 
 55:
-Before: NullnessNoInitStore#369(
+Before: NullnessNoInitStore#334(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1371,7 +1319,7 @@ Before: NullnessNoInitStore#369(
 Issue5174Sub   [ ClassName ]    > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
 
 56:
-Before: NullnessNoInitStore#370(
+Before: NullnessNoInitStore#335(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1383,7 +1331,7 @@ expression statement o = Issue5174Sub.sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 57:
-Before: NullnessNoInitStore#379(
+Before: NullnessNoInitStore#344(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1392,7 +1340,7 @@ Before: NullnessNoInitStore#379(
 Issue5174Super   [ ClassName ]    > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
 
 58:
-Before: NullnessNoInitStore#380(
+Before: NullnessNoInitStore#345(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1403,7 +1351,7 @@ o = Issue5174Super.sf   [ Assignment ]    > NV{@NonNull, Object, poly nn/n=f/f}
 expression statement o = Issue5174Super.sf   [ ExpressionStatement ]
 
 49:
-Before: NullnessNoInitStore#389(
+Before: NullnessNoInitStore#354(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1418,7 +1366,7 @@ Before: NullnessNoInitStore#389(
 65 -> 60
 
 62:
-Before: NullnessNoInitStore#400(
+Before: NullnessNoInitStore#365(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1426,7 +1374,7 @@ Before: NullnessNoInitStore#400(
 <entry>
 
 63:
-Before: NullnessNoInitStore#400(
+Before: NullnessNoInitStore#365(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1435,7 +1383,7 @@ Before: NullnessNoInitStore#400(
 (this).<init>   [ MethodAccess ]    > NV{@NonNull, SubNested, poly nn/n=f/f}
 
 64:
-Before: NullnessNoInitStore#401(
+Before: NullnessNoInitStore#366(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1443,12 +1391,7 @@ Before: NullnessNoInitStore#401(
 (this).<init>()   [ MethodInvocation ]    > NV{@NonNull, Object, poly nn/n=f/f}
 
 65:
-Before: then=NullnessNoInitStore#402(
-  this > NV{@NonNull, SubNested, poly nn/n=f/f}
-  this.<init>() > NV{@NonNull, Object, poly nn/n=f/f}
-  isPolyNullNonNull = false
-  isPolyNullNull = false),
-else=NullnessNoInitStore#403(
+Before: NullnessNoInitStore#367(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   this.<init>() > NV{@NonNull, Object, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1457,7 +1400,7 @@ else=NullnessNoInitStore#403(
 expression statement super()   [ ExpressionStatement ]
 
 61:
-Before: NullnessNoInitStore#404(
+Before: NullnessNoInitStore#368(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1465,7 +1408,7 @@ Before: NullnessNoInitStore#404(
 <exceptional-exit>
 
 60:
-Before: NullnessNoInitStore#409(
+Before: NullnessNoInitStore#371(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   this.<init>() > NV{@NonNull, Object, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1480,7 +1423,7 @@ Before: NullnessNoInitStore#409(
 72 -> 67
 
 69:
-Before: NullnessNoInitStore#416(
+Before: NullnessNoInitStore#378(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1489,7 +1432,7 @@ Before: NullnessNoInitStore#416(
 <entry>
 
 70:
-Before: NullnessNoInitStore#416(
+Before: NullnessNoInitStore#378(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1501,7 +1444,7 @@ o   [ VariableDeclaration ]
 in   [ LocalVariable ]    > NV{, T, poly nn/n=f/f}
 
 71:
-Before: NullnessNoInitStore#417(
+Before: NullnessNoInitStore#379(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1510,12 +1453,7 @@ Before: NullnessNoInitStore#417(
 (this).methodInner(in)   [ MethodInvocation ]    > NV{, T, poly nn/n=f/f}
 
 72:
-Before: then=NullnessNoInitStore#418(
-  in > NV{, T, poly nn/n=f/f}
-  this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
-  isPolyNullNonNull = false
-  isPolyNullNull = false),
-else=NullnessNoInitStore#419(
+Before: NullnessNoInitStore#380(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1524,7 +1462,7 @@ else=NullnessNoInitStore#419(
 o = (this).methodInner(in)   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 68:
-Before: NullnessNoInitStore#420(
+Before: NullnessNoInitStore#381(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1533,7 +1471,7 @@ Before: NullnessNoInitStore#420(
 <exceptional-exit>
 
 67:
-Before: NullnessNoInitStore#425(
+Before: NullnessNoInitStore#384(
   in > NV{, T, poly nn/n=f/f}
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1559,7 +1497,7 @@ Before: NullnessNoInitStore#425(
 85 -> 74
 
 76:
-Before: NullnessNoInitStore#432(
+Before: NullnessNoInitStore#391(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1568,7 +1506,7 @@ Before: NullnessNoInitStore#432(
 <entry>
 
 77:
-Before: NullnessNoInitStore#432(
+Before: NullnessNoInitStore#391(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1577,7 +1515,7 @@ Before: NullnessNoInitStore#432(
 o   [ VariableDeclaration ]
 
 78:
-Before: NullnessNoInitStore#433(
+Before: NullnessNoInitStore#392(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1586,7 +1524,7 @@ Before: NullnessNoInitStore#433(
 Issue5174Sub   [ ClassName ]    > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
 
 80:
-Before: NullnessNoInitStore#434(
+Before: NullnessNoInitStore#393(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1595,7 +1533,7 @@ Before: NullnessNoInitStore#434(
 Issue5174Sub.this   [ FieldAccess ]    > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
 
 75:
-Before: NullnessNoInitStore#452(
+Before: NullnessNoInitStore#410(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Object, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1604,7 +1542,7 @@ Before: NullnessNoInitStore#452(
 <exceptional-exit>
 
 82:
-Before: NullnessNoInitStore#442(
+Before: NullnessNoInitStore#401(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1614,7 +1552,7 @@ Before: NullnessNoInitStore#442(
 Issue5174Sub.this.methodInner   [ MethodAccess ]
 
 83:
-Before: NullnessNoInitStore#445(
+Before: NullnessNoInitStore#404(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1624,7 +1562,7 @@ Before: NullnessNoInitStore#445(
 in   [ LocalVariable ]    > NV{, T, poly nn/n=f/f}
 
 84:
-Before: NullnessNoInitStore#448(
+Before: NullnessNoInitStore#407(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1634,13 +1572,7 @@ Before: NullnessNoInitStore#448(
 Issue5174Sub.this.methodInner(in)   [ MethodInvocation ]    > NV{, T, poly nn/n=f/f}
 
 85:
-Before: then=NullnessNoInitStore#449(
-  in > NV{, T, poly nn/n=f/f}
-  this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
-  Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
-  isPolyNullNonNull = false
-  isPolyNullNull = false),
-else=NullnessNoInitStore#450(
+Before: NullnessNoInitStore#408(
   in > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1650,7 +1582,7 @@ else=NullnessNoInitStore#450(
 o = Issue5174Sub.this.methodInner(in)   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 74:
-Before: NullnessNoInitStore#457(
+Before: NullnessNoInitStore#413(
   in > NV{, T, poly nn/n=f/f}
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1663,7 +1595,7 @@ Before: NullnessNoInitStore#457(
 90 -> 87
 
 89:
-Before: NullnessNoInitStore#468(
+Before: NullnessNoInitStore#424(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1671,7 +1603,7 @@ Before: NullnessNoInitStore#468(
 <entry>
 
 90:
-Before: NullnessNoInitStore#468(
+Before: NullnessNoInitStore#424(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1682,7 +1614,7 @@ o   [ VariableDeclaration ]
 o = (this).f   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 87:
-Before: NullnessNoInitStore#469(
+Before: NullnessNoInitStore#425(
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1703,7 +1635,7 @@ Before: NullnessNoInitStore#469(
 101 -> 92
 
 94:
-Before: NullnessNoInitStore#473(
+Before: NullnessNoInitStore#429(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1711,7 +1643,7 @@ Before: NullnessNoInitStore#473(
 <entry>
 
 95:
-Before: NullnessNoInitStore#473(
+Before: NullnessNoInitStore#429(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1719,7 +1651,7 @@ Before: NullnessNoInitStore#473(
 o   [ VariableDeclaration ]
 
 96:
-Before: NullnessNoInitStore#474(
+Before: NullnessNoInitStore#430(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1727,7 +1659,7 @@ Before: NullnessNoInitStore#474(
 Issue5174Sub   [ ClassName ]    > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
 
 98:
-Before: NullnessNoInitStore#475(
+Before: NullnessNoInitStore#431(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1735,7 +1667,7 @@ Before: NullnessNoInitStore#475(
 Issue5174Sub.this   [ FieldAccess ]    > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
 
 93:
-Before: NullnessNoInitStore#476(
+Before: NullnessNoInitStore#432(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1743,7 +1675,7 @@ Before: NullnessNoInitStore#476(
 <exceptional-exit>
 
 100:
-Before: NullnessNoInitStore#483(
+Before: NullnessNoInitStore#439(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1752,7 +1684,7 @@ Before: NullnessNoInitStore#483(
 Issue5174Sub.this.f   [ FieldAccess ]    > NV{, T, poly nn/n=f/f}
 
 101:
-Before: NullnessNoInitStore#486(
+Before: NullnessNoInitStore#442(
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1761,7 +1693,7 @@ Before: NullnessNoInitStore#486(
 o = Issue5174Sub.this.f   [ Assignment ]    > NV{, T, poly nn/n=f/f}
 
 92:
-Before: NullnessNoInitStore#489(
+Before: NullnessNoInitStore#445(
   o > NV{, T, poly nn/n=f/f}
   this > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
   Issue5174Sub.class > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
@@ -1791,7 +1723,7 @@ Before: NullnessNoInitStore#489(
 112 -> 103
 
 105:
-Before: NullnessNoInitStore#498(
+Before: NullnessNoInitStore#454(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1799,7 +1731,7 @@ Before: NullnessNoInitStore#498(
 <entry>
 
 106:
-Before: NullnessNoInitStore#498(
+Before: NullnessNoInitStore#454(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1808,7 +1740,7 @@ o   [ VariableDeclaration ]
 o   [ LocalVariable ]
 
 107:
-Before: NullnessNoInitStore#499(
+Before: NullnessNoInitStore#455(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1816,7 +1748,7 @@ Before: NullnessNoInitStore#499(
 Issue5174Super   [ ClassName ]
 
 108:
-Before: NullnessNoInitStore#500(
+Before: NullnessNoInitStore#456(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1827,7 +1759,7 @@ expression statement o = sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 104:
-Before: NullnessNoInitStore#501(
+Before: NullnessNoInitStore#457(
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
   isPolyNullNull = false)
@@ -1835,7 +1767,7 @@ Before: NullnessNoInitStore#501(
 <exceptional-exit>
 
 109:
-Before: NullnessNoInitStore#508(
+Before: NullnessNoInitStore#464(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1844,7 +1776,7 @@ Before: NullnessNoInitStore#508(
 Issue5174Sub   [ ClassName ]    > NV{@NonNull, Issue5174Sub, poly nn/n=f/f}
 
 110:
-Before: NullnessNoInitStore#509(
+Before: NullnessNoInitStore#465(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1856,7 +1788,7 @@ expression statement o = Issue5174Sub.sf   [ ExpressionStatement ]
 o   [ LocalVariable ]
 
 111:
-Before: NullnessNoInitStore#518(
+Before: NullnessNoInitStore#474(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1865,7 +1797,7 @@ Before: NullnessNoInitStore#518(
 Issue5174Super   [ ClassName ]    > NV{@NonNull, Issue5174Super, poly nn/n=f/f}
 
 112:
-Before: NullnessNoInitStore#519(
+Before: NullnessNoInitStore#475(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false
@@ -1876,7 +1808,7 @@ o = Issue5174Super.sf   [ Assignment ]    > NV{@NonNull, Object, poly nn/n=f/f}
 expression statement o = Issue5174Super.sf   [ ExpressionStatement ]
 
 103:
-Before: NullnessNoInitStore#528(
+Before: NullnessNoInitStore#484(
   o > NV{@NonNull, Object, poly nn/n=f/f}
   this > NV{@NonNull, SubNested, poly nn/n=f/f}
   isPolyNullNonNull = false

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -74,6 +74,7 @@ import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypesUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1159,14 +1160,18 @@ public abstract class CFAbstractTransfer<
         // add new information based on postcondition
         processPostconditions(n, store, method, invocationTree);
 
-        S thenStore = store;
-        S elseStore = thenStore.copy();
+        if (TypesUtils.isBooleanType(method.getReturnType())) {
+            S thenStore = store;
+            S elseStore = thenStore.copy();
 
-        // add new information based on conditional postcondition
-        processConditionalPostconditions(n, method, invocationTree, thenStore, elseStore);
+            // add new information based on conditional postcondition
+            processConditionalPostconditions(n, method, invocationTree, thenStore, elseStore);
 
-        return new ConditionalTransferResult<>(
-                finishValue(resValue, thenStore, elseStore), thenStore, elseStore);
+            return new ConditionalTransferResult<>(
+                    finishValue(resValue, thenStore, elseStore), thenStore, elseStore);
+        } else {
+            return new RegularTransferResult<>(finishValue(resValue, store), store);
+        }
     }
 
     @Override


### PR DESCRIPTION
In #1099, the optimization (applied in #259) is reverted because it causes test failure in #1097. This PR reapply this optimization and fix the problem that causes the test failure.

### Problem description:
The test failure happens when the `TransferResult` is regular when visiting a boolean expression. The checker refine one branch if one hand of the expression has a more detailed type (known to be non-empty or a special empty value like `o.size() != 0`). In some cases, the refinement is applied to `result.getElseStore()`, which is lost when `result` is regular (the refinement is applied to a copy that is not stored).

### Solution:
This PR fix this problem by adding a check in visit methods of boolean expressions. If `result` is regular, then turn it into conditional with same `ThenStore` and `ElseStore`. 

### Evaluation:
No test failure with this fix. Also looks into the same test case as in 2e14088. The store number also drops to 484. Additionally compared the number of stores drops from 2227 on master branch to 1676 after this fix, which is around 25% reduction.