### PR TITLE
CI: pin JDK 27 EA builds by direct URI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,10 @@ jobs:
       if: ${{ matrix.java.version == 'EA' }}
       uses: oracle-actions/setup-java@v1
       with:
+        # Install the requested EA JDK second, to make it the default on which everything else runs.
         # Pin EA builds by direct archive URI.
+        # If the URI stops working, check for the updated pattern here:
+        # https://github.com/oracle-actions/setup-java/blob/main/jdk.java.net-uri.properties
         uri: ${{ format('https://download.java.net/java/early_access/jdk{0}/{1}/GPL/openjdk-{0}-ea+{1}_linux-x64_bin.tar.gz', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
         install-as-version: ${{ env.JDK_EA_MAJOR }}
     - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle


### PR DESCRIPTION
This updates the JDK 27 EA setup in CI to install from a direct archive URI instead of using `oracle-actions/setup-java`'s `release`/`version` resolver as first suggested [here](https://github.com/eisop/checker-framework/pull/1617#issuecomment-4185371046).

The current resolver path depends on Oracle's moving `jdk.java.net-uri.properties` mapping, which can drop older EA builds even when the underlying archive is still available. Pinning the tarball URI should keep the workflow stable for a known-good EA build while preserving the  Renovate flow for `JDK_EA_BUILD` updates.