### PR TITLE
Modify requireJavadoc task to exclude module-info.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -809,7 +809,9 @@ task requireJavadoc(type: JavaExec, group: 'Documentation') {
     // Convert each srcDir to its absolute path and flatten the list.
     // require-javadoc 2.0.0 throws an Error for module-info.java (which has no package declaration).
     // Exclude module-info.java to avoid this crash.
-    args(['--exclude=module-info\\.java'] + requireJavadocDirs.collect { it.srcDirs*.absolutePath }.flatten())
+    args([
+        '--exclude=module-info\\.java'
+    ] + requireJavadocDirs.collect { it.srcDirs*.absolutePath }.flatten())
     jvmArgs += [
         '--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED',
         '--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED',


### PR DESCRIPTION
After merging https://github.com/eisop-plume-lib/plume-scripts/pull/12 the CI `misc` task started failing with:

```
+ /home/runner/work/checker-framework/checker-framework/checker/bin-devel/.plume-scripts/lint-diff.py --guess-strip /tmp/diff-plYkwK.txt /tmp/warnings-requireJavadoc.txt
Error: Exception in thread "main" java.lang.Error: null package for /home/runner/work/checker-framework/checker-framework/checker-qual/src/main/java/module-info.java
	at org.plumelib.javadoc.RequireJavadoc$RequireJavadocVisitor.visitTopLevel(RequireJavadoc.java:744)
	at org.plumelib.javadoc.RequireJavadoc.main(RequireJavadoc.java:202)
+ status=1
```

It looks like `./gradlew requireJavadoc` has been failing with this error for a while, but the scripts ignored such errors.

There are changes in https://github.com/eisop-plume-lib/require-javadoc/pull/133 that look like they are avoiding this error, but there was no new release of that artifact.

Let's see whether ignoring `module-info.java` fixes the issue.