### PR TITLE
Several smaller performance optimizations

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
@@ -67,7 +67,7 @@ public abstract class AbstractViewpointAdapter implements ViewpointAdapter {
 
         AnnotatedTypeMirror decltype = atypeFactory.getAnnotatedType(memberElement);
         AnnotatedTypeMirror combinedType = combineTypeWithType(receiverType, decltype);
-        memberType.replaceAnnotations(combinedType.getAnnotations());
+        memberType.replaceAnnotations(combinedType.getAnnotationsField());
         if (memberType.getKind() == TypeKind.DECLARED
                 && combinedType.getKind() == TypeKind.DECLARED) {
             AnnotatedDeclaredType adtType = (AnnotatedDeclaredType) memberType;

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3023,11 +3023,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 p.addAll(superCon.getParameterTypes());
                 con.setParameterTypes(Collections.unmodifiableList(p));
             }
-            Set<? extends AnnotationMirror> lub =
+            AnnotationMirrorSet lub =
+                    // TODO: should we use getAnnotationsField() even though it flows to the
+                    // QualifierHierarchy?
                     qualHierarchy.leastUpperBoundsShallow(
-                            type.getAnnotationsField(),
+                            type.getAnnotations(),
                             type.getUnderlyingType(),
-                            superCon.getReturnType().getAnnotationsField(),
+                            superCon.getReturnType().getAnnotations(),
                             superCon.getReturnType().getUnderlyingType());
             con.getReturnType().replaceAnnotations(lub);
         } else {

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -599,9 +599,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             this.fromTypeTreeCache = CollectionsPlume.createLruCache(cacheSize);
             this.elementCache = CollectionsPlume.createLruCache(cacheSize);
             this.elementToTreeCache = CollectionsPlume.createLruCache(cacheSize);
-            this.annotationClassNames =
-                    Collections.synchronizedMap(
-                            CollectionsPlume.createLruCache(ANNOTATION_CACHE_SIZE));
+            this.annotationClassNames = CollectionsPlume.createLruCache(ANNOTATION_CACHE_SIZE);
         } else {
             this.classAndMethodTreeCache = null;
             this.fromExpressionTreeCache = null;

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2555,7 +2555,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 // (See call to addDefaultAnnotations below.)
                 t.clearAnnotations();
             } else {
-                t.replaceAnnotations(wildcard.getExtendsBound().getAnnotations());
+                t.replaceAnnotations(wildcard.getExtendsBound().getAnnotationsField());
             }
             wildcard.setExtendsBound(t);
             addDefaultAnnotations(wildcard);
@@ -2926,7 +2926,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             // instead.
             AnnotatedTypeMirror re = constructorType.getReturnType().deepCopy(false);
             re.clearAnnotations();
-            re.addAnnotations(constructorReturnType.getAnnotations());
+            re.addAnnotations(constructorReturnType.getAnnotationsField());
             constructorReturnType = re;
         }
 
@@ -3025,9 +3025,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             }
             Set<? extends AnnotationMirror> lub =
                     qualHierarchy.leastUpperBoundsShallow(
-                            type.getAnnotations(),
+                            type.getAnnotationsField(),
                             type.getUnderlyingType(),
-                            superCon.getReturnType().getAnnotations(),
+                            superCon.getReturnType().getAnnotationsField(),
                             superCon.getReturnType().getUnderlyingType());
             con.getReturnType().replaceAnnotations(lub);
         } else {
@@ -3201,7 +3201,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     public AnnotatedDeclaredType getBoxedType(AnnotatedPrimitiveType type) {
         TypeElement typeElt = types.boxedClass(type.getUnderlyingType());
         AnnotatedDeclaredType dt = fromElement(typeElt).asUse();
-        dt.addAnnotations(type.getAnnotations());
+        dt.addAnnotations(type.getAnnotationsField());
         return dt;
     }
 
@@ -3241,7 +3241,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         PrimitiveType primitiveType = types.unboxedType(type.getUnderlyingType());
         AnnotatedPrimitiveType pt =
                 (AnnotatedPrimitiveType) AnnotatedTypeMirror.createType(primitiveType, this, false);
-        pt.addAnnotations(type.getAnnotations());
+        pt.addAnnotations(type.getAnnotationsField());
         return pt;
     }
 
