### PR TITLE
Cache the hashCode for dataflow expressions

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayAccess.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayAccess.java
@@ -104,9 +104,15 @@ public class ArrayAccess extends JavaExpression {
         return array.equals(other.array) && index.equals(other.index);
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        return Objects.hash(array, index);
+        if (hashCodeCache == 0) {
+            hashCodeCache = Objects.hash(array, index);
+        }
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayCreation.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayCreation.java
@@ -88,9 +88,15 @@ public class ArrayCreation extends JavaExpression {
         return true;
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        return Objects.hash(dimensions, initializers, getType().toString());
+        if (hashCodeCache == 0) {
+            hashCodeCache = Objects.hash(dimensions, initializers, getType().toString());
+        }
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/BinaryOperation.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/BinaryOperation.java
@@ -130,9 +130,15 @@ public class BinaryOperation extends JavaExpression {
                 || right.containsModifiableAliasOf(store, other);
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        return Objects.hash(operationKind, left, right);
+        if (hashCodeCache == 0) {
+            hashCodeCache = Objects.hash(operationKind, left, right);
+        }
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/FieldAccess.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/FieldAccess.java
@@ -117,9 +117,15 @@ public class FieldAccess extends JavaExpression {
                         || this.getReceiver() instanceof ThisReference);
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        return Objects.hash(getField(), getReceiver());
+        if (hashCodeCache == 0) {
+            hashCodeCache = Objects.hash(getField(), getReceiver());
+        }
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/FormalParameter.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/FormalParameter.java
@@ -64,14 +64,21 @@ public class FormalParameter extends JavaExpression {
         return element;
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        VarSymbol vs = (VarSymbol) element;
-        return Objects.hash(
-                index,
-                vs.name.toString(),
-                TypeAnnotationUtils.unannotatedType(vs.type).toString(),
-                vs.owner.toString());
+        if (hashCodeCache == 0) {
+            VarSymbol vs = (VarSymbol) element;
+            hashCodeCache =
+                    Objects.hash(
+                            index,
+                            vs.name.toString(),
+                            TypeAnnotationUtils.unannotatedType(vs.type).toString(),
+                            vs.owner.toString());
+        }
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -79,10 +79,16 @@ public class LocalVariable extends JavaExpression {
         return element;
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        VarSymbol vs = (VarSymbol) element;
-        return Objects.hash(vs.pos, vs.name, vs.owner);
+        if (hashCodeCache == 0) {
+            VarSymbol vs = (VarSymbol) element;
+            hashCodeCache = Objects.hash(vs.pos, vs.name, vs.owner);
+        }
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
@@ -167,13 +167,20 @@ public class MethodCall extends JavaExpression {
                 && arguments.equals(other.arguments);
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        if (method.getKind() == ElementKind.CONSTRUCTOR) {
-            // No two constructor instances have the same hashcode.
-            return System.identityHashCode(this);
+        if (hashCodeCache == 0) {
+            if (method.getKind() == ElementKind.CONSTRUCTOR) {
+                // No two constructor instances have the same hashcode.
+                hashCodeCache = System.identityHashCode(this);
+            } else {
+                hashCodeCache = Objects.hash(method, receiver, arguments);
+            }
         }
-        return Objects.hash(method, receiver, arguments);
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/UnaryOperation.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/UnaryOperation.java
@@ -105,9 +105,15 @@ public class UnaryOperation extends JavaExpression {
         return operand.containsModifiableAliasOf(store, other);
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        return Objects.hash(operationKind, operand);
+        if (hashCodeCache == 0) {
+            hashCodeCache = Objects.hash(operationKind, operand);
+        }
+        return hashCodeCache;
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/ValueLiteral.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/ValueLiteral.java
@@ -163,9 +163,15 @@ public class ValueLiteral extends JavaExpression {
         return value == null ? "null" : value.toString();
     }
 
+    /** Cache the hashCode. Recomputed if zero. */
+    private int hashCodeCache = 0;
+
     @Override
     public int hashCode() {
-        return Objects.hash(value, type.toString());
+        if (hashCodeCache == 0) {
+            hashCodeCache = Objects.hash(value, type.toString());
+        }
+        return hashCodeCache;
     }
 
     @Override


### PR DESCRIPTION
The dataflow expressions are in many maps, so the hash is computed frequently.
Objects.hashCode allocates an array for the varargs, which is bad on the hot path.
The additional memory overhead seems low, and outweighed by the array allocations.

Size impact analysis from Claude on a JFR trace:

The crucial fact that makes this mostly a non-issue: `JavaExpression` objects are <em>shared</em> across store copies. When `CFAbstractStore(other)` copies `other.localVariableValues`, it copies the `HashMap` entries but not the key objects — the new store holds references to the same `LocalVariable` and `FieldAccess` instances. So there are O(unique expressions in one method) live instances at peak, not O(blocks × expressions). For a complex method that's maybe 20–40 objects total, not thousands.

Whether an extra `int` costs anything depends on alignment. With compressed oops (the default on any 64-bit JVM with heap &lt; 32 GB), the object header is 12 bytes, and the total is rounded up to an 8-byte boundary. An extra `int` field (4 bytes) only costs memory if it crosses that boundary. Specifically:

````
Class | Current size | After +int | Cost
-- | -- | -- | --
LocalVariable | 24 B | 24 B | Free — header(12) + type(4) + element(4) = 20, pads to 24; int fills the 4B gap
FieldAccess | 24 B | 32 B | +8 B — header(12) + type(4) + receiver(4) + field(4) = 24; no gap, so int forces next alignment slot
MethodCall | 24 B | 32 B | +8 B
ClassName | 24 B | 24 B | Free — same layout as LocalVariable
BinaryOperation | 32 B | 32 B | Free — 4 refs = 16B fields, 12+16=28 pads to 32; int fills the 4B gap
ThisReference | 16 B | 24 B | +8 B — only 1 ref field, so 12+4=16; no gap
````

The hottest type by far is `LocalVariable` (559 profile samples, dominant in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">localVariableValues</code>). It pays <strong>nothing</strong> — the int slots into the existing alignment gap.</p>