### PR TITLE
Test case for `Pattern.pattern` and `Pattern.toString`

### DIFF
--- a/checker/tests/regex/PatternRegexes.java
+++ b/checker/tests/regex/PatternRegexes.java
@@ -1,0 +1,35 @@
+// Test case for typetools issue #7539:
+// https://github.com/typetools/checker-framework/issues/7539
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PatternRegexes {
+    void simple() {
+        Pattern abc = Pattern.compile("abc");
+        String str = abc.pattern();
+        System.out.println("abc".replaceAll(str, ""));
+    }
+
+    void complex(String content) {
+        Pattern g2 = Pattern.compile("a(b*)(c*)");
+        String strPattern = g2.pattern();
+        Pattern g2Pattern = Pattern.compile(strPattern);
+        Matcher matPattern = g2Pattern.matcher(content);
+
+        if (matPattern.matches()) {
+            matPattern.group(2); // ok
+            // :: error: (group.count.invalid)
+            matPattern.group(3);
+        }
+
+        String strToString = g2.toString();
+        Pattern g2ToString = Pattern.compile(strToString);
+        Matcher matToString = g2ToString.matcher(content);
+        if (matToString.matches()) {
+            matToString.group(2); // ok
+            // :: error: (group.count.invalid)
+            matToString.group(3);
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,7 +53,7 @@ Removed method `InitializationParentAnnotatedTypeFactory.createUnderInitializati
 
 **Closed issues:**
 
-eisop#1247, eisop#1263, eisop#1310, eisop#1326, typetools#7096, eisop#1448, eisop#1543.
+eisop#1247, eisop#1263, eisop#1310, eisop#1326, typetools#7096, eisop#1448, eisop#1543, typetools#7539.
 
 
 Version 3.49.5 (June 30, 2025)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -86,10 +86,10 @@ instead.
 
 **Closed issues:**
 
-typetools#7096, typetools#7539, eisop#1099, eisop#1219, eisop#1225, eisop#1231, eisop#1242,
-eisop#1247, eisop#1257, eisop#1263, eisop#1265, eisop#1272, eisop#1310,
-eisop#1326, eisop#1444, eisop#1448, eisop#1500, eisop#1506, eisop#1536,
-eisop#1543, eisop#1565.
+typetools#7096, typetools#7539, eisop#1099, eisop#1219, eisop#1225, eisop#1231,
+eisop#1242, eisop#1247, eisop#1257, eisop#1263, eisop#1265, eisop#1272,
+eisop#1310, eisop#1326, eisop#1444, eisop#1448, eisop#1500, eisop#1506,
+eisop#1536, eisop#1543, eisop#1565.
 
 
 Version 3.49.5 (June 30, 2025)


### PR DESCRIPTION
Merge with https://github.com/eisop/jdk/pull/132

Fixes typetools issue 7539 properly by using `PolyRegex` on the return and receiver types.
This preserves the regex information, instead of over-approximating it as `@Regex`.