@@ -3343,6 +3343,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                         AnnotatedTypeMirror.createType(
                                 widenedTypeMirror, this, type.isDeclaration());
         result.addAnnotations(
+                // TODO: would it be safe to use type.getAnnotationsField()? Subclass could override
+                // getWidenedAnnotations and modify the set.
                 getWidenedAnnotations(type.getAnnotations(), type.getKind(), result.getKind()));
         return result;
     }
@@ -3484,7 +3486,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 (AnnotatedPrimitiveType)
                         AnnotatedTypeMirror.createType(
                                 narrowedTypeMirror, this, type.isDeclaration());
-        narrowed.addAnnotations(type.getAnnotations());
+        narrowed.addAnnotations(type.getAnnotationsField());
         return narrowed;
     }
 
@@ -4522,7 +4524,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             Element element, Class<? extends Annotation> metaAnnotationClass) {
         AnnotationMirrorSet annotationMirrors = new AnnotationMirrorSet();
         // Consider real annotations.
-        annotationMirrors.addAll(getAnnotatedType(element).getAnnotations());
+        annotationMirrors.addAll(getAnnotatedType(element).getAnnotationsField());
         // Consider declaration annotations
         annotationMirrors.addAll(getDeclAnnotations(element));
 
@@ -5076,13 +5078,15 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                         newArgAsTypeVar
                                 .getUpperBound()
                                 .replaceAnnotations(
-                                        wildcardType.getExtendsBound().getAnnotations());
+                                        wildcardType.getExtendsBound().getAnnotationsField());
                         newArgAsTypeVar
                                 .getLowerBound()
-                                .replaceAnnotations(wildcardType.getSuperBound().getAnnotations());
+                                .replaceAnnotations(
+                                        wildcardType.getSuperBound().getAnnotationsField());
                     } else {
                         newArg = this.toAnnotatedType(correctArgType, false);
-                        newArg.replaceAnnotations(wildcardType.getExtendsBound().getAnnotations());
+                        newArg.replaceAnnotations(
+                                wildcardType.getExtendsBound().getAnnotationsField());
                     }
 
                     typeVarToTypeArg.put(typeVariable, newArg);
@@ -5104,7 +5108,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         groundFunctionalType =
                 (AnnotatedDeclaredType)
                         getTypeVarSubstitutor().substitute(typeVarToTypeArg, groundFunctionalType);
-        groundFunctionalType.addAnnotations(functionalType.getAnnotations());
+        groundFunctionalType.addAnnotations(functionalType.getAnnotationsField());
 
         // When the groundTargetJavaType is different from the underlying type of functionalType,
         // only the main annotations are copied.  Add default annotations in places without
@@ -5323,7 +5327,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         }
 
         capturedType.setTypeArguments(newTypeArgs);
-        capturedType.addAnnotations(uncapturedType.getAnnotations());
+        capturedType.addAnnotations(uncapturedType.getAnnotationsField());
         return capturedType;
     }
 
@@ -5529,8 +5533,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // Add as a primary annotation any qualifiers that are the same on the upper and lower
         // bound.
         AnnotationMirrorSet p =
-                new AnnotationMirrorSet(capturedTypeVar.getUpperBound().getAnnotations());
-        p.retainAll(capturedTypeVar.getLowerBound().getAnnotations());
+                new AnnotationMirrorSet(capturedTypeVar.getUpperBound().getAnnotationsField());
+        p.retainAll(capturedTypeVar.getLowerBound().getAnnotationsField());
         capturedTypeVar.replaceAnnotations(p);
 
         capturedTypeVarSubstitutor.substitute(capturedTypeVar, capturedTypeVarToAnnotatedTypeVar);
@@ -5995,7 +5999,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
               || !otherConditionMap.containsKey(expr)) {
             // `otherInferredType` was inferred to be the top type.
             // Put the top type on `inferredType`.
-            inferredType.replaceAnnotations(declaredType.getAnnotations());
+            inferredType.replaceAnnotations(declaredType.getAnnotationsField());
           } else {
             AnnotatedTypeMirror otherInferredType =
                 isPrecondition

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3023,7 +3023,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 p.addAll(superCon.getParameterTypes());
                 con.setParameterTypes(Collections.unmodifiableList(p));
             }
-            AnnotationMirrorSet lub =
+            Set<? extends AnnotationMirror> lub =
                     // TODO: should we use getAnnotationsField() even though it flows to the
                     // QualifierHierarchy?
                     qualHierarchy.leastUpperBoundsShallow(

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1203,11 +1203,11 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
                                     atypeFactory.types.erasure(underlyingType),
                                     atypeFactory,
                                     false);
