### PR TITLE
Suppress warnings from methods marked for removal in JDK27 b17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,14 +138,14 @@ jobs:
         # Keep all LTS versions and the newest non-LTS version.
         # `experimental` versions use the $version compiler, but run on JDK 21.
         java:
-          - {version: '8', experimental: false}
-          - {version: '11', experimental: false}
-          - {version: '17', experimental: false}
-          - {version: '25', experimental: false}
-          - {version: '26', experimental: false}
           # Keep in sync with env.JDK_EA_MAJOR above.
           # env context is not available in strategy.matrix, so the version is hard-coded here.
           - {version: '27', experimental: true}
+          - {version: '26', experimental: false}
+          - {version: '25', experimental: false}
+          - {version: '17', experimental: false}
+          - {version: '11', experimental: false}
+          - {version: '8', experimental: false}
         exclude:
           # JDK 8 does not allow toolchains, so testing 'cftests-junit-jdk21' is unnecessary.
           - script: 'cftests-junit-jdk21'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       JAVA_VERSION: ${{ matrix.java.version }}
       USE_BAZEL_VERSION: "9.0.2"
       JDK_EA_MAJOR: "27"
-      JDK_EA_BUILD: "15"
+      JDK_EA_BUILD: "18"
     strategy:
       fail-fast: true
       matrix:

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3679,6 +3679,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     private String fileAndLineNumber(Tree tree) {
         StringBuilder result = new StringBuilder();
         result.append(Paths.get(root.getSourceFile().getName()).getFileName().toString());
+        @SuppressWarnings("removal")
         long valuePos = positions.getStartPosition(root, tree);
         LineMap lineMap = root.getLineMap();
         if (valuePos != -1 && lineMap != null) {

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -512,11 +512,13 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             expectedTreesVisitor.visitCompilationUnit(root, null);
             for (Tree expected : expectedTreesVisitor.getTrees()) {
                 if (!treePairs.containsKey(expected)) {
+                    @SuppressWarnings("removal") // TODO: encapsulate methods
+                    long startpos = positions.getStartPosition(root, expected);
                     throw new BugInCF(
                             "Javac tree not matched to JavaParser node: %s [%s @ %d], in file: %s",
                             expected,
                             expected.getClass(),
-                            positions.getStartPosition(root, expected),
+                            startpos,
                             root.getSourceFile().getName());
                 }
             }

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1908,7 +1908,9 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
         }
 
         SourcePositions sourcePositions = trees.getSourcePositions();
+        @SuppressWarnings("removal") // TODO: encapsulate methods
         long start = sourcePositions.getStartPosition(currentRoot, tree);
+        @SuppressWarnings("removal")
         long end = sourcePositions.getEndPosition(currentRoot, tree);
 
         return "( " + start + ", " + end + " )";

--- a/framework/src/main/java/org/checkerframework/framework/util/visualize/LspTypeInformationPresenter.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/visualize/LspTypeInformationPresenter.java
@@ -98,7 +98,9 @@ public class LspTypeInformationPresenter extends AbstractTypeInformationPresente
          * @return a message range corresponds to the tree
          */
         protected @Nullable TypeOccurrenceRange computeTypeOccurrenceRange(Tree tree) {
+            @SuppressWarnings("removal") // TODO: encapsulate methods
             long startPos = sourcePositions.getStartPosition(currentRoot, tree);
+            @SuppressWarnings("removal")
             long endPos = sourcePositions.getEndPosition(currentRoot, tree);
             if (startPos == Diagnostic.NOPOS || endPos == Diagnostic.NOPOS) {
                 // The tree doesn't exist in the source file.


### PR DESCRIPTION
This partially addresses #1637, but I'll leave the issue open to extract that logic into a helper method.