### PR TITLE
Update troubleshooting.tex

### DIFF
--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -829,7 +829,7 @@ You might want to add an \<export CHECKERFRAMEWORK=...> line to your
 \<.bashrc> file.
 
 Ensure line endings are handled properly. If necessary, run
-\code{git config --global core.autocrlf true} to prevent line ending issues between
+\code{git config --global core.autocrlf true} on Windows to prevent line ending issues between
 Windows and Unix-based systems.
 
 \subsectionAndLabel{Build the Checker Framework}{building}


### PR DESCRIPTION
I believe this command: ``git config --global core.autocrlf`` true should only be used on Windows. I got confused by this so I thought it would be a good idea to be more explicit. 

Thanks for reviewing.