### PR TITLE
Do not ignore variable use in assignment lhs for liveness

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/livevariable/LiveVarTransfer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/livevariable/LiveVarTransfer.java
@@ -8,6 +8,7 @@ import org.checkerframework.dataflow.analysis.UnusedAbstractValue;
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.dataflow.cfg.node.AbstractNodeVisitor;
 import org.checkerframework.dataflow.cfg.node.AssignmentNode;
+import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
@@ -106,6 +107,9 @@ public class LiveVarTransfer
      * @param store the live variable store
      */
     private void processLiveVarInAssignment(Node variable, Node expression, LiveVarStore store) {
+        if (!(variable instanceof LocalVariableNode)) {
+            store.addUseInExpression(variable);
+        }
         store.killLiveVar(new LiveVarNode(variable));
         store.addUseInExpression(expression);
     }


### PR DESCRIPTION
Currently in
```java
var abc = new A();
abc.copy().x = 3;
```
`abc` is not counted as live.