### PR TITLE
`-XDaddTypeAnnotationsToSymbol=true` is no longer needed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -607,12 +607,6 @@ allprojects { currentProj ->
                     // '-XepPatchChecks:EffectivelyPrivate',
                     // '-XepPatchLocation:IN_PLACE',
                 ]
-                if (useJdkVersionInt == 21) {
-                    options.compilerArgs += [
-                        // Required on JDK 21 starting with Error Prone 2.46.0
-                        '-XDaddTypeAnnotationsToSymbol=true'
-                    ]
-                }
 
                 if (compilationTask.name.equals('compileTestJava')) {
                     options.errorprone.errorproneArgs.addAll([


### PR DESCRIPTION
gradle-errorprone-plugin 4.4.0 adds it automatically