### PR TITLE
Clear SubtypeVisitHistory to avoid huge caches that slow down checking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@ Version 3.49.5-eisop1 (July ??, 2025)
 
 **User-visible changes:**
 
+Considerable performance improvements. In a large project (over 4000 .java files) with
+complex qualifiers, compilation time was reduced from around 30 minutes to around 11 minutes.
+
 The new command-line option `-AonlyAnnotatedFor` suppresses all type-checking errors and warnings outside the scope of
 a corresponding `@AnnotatedFor` annotation.
 Note that the `@AnnotatedFor` annotation must include the checker's name to enable warnings from that checker.

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -124,6 +124,15 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     }
 
     /**
+     * Tracks re-entrant calls to {@link #isSubtype(AnnotatedTypeMirror, AnnotatedTypeMirror)}. The
+     * visit histories are cleared only when this counter transitions from 1 to 0, i.e. at the end
+     * of a true outermost entry. {@link #isContainedWithinBounds} internally invokes the public
+     * 2-arg method, so a clear-on-every-entry would wipe the history mid-check and destroy cycle
+     * detection for recursive wildcard bounds.
+     */
+    private int isSubtypeDepth = 0;
+
+    /**
      * Returns true if subtype {@literal <:} supertype.
      *
      * <p>This implementation iterates over all top annotations and invokes {@link
@@ -137,13 +146,23 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
      */
     @Override
     public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype) {
-        for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
-            if (!isSubtype(subtype, supertype, top)) {
-                return false;
+        isSubtypeDepth++;
+        try {
+            for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
+                if (!isSubtype(subtype, supertype, top)) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            isSubtypeDepth--;
+
+            // Bound the lifetime of the visit histories to a single top-level check.
+            if (isSubtypeDepth == 0) {
+                isSubtypeVisitHistory.clear();
+                areEqualVisitHistory.clear();
             }
         }
-
-        return true;
     }
 
     /** A set of annotations and a {@link TypeMirror}. */

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -127,7 +127,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
      * Tracks re-entrant calls to {@link #isSubtype(AnnotatedTypeMirror, AnnotatedTypeMirror)}. The
      * visit histories are cleared only when this counter transitions from 1 to 0, i.e. at the end
      * of a true outermost entry. {@link #isContainedWithinBounds} internally invokes the public
-     * 2-arg method, so a clear-on-every-entry would wipe the history mid-check and destroy cycle
+     * 2-arg method, so a clear-on-every-exit would wipe the history mid-check and destroy cycle
      * detection for recursive wildcard bounds.
      */
     private int isSubtypeDepth = 0;

--- a/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
@@ -32,8 +32,8 @@ public class StructuralEqualityVisitHistory {
     }
 
     /**
-     * Removes all entries from both inner histories. Called at the start of each top-level subtype
-     * check to bound memory.
+     * Removes all entries from both inner histories. Called between top-level subtype checks to
+     * bound memory.
      */
     public void clear() {
         trueHistory.clear();

--- a/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
@@ -32,6 +32,15 @@ public class StructuralEqualityVisitHistory {
     }
 
     /**
+     * Removes all entries from both inner histories. Called at the start of each top-level subtype
+     * check to bound memory.
+     */
+    public void clear() {
+        trueHistory.clear();
+        falseHistory.clear();
+    }
+
+    /**
      * Put result of comparing {@code type1} and {@code type2} for structural equality for the given
      * hierarchy.
      *

--- a/framework/src/main/java/org/checkerframework/framework/type/SubtypeVisitHistory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SubtypeVisitHistory.java
@@ -37,9 +37,10 @@ public class SubtypeVisitHistory {
     }
 
     /**
-     * Removes all entries. Must be called at the start of each top-level subtype check so the map
-     * does not grow unboundedly across a compilation. Clearing is safe because the history is only
-     * needed to break cycles within a single subtype check, not across independent checks.
+     * Removes all entries. Must be called once per top-level subtype check (for example, between
+     * independent top-level subtype checks) so the map does not grow unboundedly across a
+     * compilation. Clearing is safe because the history is only needed to break cycles within a
+     * single subtype check, not across independent checks.
      */
     public void clear() {
         visited.clear();

--- a/framework/src/main/java/org/checkerframework/framework/type/SubtypeVisitHistory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SubtypeVisitHistory.java
@@ -23,7 +23,6 @@ import javax.lang.model.element.AnnotationMirror;
  * Serializable<T>} and {@code @C Serializable<?>}, then isSubtype is first called one those types
  * and then on {@code @B Serializable<T>} and {@code @C Serializable<?>}.
  */
-// TODO: do we need to clear the history sometimes?
 public class SubtypeVisitHistory {
 
     /**
@@ -35,6 +34,15 @@ public class SubtypeVisitHistory {
     /** Creates a new SubtypeVisitHistory. */
     public SubtypeVisitHistory() {
         this.visited = new HashMap<>();
+    }
+
+    /**
+     * Removes all entries. Must be called at the start of each top-level subtype check so the map
+     * does not grow unboundedly across a compilation. Clearing is safe because the history is only
+     * needed to break cycles within a single subtype check, not across independent checks.
+     */
+    public void clear() {
+        visited.clear();
     }
 
     /**


### PR DESCRIPTION
This came from profiling and several failed attempts with Claude. This final version achieves a speedup from 30 minutes to 11 minutes in a large benchmark.