-            erased.addAnnotations(this.getAnnotations());
+            erased.addAnnotations(this.getAnnotationsField());
             AnnotatedDeclaredType erasedEnclosing = erased.getEnclosingType();
             AnnotatedDeclaredType thisEnclosing = this.getEnclosingType();
             while (erasedEnclosing != null) {
-                erasedEnclosing.addAnnotations(thisEnclosing.getAnnotations());
+                erasedEnclosing.addAnnotations(thisEnclosing.getAnnotationsField());
                 erasedEnclosing = erasedEnclosing.getEnclosingType();
                 thisEnclosing = thisEnclosing.getEnclosingType();
             }
@@ -2636,7 +2636,7 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         public void copyIntersectionBoundAnnotations() {
             AnnotationMirrorSet annos = new AnnotationMirrorSet();
             for (AnnotatedTypeMirror bound : getBounds()) {
-                for (AnnotationMirror a : bound.getAnnotations()) {
+                for (AnnotationMirror a : bound.getAnnotationsField()) {
                     if (atypeFactory.getQualifierHierarchy().findAnnotationInSameHierarchy(annos, a)
                             == null) {
                         annos.add(a);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
@@ -74,7 +74,7 @@ public class AnnotatedTypeReplacer extends DoubleAnnotatedTypeScanner<Void> {
      */
     protected void replaceAnnotations(AnnotatedTypeMirror from, AnnotatedTypeMirror to) {
         if (top == null) {
-            to.replaceAnnotations(from.getAnnotations());
+            to.replaceAnnotations(from.getAnnotationsField());
         } else {
             AnnotationMirror replacement = from.getAnnotationInHierarchy(top);
             if (replacement != null) {
@@ -111,7 +111,7 @@ public class AnnotatedTypeReplacer extends DoubleAnnotatedTypeScanner<Void> {
                 }
             } else {
                 List<AnnotationMirror> toRemove = new ArrayList<>(1);
-                for (AnnotationMirror toPrimaryAnno : to.getAnnotations()) {
+                for (AnnotationMirror toPrimaryAnno : to.getAnnotationsField()) {
                     if (from.getAnnotationInHierarchy(toPrimaryAnno) == null) {
                         // Doing the removal here directly can lead to a
                         // ConcurrentModificationException,

--- a/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
@@ -122,7 +122,7 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
             AnnotationMirrorSet lubs = null;
             for (AnnotatedDeclaredType altern : annotatedUnionType.getAlternatives()) {
                 if (lubs == null) {
-                    lubs = altern.getAnnotations();
+                    lubs = altern.getAnnotationsField();
                 } else {
                     TypeMirror typeMirror = type.getUnderlyingType();
                     AnnotationMirrorSet newLubs = new AnnotationMirrorSet();
@@ -156,8 +156,9 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
 
     private AnnotatedTypeMirror copyPrimaryAnnos(AnnotatedTypeMirror from, AnnotatedTypeMirror to) {
         // There may have been annotations added by a recursive call to asSuper, so replace existing
-        // annotations
-        to.replaceAnnotations(new ArrayList<>(from.getAnnotations()));
+        // annotations.
+        // TODO: Use from.getAnnotations() to avoid a concurrent modification problem.
+        to.replaceAnnotations(from.getAnnotations());
         // if to is a Typevar or Wildcard, then replaceAnnotations also sets primary annotations on
         // the bounds to from.getAnnotations()
 
@@ -166,7 +167,7 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
             // Alternatives cannot have type arguments, so asSuper isn't called recursively
             AnnotatedUnionType unionType = (AnnotatedUnionType) to;
             for (AnnotatedDeclaredType altern : unionType.getAlternatives()) {
-                altern.addMissingAnnotations(unionType.getAnnotations());
+                altern.addMissingAnnotations(unionType.getAnnotationsField());
             }
         }
         return to;

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -215,7 +215,7 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
             } else {
                 sb.append(
                         annoFormatter.formatAnnotationString(
-                                field.getAnnotations(), currentPrintInvisibleSetting));
+                                field.getAnnotationsField(), currentPrintInvisibleSetting));
                 sb.append("NullType");
             }
         }
@@ -252,7 +252,7 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
             }
             sb.append(
                     annoFormatter.formatAnnotationString(
-                            type.getAnnotations(), currentPrintInvisibleSetting));
+                            type.getAnnotationsField(), currentPrintInvisibleSetting));
             sb.append(smpl);
 
             boolean oldPrintingRaw = currentlyPrintingRaw;
@@ -386,11 +386,11 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
             AnnotatedTypeMirror component;
             while (true) {
                 component = array.componentType;
-                if (!array.getAnnotations().isEmpty()) {
+                if (!array.getAnnotationsField().isEmpty()) {
                     sb.append(' ');
                     sb.append(
                             annoFormatter.formatAnnotationString(
-                                    array.getAnnotations(), currentPrintInvisibleSetting));
+                                    array.getAnnotationsField(), currentPrintInvisibleSetting));
                 }
                 sb.append("[]");
                 if (!(component instanceof AnnotatedArrayType)) {
@@ -469,7 +469,7 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         @Override
         public String visitNull(AnnotatedNullType type, Set<AnnotatedTypeMirror> visiting) {
             return annoFormatter.formatAnnotationString(
-                            type.getAnnotations(), currentPrintInvisibleSetting)
+                            type.getAnnotationsField(), currentPrintInvisibleSetting)
                     + "NullType";
         }
 
@@ -512,7 +512,7 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         @SideEffectFree
         protected String formatFlatType(AnnotatedTypeMirror flatType) {
             return annoFormatter.formatAnnotationString(
-                            flatType.getAnnotations(), currentPrintInvisibleSetting)
+                            flatType.getAnnotationsField(), currentPrintInvisibleSetting)
                     + TypeAnnotationUtils.unannotatedType((Type) flatType.getUnderlyingType());
         }
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -182,7 +182,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
                             ? type.getUnderlyingType()
                             : erasedType.getUnderlyingType();
             // The effective annotations are the primary annotations on the erased type.
-            return new ShallowType(erasedType.getAnnotations(), typeMirror);
+            return new ShallowType(erasedType.getAnnotationsField(), typeMirror);
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
@@ -212,8 +212,8 @@ public final class ElementAnnotationApplier {
             TypeParameterElement tpelt =
                     (TypeParameterElement) type.getUnderlyingType().asElement();
 
-            if (type.getAnnotations().isEmpty()
-                    && type.getUpperBound().getAnnotations().isEmpty()
+            if (type.getAnnotationsField().isEmpty()
+                    && type.getUpperBound().getAnnotationsField().isEmpty()
                     && tpelt.getEnclosingElement().getKind() != ElementKind.TYPE_PARAMETER) {
                 try {
                     ElementAnnotationApplier.applyInternal(type, tpelt, factory);

--- a/framework/src/main/java/org/checkerframework/framework/type/EqualityAtmComparer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/EqualityAtmComparer.java
@@ -4,6 +4,8 @@ import org.checkerframework.checker.interning.qual.EqualsMethod;
 import org.checkerframework.framework.type.visitor.EquivalentAtmComboScanner;
 import org.checkerframework.javacutil.AnnotationUtils;
 
+import javax.lang.model.type.TypeMirror;
+
 /**
  * Compares two annotated type mirrors for structural equality using only the primary annotations
  * and underlying types of the two input types and their component types. Note, this leaves out
@@ -28,7 +30,7 @@ public class EqualityAtmComparer extends EquivalentAtmComboScanner<Boolean, Void
      * @return true if {@code type1} and {@code type2} have equivalent sets of annotations
      */
     protected boolean arePrimaryAnnosEqual(AnnotatedTypeMirror type1, AnnotatedTypeMirror type2) {
-        return AnnotationUtils.areSame(type1.getAnnotations(), type2.getAnnotations());
+        return AnnotationUtils.areSame(type1.getAnnotationsField(), type2.getAnnotationsField());
     }
 
     /**
@@ -47,8 +49,10 @@ public class EqualityAtmComparer extends EquivalentAtmComboScanner<Boolean, Void
             return false;
         }
 
+        TypeMirror ut1 = type1.underlyingType;
+        TypeMirror ut2 = type2.underlyingType;
         @SuppressWarnings("TypeEquals") // TODO
-        boolean sameUnderlyingType = type1.getUnderlyingType().equals(type2.getUnderlyingType());
+        boolean sameUnderlyingType = (ut1 == ut2) || ut1.equals(ut2);
         return sameUnderlyingType && arePrimaryAnnosEqual(type1, type2);
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2006,7 +2006,7 @@ public abstract class GenericAnnotatedTypeFactory<
      */
     public AnnotatedTypeMirror getDefaultAnnotations(Tree tree, AnnotatedTypeMirror type) {
         AnnotatedTypeMirror copy = type.deepCopy();
-        copy.removeAnnotations(type.getAnnotations());
+        copy.removeAnnotations(type.getAnnotationsField());
         addComputedTypeAnnotationsWithoutFlow(tree, copy);
         return copy;
     }
@@ -2301,7 +2301,7 @@ public abstract class GenericAnnotatedTypeFactory<
         }
 
         AnnotationMirrorSet qualParamTypes = new AnnotationMirrorSet();
-        for (AnnotationMirror initializerAnnotation : initializerType.getAnnotations()) {
+        for (AnnotationMirror initializerAnnotation : initializerType.getAnnotationsField()) {
             if (hasQualifierParameterInHierarchy(
                     type, qualHierarchy.getTopAnnotation(initializerAnnotation))) {
                 qualParamTypes.add(initializerAnnotation);
@@ -3050,7 +3050,7 @@ public abstract class GenericAnnotatedTypeFactory<
       }
 
       List<AnnotationMirror> result = new ArrayList<>();
-      for (AnnotationMirror inferredAm : inferredType.getAnnotations()) {
+      for (AnnotationMirror inferredAm : inferredType.getAnnotationsField()) {
         AnnotationMirror declaredAm = declaredType.getAnnotationInHierarchy(inferredAm);
         if (declaredAm == null || AnnotationUtils.areSame(inferredAm, declaredAm)) {
           continue;
@@ -3062,7 +3062,7 @@ public abstract class GenericAnnotatedTypeFactory<
         }
 
         List<AnnotationMirror> result = new ArrayList<>();
-        for (AnnotationMirror inferredAm : inferredType.getAnnotations()) {
+        for (AnnotationMirror inferredAm : inferredType.getAnnotationsField()) {
             AnnotationMirror declaredAm = declaredType.getAnnotationInHierarchy(inferredAm);
             if (declaredAm == null || AnnotationUtils.areSame(inferredAm, declaredAm)) {
                 continue;

--- a/framework/src/main/java/org/checkerframework/framework/type/HashcodeAtmVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/HashcodeAtmVisitor.java
@@ -18,6 +18,8 @@ public class HashcodeAtmVisitor extends SimpleAnnotatedTypeScanner<Integer, Void
     /** Creates a {@link HashcodeAtmVisitor}. */
     public HashcodeAtmVisitor() {
         super(Integer::sum, 0);
+        // TODO: evaluate whether using collision-avoiding hash would improve performance.
+        // super((r1, r2) -> 31 * r1 + r2, 0);
     }
 
     /**
@@ -33,6 +35,7 @@ public class HashcodeAtmVisitor extends SimpleAnnotatedTypeScanner<Integer, Void
         if (type == null) {
             return 0;
         }
-        return Objects.hash(type.getUnderlyingTypeHashCode(), type.getAnnotations().toString());
+        return Objects.hash(
+                type.getUnderlyingTypeHashCode(), type.getAnnotationsField().toString());
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/SupertypeFinder.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SupertypeFinder.java
@@ -126,7 +126,7 @@ final class SupertypeFinder {
         @Override
         public List<AnnotatedTypeMirror> visitPrimitive(AnnotatedPrimitiveType type, Void p) {
             List<AnnotatedTypeMirror> superTypes = new ArrayList<>(1);
-            AnnotationMirrorSet annotations = type.getAnnotations();
+            AnnotationMirrorSet annotations = type.getAnnotationsField();
 
             // Find Boxed type
             TypeElement boxed = types.boxedClass(type.getUnderlyingType());
@@ -170,8 +170,6 @@ final class SupertypeFinder {
 
         @Override
         public List<AnnotatedDeclaredType> visitDeclared(AnnotatedDeclaredType type, Void p) {
-            // AnnotationMirrorSet annotations = type.getAnnotations();
-
             TypeElement typeElement = (TypeElement) type.getUnderlyingType().asElement();
 
             if (type.getTypeArguments().size() != typeElement.getTypeParameters().size()) {
@@ -196,7 +194,7 @@ final class SupertypeFinder {
                 TypeElement jlaElement =
                         atypeFactory.elements.getTypeElement(Annotation.class.getCanonicalName());
                 AnnotatedDeclaredType jlaAnnotation = atypeFactory.fromElement(jlaElement);
-                jlaAnnotation.addAnnotations(type.getAnnotations());
+                jlaAnnotation.addAnnotations(type.getAnnotationsField());
                 supertypes.add(jlaAnnotation);
             }
 
@@ -385,7 +383,7 @@ final class SupertypeFinder {
                     t.addAnnotations(type.primaryAnnotations);
                 }
             }
-            adt.addAnnotations(type.getAnnotations());
+            adt.addAnnotations(type.getAnnotationsField());
             return adt;
         }
 
@@ -405,7 +403,7 @@ final class SupertypeFinder {
         @Override
         public List<AnnotatedTypeMirror> visitArray(AnnotatedArrayType type, Void p) {
             List<AnnotatedTypeMirror> superTypes = new ArrayList<>();
-            AnnotationMirrorSet annotations = type.getAnnotations();
+            AnnotationMirrorSet annotations = type.getAnnotationsField();
             AnnotatedTypeMirror objectType = atypeFactory.getAnnotatedType(Object.class);
             objectType.addAnnotations(annotations);
             superTypes.add(objectType);

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -361,7 +361,7 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
         boolean hasInit = tree.getInitializers() != null;
         AnnotatedTypeMirror typeElem = descendBy(result, hasInit ? 1 : tree.getDimensions().size());
         while (true) {
-            typeElem.addAnnotations(treeElem.getAnnotations());
+            typeElem.addAnnotations(treeElem.getAnnotationsField());
             if (!(treeElem instanceof AnnotatedArrayType)) {
                 break;
             }
@@ -406,7 +406,7 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
                 (AnnotatedDeclaredType) f.constructorFromUse(tree).executableType.getReturnType();
         // Clear the annotations on the return type, so that the explicit annotations can be added
         // first, then the annotations from the return type are added as needed.
-        AnnotationMirrorSet fromReturn = new AnnotationMirrorSet(returnType.getAnnotations());
+        AnnotationMirrorSet fromReturn = new AnnotationMirrorSet(returnType.getAnnotationsField());
         returnType.clearAnnotations();
         returnType.addAnnotations(f.getExplicitNewClassAnnos(tree));
         returnType.addMissingAnnotations(fromReturn);

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -131,7 +131,7 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
 
         AnnotatedTypeMirror result = f.type(tree); // use creator?
         AnnotatedTypeMirror atype = visit(tree.getType(), f);
-        result.addAnnotations(atype.getAnnotations());
+        result.addAnnotations(atype.getAnnotationsField());
         // new ArrayList<>() type is AnnotatedExecutableType for some reason
 
         // Don't initialize the type arguments if they are empty. The type arguments might be a

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -70,7 +70,7 @@ public class TypeVariableSubstitutor {
             AnnotatedTypeMirror argument, AnnotatedTypeVariable use) {
         AnnotatedTypeMirror substitute = argument.deepCopy(true);
         if (!use.getAnnotationsField().isEmpty()) {
-            substitute.replaceAnnotations(use.getAnnotations());
+            substitute.replaceAnnotations(use.getAnnotationsField());
         }
         return substitute;
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypesIntoElements.java
@@ -235,7 +235,7 @@ public final class TypesIntoElements {
             { // This block is essentially direct annotations, perhaps we should refactor that
                 // method out
                 List<Attribute.TypeCompound> res = List.nil();
-                for (AnnotationMirror am : typeVar.getLowerBound().getAnnotations()) {
+                for (AnnotationMirror am : typeVar.getLowerBound().getAnnotationsField()) {
                     Attribute.TypeCompound tc =
                             TypeAnnotationUtils.createTypeCompoundFromAnnotationMirror(
                                     am, tapos, processingEnv);
@@ -344,7 +344,7 @@ public final class TypesIntoElements {
                 AnnotatedTypeMirror type, TypeAnnotationPosition tapos) {
             List<Attribute.TypeCompound> res = List.nil();
 
-            for (AnnotationMirror am : type.getAnnotations()) {
+            for (AnnotationMirror am : type.getAnnotationsField()) {
                 // TODO: I BELIEVE THIS ISN'T TRUE BECAUSE PARAMETERS MAY HAVE ANNOTATIONS THAT CAME
                 // FROM THE ELEMENT OF THE CLASS WHICH PREVIOUSLY WAS WRITTEN OUT BY
                 // TYPESINTOELEMENT.

--- a/framework/src/main/java/org/checkerframework/framework/util/DefaultQualifierKindHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/DefaultQualifierKindHierarchy.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -248,8 +249,9 @@ public class DefaultQualifierKindHierarchy implements QualifierKindHierarchy {
     protected Map<@Interned @CanonicalName String, DefaultQualifierKind> createQualifierKinds(
             @UnderInitialization DefaultQualifierKindHierarchy this,
             Collection<Class<? extends Annotation>> qualifierClasses) {
-        TreeMap<@Interned @CanonicalName String, DefaultQualifierKind> nameToQualifierKind =
-                new TreeMap<>();
+        // Use a LinkedHashMap instead of a TreeMap for O(1) access.
+        LinkedHashMap<@Interned @CanonicalName String, DefaultQualifierKind> nameToQualifierKind =
+                new LinkedHashMap<>();
         for (Class<? extends Annotation> clazz : qualifierClasses) {
             @SuppressWarnings("interning") // uniqueness is tested immediately below
             @Interned DefaultQualifierKind qualifierKind = new DefaultQualifierKind(clazz);

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationMirrorSet.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationMirrorSet.java
@@ -142,7 +142,9 @@ public class AnnotationMirrorSet
             @UnknownInitialization(AnnotationMirrorSet.class) AnnotationMirrorSet this,
             @Nullable Object o) {
         return o instanceof AnnotationMirror
-                && AnnotationUtils.containsSame(shadowSet, (AnnotationMirror) o);
+                // We can directly use shadowSet.contains instead of AnnotationUtils.containsSame,
+                // because compareAnnotationMirrors is compatible with areSame.
+                && shadowSet.contains(o);
     }
 
     @Override
@@ -166,18 +168,23 @@ public class AnnotationMirrorSet
     public boolean add(
             @UnknownInitialization(AnnotationMirrorSet.class) AnnotationMirrorSet this,
             AnnotationMirror annotationMirror) {
-        if (contains(annotationMirror)) {
-            return false;
-        }
-        shadowSet.add(annotationMirror);
-        return true;
+        return shadowSet.add(annotationMirror);
     }
 
     @Override
     public boolean remove(@Nullable Object o) {
         if (o instanceof AnnotationMirror) {
-            AnnotationMirror found = AnnotationUtils.getSame(shadowSet, (AnnotationMirror) o);
-            return found != null && shadowSet.remove(found);
+            // Use floor() to find the element in O(log n) via the comparator, rather than the
+            // O(n) linear scan of getSame(). floor() returns the greatest element <= o; if
+            // compareAnnotationMirrors returns 0 (i.e. they are equivalent), it is the match.
+            AnnotationMirror am = (AnnotationMirror) o;
+            @SuppressWarnings(
+                    // TODO: floor requires KeyFor arg, which seems wrong.
+                    "keyfor:argument.type.incompatible")
+            AnnotationMirror found = shadowSet.floor(am);
+            return found != null
+                    && AnnotationUtils.compareAnnotationMirrors(found, am) == 0
+                    && shadowSet.remove(found);
         }
         return false;
     }
@@ -196,6 +203,15 @@ public class AnnotationMirrorSet
     public boolean addAll(
             @UnknownInitialization(AnnotationMirrorSet.class) AnnotationMirrorSet this,
             Collection<? extends AnnotationMirror> c) {
+        if (c instanceof AnnotationMirrorSet) {
+            // Both sets use the same comparator, so we can bulk-insert via the backing TreeSet.
+            // TreeSet.addAll() skips elements that compare as equal (returns 0), which is the
+            // correct duplicate-rejection semantics. This avoids per-element contains() checks.
+            @SuppressWarnings("keyfor:argument.type.incompatible") // TODO: wildcard issue.
+            boolean ret = shadowSet.addAll(((AnnotationMirrorSet) c).shadowSet);
+            return ret;
+        }
+
         boolean result = true;
         for (AnnotationMirror a : c) {
             if (!add(a)) {


### PR DESCRIPTION
When running in a large project with more than 4000 .java files, this reduced checking time from over 30 minutes to around 26 minutes, so another 10 percent boost.