### PR TITLE
CI: disable fail-fast for `remainder` jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
     permissions:
       contents: read
     strategy:
-      fail-fast: true
+      # Run all `remainder` tasks, even if one fails.
+      fail-fast: false
       matrix:
         # No need to run 'cftests-junit-jdk21' on JDK 21.
         script: ['typecheck-part1', 'typecheck-part2',


### PR DESCRIPTION
`misc` failures frequently block interesting feedback from other tasks.
Run all of them to get more feedback from one commit.