### PR TITLE
CI: cleanup early-access builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,15 @@ jobs:
         # JDK 21 used by `sanity` and `remainder` before.
         # Keep all LTS versions and the newest non-LTS version.
         # `experimental` versions use the $version compiler, but run on JDK 21.
-        java: [{version: '8', experimental: false},
-          {version: '11', experimental: false},
-          {version: '17', experimental: false},
-          {version: '25', experimental: false},
-          {version: '26', experimental: false},
-          {version: env.JDK_EA_MAJOR, experimental: true}]
+        java:
+          - {version: '8', experimental: false}
+          - {version: '11', experimental: false}
+          - {version: '17', experimental: false}
+          - {version: '25', experimental: false}
+          - {version: '26', experimental: false}
+          # Keep in sync with env.JDK_EA_MAJOR above.
+          # env context is not available in strategy.matrix, so the version is hard-coded here.
+          - {version: '27', experimental: true}
         exclude:
           # JDK 8 does not allow toolchains, so testing 'cftests-junit-jdk21' is unnecessary.
           - script: 'cftests-junit-jdk21'


### PR DESCRIPTION
- [x] Fix `env.JDK_EA_MAJOR` literal string in matrix definition (GitHub Actions `env` context is not available in `strategy.matrix`)
- [x] Switch `java` matrix list to block YAML style for clarity
- [x] Hard-code `'27'` in the matrix entry with a comment to keep it in sync with `env.JDK_EA_MAJOR`