### PR TITLE
Add extra maps to qualifier hierarchies

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
@@ -245,7 +245,7 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         public FormatterQualifierHierarchy() {
             super(
                     FormatterAnnotatedTypeFactory.this.getSupportedTypeQualifiers(),
-                    elements,
+                    FormatterAnnotatedTypeFactory.this.elements,
                     FormatterAnnotatedTypeFactory.this);
             FORMAT_KIND = getQualifierKind(FORMAT_NAME);
             INVALIDFORMAT_KIND = getQualifierKind(INVALIDFORMAT_NAME);

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
@@ -226,7 +226,7 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
         public I18nFormatterQualifierHierarchy() {
             super(
                     I18nFormatterAnnotatedTypeFactory.this.getSupportedTypeQualifiers(),
-                    elements,
+                    I18nFormatterAnnotatedTypeFactory.this.elements,
                     I18nFormatterAnnotatedTypeFactory.this);
             this.I18NFORMAT_KIND = this.getQualifierKind(I18NFORMAT_NAME);
             this.I18NFORMATFOR_KIND = this.getQualifierKind(I18NFORMATFOR_NAME);

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationParentAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationParentAnnotatedTypeFactory.java
@@ -844,7 +844,7 @@ public abstract class InitializationParentAnnotatedTypeFactory
         protected InitializationQualifierHierarchy() {
             super(
                     InitializationParentAnnotatedTypeFactory.this.getSupportedTypeQualifiers(),
-                    elements,
+                    InitializationParentAnnotatedTypeFactory.this.elements,
                     InitializationParentAnnotatedTypeFactory.this);
             UNKNOWN_INIT = getQualifierKind(UNKNOWN_INITIALIZATION);
             UNDER_INIT = getQualifierKind(UNDER_INITALIZATION);

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -586,7 +586,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         public UnitsQualifierHierarchy() {
             super(
                     UnitsAnnotatedTypeFactory.this.getSupportedTypeQualifiers(),
-                    elements,
+                    UnitsAnnotatedTypeFactory.this.elements,
                     UnitsAnnotatedTypeFactory.this);
         }
 
@@ -594,7 +594,8 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         protected QualifierKindHierarchy createQualifierKindHierarchy(
                 @UnderInitialization UnitsQualifierHierarchy this,
                 Collection<Class<? extends Annotation>> qualifierClasses) {
-            return new UnitsQualifierKindHierarchy(qualifierClasses, elements);
+            return new UnitsQualifierKindHierarchy(
+                    qualifierClasses, UnitsAnnotatedTypeFactory.this.elements);
         }
 
         @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
@@ -187,9 +187,7 @@ public abstract class ElementQualifierHierarchy extends QualifierHierarchy {
         Set<QualifierKind> coveredKinds = new HashSet<>(teMap.values());
         for (QualifierKind kind : qualifierKindHierarchy.allQualifierKinds()) {
             if (kind.hasElements() && !coveredKinds.contains(kind)) {
-                @SuppressWarnings(
-                        "nullness:assignment.type.incompatible") // annotations have a name
-                @NonNull String className = kind.getAnnotationClass().getCanonicalName();
+                String className = kind.getName();
                 TypeElement te = elements.getTypeElement(className);
                 if (te != null) {
                     teMap.put(te, kind);

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
@@ -18,10 +18,14 @@ import org.checkerframework.javacutil.TypeSystemError;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
 /**
@@ -60,8 +64,21 @@ public abstract class ElementQualifierHierarchy extends QualifierHierarchy {
     protected final AnnotationMirrorSet bottoms;
 
     /**
-     * A mapping from QualifierKind to AnnotationMirror for all qualifiers whose annotations do not
-     * have elements.
+     * A mapping from an annotation's declaring {@link TypeElement} to its {@link QualifierKind}.
+     * See {@link NoElementQualifierHierarchy#elementToQualifierKind} for the full rationale.
+     *
+     * <p>For annotations with elements (e.g., {@code @IntRange}), multiple distinct {@code
+     * AnnotationMirror} instances share the same declaring TypeElement, and that TypeElement maps
+     * to the single corresponding QualifierKind. The identity lookup thus resolves the kind in O(1)
+     * without comparing annotation element values, which is exactly what the kind-level hierarchy
+     * operations require.
+     */
+    protected final IdentityHashMap<TypeElement, QualifierKind> elementToQualifierKind;
+
+    /**
+     * A mapping from an annotation's declaring {@link QualifierKind} to its {@link
+     * AnnotationMirror}, for qualifiers that have no elements. Not used for element-bearing
+     * qualifiers.
      */
     protected final Map<QualifierKind, AnnotationMirror> kindToElementlessQualifier;
 
@@ -88,7 +105,9 @@ public abstract class ElementQualifierHierarchy extends QualifierHierarchy {
         this.bottomsMap = Collections.unmodifiableMap(createBottomsMap());
         this.bottoms = AnnotationMirrorSet.unmodifiableSet(bottomsMap.values());
 
-        this.kindToElementlessQualifier = createElementlessQualifierMap();
+        this.kindToElementlessQualifier =
+                Collections.unmodifiableMap(createElementlessQualifierMap());
+        this.elementToQualifierKind = createElementToQualifierKindMap();
     }
 
     @Override
@@ -128,7 +147,56 @@ public abstract class ElementQualifierHierarchy extends QualifierHierarchy {
                 quals.put(kind, AnnotationBuilder.fromClass(elements, kind.getAnnotationClass()));
             }
         }
-        return Collections.unmodifiableMap(quals);
+        return quals;
+    }
+
+    /**
+     * Creates a mapping from TypeElement to QualifierKind identity map covering all qualifier
+     * kinds.
+     *
+     * @return the mapping
+     */
+    @RequiresNonNull({
+        "this.qualifierKindHierarchy",
+        "this.elements",
+        "this.kindToElementlessQualifier",
+        "this.topsMap",
+        "this.bottomsMap"
+    })
+    protected IdentityHashMap<TypeElement, QualifierKind> createElementToQualifierKindMap(
+            @UnderInitialization ElementQualifierHierarchy this) {
+        IdentityHashMap<TypeElement, QualifierKind> teMap = new IdentityHashMap<>();
+        // Elementless qualifiers: TypeElement available directly from the AnnotationMirror.
+        for (Map.Entry<QualifierKind, AnnotationMirror> entry :
+                kindToElementlessQualifier.entrySet()) {
+            TypeElement te = (TypeElement) entry.getValue().getAnnotationType().asElement();
+            teMap.put(te, entry.getKey());
+        }
+        // Tops and bottoms (may be element-bearing in some subclass configurations).
+        for (Map.Entry<QualifierKind, AnnotationMirror> entry : topsMap.entrySet()) {
+            teMap.put(
+                    (TypeElement) entry.getValue().getAnnotationType().asElement(), entry.getKey());
+        }
+        for (Map.Entry<QualifierKind, AnnotationMirror> entry : bottomsMap.entrySet()) {
+            teMap.put(
+                    (TypeElement) entry.getValue().getAnnotationType().asElement(), entry.getKey());
+        }
+        // Element-bearing qualifiers not yet in the map: look up TypeElement by class name.
+        // teMap at this point uses TypeElement keys; checking coverage via teMap.values() would
+        // be O(n) per element. Collect covered QualifierKinds first.
+        Set<QualifierKind> coveredKinds = new HashSet<>(teMap.values());
+        for (QualifierKind kind : qualifierKindHierarchy.allQualifierKinds()) {
+            if (kind.hasElements() && !coveredKinds.contains(kind)) {
+                @SuppressWarnings(
+                        "nullness:assignment.type.incompatible") // annotations have a name
+                @NonNull String className = kind.getAnnotationClass().getCanonicalName();
+                TypeElement te = elements.getTypeElement(className);
+                if (te != null) {
+                    teMap.put(te, kind);
+                }
+            }
+        }
+        return teMap;
     }
 
     /**
@@ -170,12 +238,18 @@ public abstract class ElementQualifierHierarchy extends QualifierHierarchy {
     }
 
     /**
-     * Returns the qualifier kind for the given annotation.
+     * Returns the qualifier kind for the given annotation, using a TypeElement identity lookup.
      *
      * @param anno an annotation mirror that is in this hierarchy
      * @return the qualifier kind for the given annotation
      */
     protected QualifierKind getQualifierKind(AnnotationMirror anno) {
+        TypeElement te = (TypeElement) anno.getAnnotationType().asElement();
+        QualifierKind kind = elementToQualifierKind.get(te);
+        if (kind != null) {
+            return kind;
+        }
+        // Defensive fallback for AnnotationMirrors from a different compilation context.
         String name = AnnotationUtils.annotationName(anno);
         QualifierKind result = getQualifierKind(name);
         if (result == null) {

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
@@ -43,7 +43,7 @@ import javax.lang.model.util.Elements;
 public abstract class ElementQualifierHierarchy extends QualifierHierarchy {
 
     /** {@link org.checkerframework.javacutil.ElementUtils}. */
-    private final Elements elements;
+    protected final Elements elements;
 
     /** {@link QualifierKindHierarchy}. */
     protected final QualifierKindHierarchy qualifierKindHierarchy;

--- a/framework/src/main/java/org/checkerframework/framework/type/NoElementQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/NoElementQualifierHierarchy.java
@@ -17,11 +17,13 @@ import org.checkerframework.javacutil.TypeSystemError;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
 /**
@@ -52,6 +54,26 @@ public class NoElementQualifierHierarchy extends QualifierHierarchy {
     protected final Set<? extends AnnotationMirror> qualifiers;
 
     /**
+     * A mapping from an annotation's declaring {@link TypeElement} to its {@link QualifierKind}.
+     *
+     * <p>Keyed by identity because javac's {@code ClassSymbol} (the {@link TypeElement}
+     * implementation) does not override {@code equals}/{@code hashCode}. All annotation mirrors
+     * produced within the same javac compilation share the same {@link
+     * javax.lang.model.util.Elements} instance, so the {@code TypeElement} for (e.g.)
+     * {@code @NonNull} in the qualifier hierarchy is the same object as the {@code TypeElement} in
+     * any {@code @NonNull} encountered during type-checking.
+     *
+     * <p>This allows {@link #getQualifierKind(AnnotationMirror)} to resolve a candidate annotation
+     * to its {@link QualifierKind} in O(1) via a single identity lookup, avoiding two string-based
+     * map lookups ({@link AnnotationUtils#annotationName} + {@link
+     * QualifierKindHierarchy#getQualifierKind(String)}) per call.
+     *
+     * <p>This map is per-hierarchy-instance (not static), so its TypeElement keys are naturally
+     * reclaimed when the associated type factory and javac compilation context are released.
+     */
+    protected final IdentityHashMap<TypeElement, QualifierKind> elementToQualifierKind;
+
+    /**
      * Creates a NoElementQualifierHierarchy from the given classes.
      *
      * @param qualifierClasses classes of annotations that are the qualifiers
@@ -67,8 +89,11 @@ public class NoElementQualifierHierarchy extends QualifierHierarchy {
 
         this.qualifierKindHierarchy = createQualifierKindHierarchy(qualifierClasses);
 
-        this.kindToAnnotationMirror = createAnnotationMirrors(elements);
+        this.kindToAnnotationMirror =
+                Collections.unmodifiableMap(createAnnotationMirrors(elements));
         this.qualifiers = AnnotationMirrorSet.unmodifiableSet(kindToAnnotationMirror.values());
+
+        this.elementToQualifierKind = createElementToQualifierKindMap();
 
         this.tops = createTops();
         this.bottoms = createBottoms();
@@ -107,7 +132,24 @@ public class NoElementQualifierHierarchy extends QualifierHierarchy {
             }
             quals.put(kind, AnnotationBuilder.fromClass(elements, kind.getAnnotationClass()));
         }
-        return Collections.unmodifiableMap(quals);
+        return quals;
+    }
+
+    /**
+     * Creates the TypeElement to QualifierKind identity map from the already-populated
+     * kindToAnnotationMirror. This is O(n) in the number of qualifier kinds (tiny), done once
+     *
+     * @return a mapping from qualifier kind to its annotation mirror
+     */
+    @RequiresNonNull("this.kindToAnnotationMirror")
+    protected IdentityHashMap<TypeElement, QualifierKind> createElementToQualifierKindMap(
+            @UnderInitialization NoElementQualifierHierarchy this) {
+        IdentityHashMap<TypeElement, QualifierKind> teMap = new IdentityHashMap<>();
+        for (Map.Entry<QualifierKind, AnnotationMirror> entry : kindToAnnotationMirror.entrySet()) {
+            TypeElement te = (TypeElement) entry.getValue().getAnnotationType().asElement();
+            teMap.put(te, entry.getKey());
+        }
+        return teMap;
     }
 
     /**
@@ -153,12 +195,24 @@ public class NoElementQualifierHierarchy extends QualifierHierarchy {
     /**
      * Returns the {@link QualifierKind} for the given annotation.
      *
+     * <p>Uses a TypeElement identity lookup rather than a string-based lookup, which requires no
+     * string allocation and no string comparison. The TypeElement for an annotation type is a
+     * unique object within a javac compilation, so identity comparison is correct.
+     *
      * @param anno an annotation that is a qualifier in this
      * @return the {@code QualifierKind} for the given annotation
      */
     protected QualifierKind getQualifierKind(AnnotationMirror anno) {
+        TypeElement te = (TypeElement) anno.getAnnotationType().asElement();
+        QualifierKind kind = elementToQualifierKind.get(te);
+        if (kind != null) {
+            return kind;
+        }
+        // Defensive fallback: te not in the identity map (should not happen in normal use;
+        // can occur if an AnnotationMirror from a different javac Context reaches this method).
+        // Falls through to the string-based lookup.
         String name = AnnotationUtils.annotationName(anno);
-        QualifierKind kind = qualifierKindHierarchy.getQualifierKind(name);
+        kind = qualifierKindHierarchy.getQualifierKind(name);
         if (kind == null) {
             throw new BugInCF("Annotation not in hierarchy: %s", anno);
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/NoElementQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/NoElementQualifierHierarchy.java
@@ -137,9 +137,9 @@ public class NoElementQualifierHierarchy extends QualifierHierarchy {
 
     /**
      * Creates the TypeElement to QualifierKind identity map from the already-populated
-     * kindToAnnotationMirror. This is O(n) in the number of qualifier kinds (tiny), done once
+     * kindToAnnotationMirror. This is O(n) in the number of qualifier kinds (tiny), done once.
      *
-     * @return a mapping from qualifier kind to its annotation mirror
+     * @return a mapping from type elements to their qualifier kind
      */
     @RequiresNonNull("this.kindToAnnotationMirror")
     protected IdentityHashMap<TypeElement, QualifierKind> createElementToQualifierKindMap(


### PR DESCRIPTION
Claude suggests this will further reduce our `toString` invocations.