### PR TITLE
Configure Renovate to correctly detect and update JDK EA builds

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,5 +41,6 @@
       "versioningTemplate": "loose",
       "depNameTemplate": "adoptium/temurin{{{major}}}-binaries",
       "extractVersionTemplate": "^jdk-\\d+\\+(?<version>\\d+)"
-    }  ]
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #1514. (again)

This PR updates the Renovate configuration to correctly handle JDK EA build updates

Changes:

1) Set `ignoreUnstable`: false for adoptium/temurin*-binaries.
Adoptium tags EA builds as "Pre-release". By default, Renovate ignores these versions unless explicitly allowed (see [Renovate Docs: ignoreUnstable](https://docs.renovatebot.com/configuration-options/#ignoreunstable)).

2) Switch to `github-releases` Datasource
The `github-releases` datasource provides the explicit "Pre-release" metadata flag from the API.

3) Set `versioningTemplate`: "loose".
We use an integer (e.g., 16) in `ci.yml` for EA build versions. Loose versioning allows SemVer strings (e.g., 33.0.0) to compare correctly against non-SemVer values (see [Renovate Docs: loose versioning](https://docs.renovatebot.com/modules/versioning/loose/))

Also loosened regex to allow for some whitespace.

These changes have been verified on a fork, where Renovate successfully generated a pull request: https://github.com/thisisalexandercook/checker-framework/pull/19