### PR TITLE
Guard an `IdentityHashMap.clear()` call with `isEmpty()`

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
@@ -33,7 +33,11 @@ public abstract class EquivalentAtmComboScanner<RETURN_TYPE, PARAM>
     /** Entry point for this scanner. */
     @Override
     public RETURN_TYPE visit(AnnotatedTypeMirror type1, AnnotatedTypeMirror type2, PARAM param) {
-        visited.clear();
+        // Avoid the cost of IdentityHashMap.clear() when the map is already empty, which is the
+        // common case for top-level equality checks on simple types.
+        if (!visited.isEmpty()) {
+            visited.clear();
+        }
         return scan(type1, type2, param);
     }
 
@@ -212,6 +216,11 @@ public abstract class EquivalentAtmComboScanner<RETURN_TYPE, PARAM>
         private final IdentityHashMap<
                         AnnotatedTypeMirror, IdentityHashMap<AnnotatedTypeMirror, RETURN_TYPE>>
                 visits = new IdentityHashMap<>();
+
+        /** Returns true if no pairs have been recorded. */
+        public boolean isEmpty() {
+            return visits.isEmpty();
+        }
 
         public void clear() {
             visits.clear();

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
@@ -213,6 +213,9 @@ public abstract class EquivalentAtmComboScanner<RETURN_TYPE, PARAM>
      */
     protected class Visited {
 
+        /** Default constructor. */
+        Visited() {}
+
         /** The backing history of type pairs. */
         private final IdentityHashMap<
                         AnnotatedTypeMirror, IdentityHashMap<AnnotatedTypeMirror, RETURN_TYPE>>

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
@@ -213,15 +213,21 @@ public abstract class EquivalentAtmComboScanner<RETURN_TYPE, PARAM>
      */
     protected class Visited {
 
+        /** The backing history of type pairs. */
         private final IdentityHashMap<
                         AnnotatedTypeMirror, IdentityHashMap<AnnotatedTypeMirror, RETURN_TYPE>>
                 visits = new IdentityHashMap<>();
 
-        /** Returns true if no pairs have been recorded. */
+        /**
+         * Returns true if no pairs have been recorded.
+         *
+         * @return true if no pairs have been recorded
+         */
         public boolean isEmpty() {
             return visits.isEmpty();
         }
 
+        /** Clears the history. */
         public void clear() {
             visits.clear();
         }


### PR DESCRIPTION
In a large project with 4000 .java files, this reduced compilation time from ~30 to ~27 minutes, so roughly a 10% micro-optimisation.