### PR TITLE
Use fixed bazel version 8.5.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         java_version: [21]
     env:
       JAVA_VERSION: ${{ matrix.java_version }}
+      USE_BAZEL_VERSION: "8.5.1"
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.java_version }}
@@ -177,6 +178,7 @@ jobs:
 
     env:
       JAVA_VERSION: ${{ matrix.java.version }}
+      USE_BAZEL_VERSION: "8.5.1"
     continue-on-error: ${{ matrix.java.experimental }}
     steps:
     - name: Check out sources


### PR DESCRIPTION
fixes #1500 

Moves the USE_BAZEL_VERSION environment variable to the Job scope.

Previously, this variable was defined within a single step, causing it to go out of scope before the test runner executed. This resulted in bazelisk ignoring the pinned version and using Bazel 9.0.0 (which is currently incompatible).

By scoping it to the job level, the variable persists across all steps, ensuring the tests run with Bazel 8.5.1 as intended.