### PR TITLE
`@AnnotatedFor` runtime retention

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
+++ b/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #compiling-libraries Compiling partially-annotated libraries
  */
 @Documented
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
 public @interface AnnotatedFor {
     /**

--- a/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
+++ b/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
  * using it in a fully-annotated library nor in an application that does not export APIs for
  * clients.
  *
- * <p>This annotation has no effect unless the {@code
+ * <p>This annotation is retained in bytecode but has no effect unless the {@code
  * -AuseConservativeDefaultsForUncheckedCode=source} command-line argument is supplied. Ordinarily,
  * the {@code -AuseConservativeDefaultsForUncheckedCode=source} command-line argument causes
  * unannotated locations to be defaulted using conservative defaults, and it suppresses all

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,13 +38,15 @@ The Nullness Checker now recognizes references to private, final fields with zer
 
 The `ClassBound` annotation can now be used with anonymous types.
 
+The `AnnotatedFor` annotation is now retained in bytecode.
+
 **Implementation details:**
 
 The `AbstractNodeVisitor` now has more summary methods, following the class hierarchy of `Node` and conceptual categories.
 
 **Closed issues:**
 
-eisop#1247, eisop#1263, eisop#1310, typetools#7096.
+eisop#1247, eisop#1263, eisop#1310, eisop#1481, typetools#7096.
 
 
 Version 3.49.5 (June 30, 2025)

--- a/docs/manual/annotating-libraries.tex
+++ b/docs/manual/annotating-libraries.tex
@@ -390,7 +390,7 @@ but does not change the default qualifiers for source code (See Section~\ref{aon
 
 The \refqualclass{framework/qual}{AnnotatedFor} annotation, written on a
 class, indicates that the class has been annotated for certain type
-systems.  For example, \<@AnnotatedFor(\ttlcb"nullness", "regex"\ttrcb)> means that
+systems. This annotation will be retained in bytecode. For example, \<@AnnotatedFor(\ttlcb"nullness", "regex"\ttrcb)> means that
 the programmer has written annotations for the Nullness and Regular
 Expression type systems.  If one of those two type-checkers is run,
 the \<-AuseConservativeDefaultsForUncheckedCode=source,bytecode> command-line argument

--- a/docs/manual/faq.tex
+++ b/docs/manual/faq.tex
@@ -1612,9 +1612,9 @@ polymorphism, see \chapterpageref{polymorphism}.
 
 \subsectionAndLabel{Why are type annotations declared with \<@Retention(RetentionPolicy.RUNTIME)>?}{faq-runtime-retention}
 
-Annotations such as \refqualclass{checker/nullness/qual}{NonNull} are
-declared with
-\<\sunjavadocanno{java.base/java/lang/annotation/Retention.html}{Retention}(RetentionPolicy.\sunjavadoc{java.base/java/lang/annotation/RetentionPolicy.html\#RUNTIME}{RUNTIME})>.  In other words,
+Annotations such as \refqualclass{checker/nullness/qual}{NonNull}
+and \refqualclass{framework/qual}{AnnotatedFor} are declared with
+\<\sunjavadocanno{java.base/java/lang/annotation/Retention.html}{Retention}(RetentionPolicy.\sunjavadoc{java.base/java/lang/annotation/RetentionPolicy.html\#RUNTIME}{RUNTIME})>. In other words,
 these type annotations are available to tools at run time.  Such run-time
 tools could check the annotations (like an \<assert> statement), type-check
 dynamically-loaded code, check casts and \<instanceof> operations, resolve


### PR DESCRIPTION
**Summary:** Fixes #1481.This PR changes the retention policy of the `@AnnotatedFor` annotation from SOURCE to RUNTIME. See Issue #1481 for motivation details.

**Documentation Note:** The documentation update for this change is intentionally minimal as this change on its own is small. However, when the overarching retention policy for type-use annotations is implemented, we may want to consider a new section with further discussion. 