### PR TITLE
CI: run other JDK tests only after JDK 21 passed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
   otherjdks:
     name: ${{ matrix.script }} on JDK ${{ matrix.java.version }}
     runs-on: ubuntu-24.04
-    needs: sanity
+    needs: remainder
     permissions:
       contents: read
     env:


### PR DESCRIPTION
This will delay the start of the other JDK tests a bit, by first making sure all JDK 21 tests pass.
But this should avoid doing lots of meaningless work if there is a failure on JDK 21.