### PR TITLE
Use identity for dataflow worklists

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -21,9 +21,9 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Objects;
 import java.util.PriorityQueue;
@@ -549,10 +549,10 @@ public abstract class AbstractAnalysis<
         public Worklist(Direction direction) {
             if (direction == Direction.FORWARD) {
                 queue = new PriorityQueue<>(new ForwardDfoComparator());
-                queueSet = new HashSet<>();
+                queueSet = Collections.newSetFromMap(new IdentityHashMap<>());
             } else if (direction == Direction.BACKWARD) {
                 queue = new PriorityQueue<>(new BackwardDfoComparator());
-                queueSet = new HashSet<>();
+                queueSet = Collections.newSetFromMap(new IdentityHashMap<>());
             } else {
                 throw new BugInCF("Unexpected Direction: " + direction.name());
             }


### PR DESCRIPTION
The rest of the Dataflow Framework compares Blocks and Nodes by identity. It was inconsistent and potentially incorrect to use "equals"-based HashSets instead of something based on identity.