### PR TITLE
Cache a frequent conversion in the Value Checker

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -758,8 +758,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             isSpecial = false;
         }
 
-        if (cached == null) {
-            specialIntRangeCache.put(anm, isSpecial);
+        if (cached == null && !isSpecial) {
+            specialIntRangeCache.put(anm, false);
         }
         return res;
     }

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -68,6 +68,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -472,8 +473,13 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     public AnnotationMirrorSet getWidenedAnnotations(
             AnnotationMirrorSet annos, TypeKind typeKind, TypeKind widenedTypeKind) {
+        AnnotationMirror anno = qualHierarchy.findAnnotationInSameHierarchy(annos, UNKNOWNVAL);
+        if (anno == null) {
+            throw new TypeSystemError("No value annotation in: " + annos);
+        }
+
         return AnnotationMirrorSet.singleton(
-                convertSpecialIntRangeToStandardIntRange(annos.first(), typeKind));
+                convertSpecialIntRangeToStandardIntRange(anno, typeKind));
     }
 
     /**
@@ -691,11 +697,17 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         if (TypesUtils.isIntegralPrimitiveOrBoxed(typeMirror)) {
             Range maxRange = Range.create(primitiveKind);
             return convertSpecialIntRangeToStandardIntRange(anm, maxRange.to);
-
         } else {
             return convertSpecialIntRangeToStandardIntRange(anm, Long.MAX_VALUE);
         }
     }
+
+    /**
+     * Identity cache: true iff the mirror is one of IntRangeFromPositive/NonNeg/GTENegOne. Absence
+     * from the map means "unknown"; false means "known non-special".
+     */
+    private final IdentityHashMap<AnnotationMirror, Boolean> specialIntRangeCache =
+            new IdentityHashMap<>();
 
     /**
      * Converts {@link IntRangeFromPositive}, {@link IntRangeFromNonNegative}, or {@link
@@ -708,18 +720,33 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     private AnnotationMirror convertSpecialIntRangeToStandardIntRange(
             AnnotationMirror anm, long max) {
-        if (AnnotationUtils.areSameByName(anm, INTRANGE_FROMPOS_NAME)) {
-            return createIntRangeAnnotation(1, max);
+        Boolean cached = specialIntRangeCache.get(anm);
+        if (Boolean.FALSE.equals(cached)) {
+            return anm; // fast path, ~95%+ of calls
         }
 
-        if (AnnotationUtils.areSameByName(anm, INTRANGE_FROMNONNEG_NAME)) {
-            return createIntRangeAnnotation(0, max);
+        String name = AnnotationUtils.annotationName(anm);
+        AnnotationMirror res;
+        boolean isSpecial;
+
+        if (name.equals(INTRANGE_FROMPOS_NAME)) {
+            res = createIntRangeAnnotation(1, max);
+            isSpecial = true;
+        } else if (name.equals(INTRANGE_FROMNONNEG_NAME)) {
+            res = createIntRangeAnnotation(0, max);
+            isSpecial = true;
+        } else if (name.equals(INTRANGE_FROMGTENEGONE_NAME)) {
+            res = createIntRangeAnnotation(-1, max);
+            isSpecial = true;
+        } else {
+            res = anm;
+            isSpecial = false;
         }
 
-        if (AnnotationUtils.areSameByName(anm, INTRANGE_FROMGTENEGONE_NAME)) {
-            return createIntRangeAnnotation(-1, max);
+        if (cached == null) {
+            specialIntRangeCache.put(anm, isSpecial);
         }
-        return anm;
+        return res;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -301,7 +301,11 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
     }
 
-    /** Gets a helper object that holds references to methods with special handling. */
+    /**
+     * Gets a helper object that holds references to methods with special handling.
+     *
+     * @return the value method identifier object
+     */
     ValueMethodIdentifier getMethodIdentifier() {
         return methods;
     }

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value;
 
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.Tree;
@@ -287,6 +288,16 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         if (this.getClass() == ValueAnnotatedTypeFactory.class) {
             this.postInit();
+        }
+    }
+
+    @Override
+    public void setRoot(@Nullable CompilationUnitTree root) {
+        super.setRoot(root);
+        // Clear out the cache between compilation units.
+        // TODO: It would be nice to have a identity-based LRU cache.
+        if (specialIntRangeCache.size() > 100) {
+            specialIntRangeCache.clear();
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
@@ -89,7 +89,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
 
         if (valueType.getKind() == TypeKind.CHAR
                 && valueType.hasAnnotation(getTypeFactory().UNKNOWNVAL)) {
-            valueType.addAnnotation(
+            valueType.replaceAnnotation(
                     getTypeFactory().createIntRangeAnnotation(Range.CHAR_EVERYTHING));
         }
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
@@ -21,7 +21,6 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
-import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreeUtils;
@@ -351,15 +350,11 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
                 && exprTypeKind != null
                 && TypeKindUtils.isIntegral(castTypeKind)
                 && TypeKindUtils.isIntegral(exprTypeKind)) {
-            AnnotationMirrorSet castAnnos = castType.getAnnotations();
-            AnnotationMirrorSet exprAnnos = exprType.getAnnotations();
-            if (castAnnos.equals(exprAnnos)) {
+            AnnotationMirror castAnno = castType.getAnnotationInHierarchy(atypeFactory.UNKNOWNVAL);
+            AnnotationMirror exprAnno = exprType.getAnnotationInHierarchy(atypeFactory.UNKNOWNVAL);
+            if (castAnno == exprAnno) {
                 return true;
             }
-            assert castAnnos.size() == 1;
-            assert exprAnnos.size() == 1;
-            AnnotationMirror castAnno = castAnnos.first();
-            AnnotationMirror exprAnno = exprAnnos.first();
             boolean castAnnoIsIntVal = atypeFactory.areSameByClass(castAnno, IntVal.class);
             boolean exprAnnoIsIntVal = atypeFactory.areSameByClass(exprAnno, IntVal.class);
             if (castAnnoIsIntVal && exprAnnoIsIntVal) {

--- a/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
@@ -352,7 +352,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
                 && TypeKindUtils.isIntegral(exprTypeKind)) {
             AnnotationMirror castAnno = castType.getAnnotationInHierarchy(atypeFactory.UNKNOWNVAL);
             AnnotationMirror exprAnno = exprType.getAnnotationInHierarchy(atypeFactory.UNKNOWNVAL);
-            if (castAnno == exprAnno) {
+            if (AnnotationUtils.areSame(castAnno, exprAnno)) {
                 return true;
             }
             boolean castAnnoIsIntVal = atypeFactory.areSameByClass(castAnno, IntVal.class);


### PR DESCRIPTION
Also ensures proper usage of `AnnotationMirrorSet`s: do not assume order and ensure one qualifier per hierarchy.