### PR TITLE
Pin JDK 27 EA build and restore Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,17 @@
       "matchStrings": ["USE_BAZEL_VERSION: \"(?<currentValue>.*?)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "bazelbuild/bazel"
+    },
+    {
+      "description": "Update JDK_EA_BUILD in GitHub Actions",
+      "fileMatch": ["^\\.github/workflows/ci\\.yml$"],
+      "matchStrings": [
+        "JDK_EA_MAJOR:\\s+\"(?<major>\\d+)\"[\\s\\S]*?JDK_EA_BUILD:\\s+\"(?<currentValue>\\d+)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "openjdk/jdk",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^jdk-{{{major}}}\\+(?<version>\\d+)$"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
       JAVA_VERSION: ${{ matrix.java.version }}
       USE_BAZEL_VERSION: "9.0.1"
       JDK_EA_MAJOR: "27"
+      JDK_EA_BUILD: "15"
     strategy:
       fail-fast: true
       matrix:
@@ -217,7 +218,8 @@ jobs:
       with:
         # Install the requested EA JDK second, to make it the default on which everything else runs.
         website: jdk.java.net
-        release: ${{ matrix.java.version }}
+        release: ${{ env.JDK_EA_MAJOR }}
+        version: ${{ format('{0}-ea+{1}', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
       run: mkdir -p ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 


### PR DESCRIPTION
This PR explicitly pins the Oracle EA setup in CI to `27-ea+15` and restores the Renovate automation for `JDK_EA_BUILD`.

I validated both pieces on my fork [here](https://github.com/thisisalexandercook/checker-framework/pull/27) CI passed with the pinned setup, and when I temporarily downgraded the EA build to `14`, Renovate correctly detected that `15` is the latest matching tag and queued an update.

Oracle’s action supports `version: latest`, but I think keeping the build explicit is preferable. It makes the tested EA build visible in the workflow and ensures new EA bumps arrive as separate PRs, so we can catch breakage before updating mainline CI.

With this setup, Renovate handles EA build bumps through PRs, which can be merged once CI passes. And moving to a new EA major version remains a manual change, for example from `26` to `27`. This should mirror previous temurin workflow. 

