### PR TITLE
Handle more elements when determining source code

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3883,7 +3883,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             return ((DetachedVarSymbol) elt).getDeclaration();
         }
 
-        // TODO: handle type parameter declarations?
         Tree fromElt;
         // Prevent calling declarationFor on elements we know we don't have the tree for.
 
@@ -3897,6 +3896,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             case METHOD:
             case CONSTRUCTOR:
             case PARAMETER:
+            case TYPE_PARAMETER:
                 fromElt = trees.getTree(elt);
                 break;
             default:


### PR DESCRIPTION
Test whether this sub-set of changes from #1556 fixes #1536.

The reasoning from copilot is that the order of files during compilation might be different between Ubuntu 22.04 and 24.04.
For a method parameter with wildcards, this might result in different types, depending on whether the element or tree are used.

Ideally, we'll come up with a minimized test case and jtreg tests that reproduce the issue.