### PR TITLE
Guard log calls by debug flag

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2074,46 +2074,62 @@ public abstract class GenericAnnotatedTypeFactory<
                                 0, thisClass.length() - "AnnotatedTypeFactory".length());
             }
             treeString = TreeUtils.toStringTruncated(tree, 60);
+            log(
+                    "%s GATF.addComputedTypeAnnotations#1(%s, %s, %s)%n",
+                    thisClass, treeString, type, this.useFlow);
         }
-        log(
-                "%s GATF.addComputedTypeAnnotations#1(%s, %s, %s)%n",
-                thisClass, treeString, type, this.useFlow);
         if (!TreeUtils.isExpressionTree(tree)) {
             // Don't apply defaults to expressions. Their types may be computed from subexpressions
             // in treeAnnotator.
             addAnnotationsFromDefaultForType(TreeUtils.elementFromTree(tree), type);
-            log("%s GATF.addComputedTypeAnnotations#2(%s, %s)%n", thisClass, treeString, type);
+            if (debug) {
+                log("%s GATF.addComputedTypeAnnotations#2(%s, %s)%n", thisClass, treeString, type);
+            }
         }
         applyQualifierParameterDefaults(tree, type);
-        log("%s GATF.addComputedTypeAnnotations#3(%s, %s)%n", thisClass, treeString, type);
+        if (debug) {
+            log("%s GATF.addComputedTypeAnnotations#3(%s, %s)%n", thisClass, treeString, type);
+        }
         treeAnnotator.visit(tree, type);
-        log(
-                "%s GATF.addComputedTypeAnnotations#4(%s, %s)%n  treeAnnotator=%s%n",
-                thisClass, treeString, type, treeAnnotator);
+        if (debug) {
+            log(
+                    "%s GATF.addComputedTypeAnnotations#4(%s, %s)%n  treeAnnotator=%s%n",
+                    thisClass, treeString, type, treeAnnotator);
+        }
         if (TreeUtils.isExpressionTree(tree)) {
             // If a tree annotator did not add a type, add the DefaultForUse default.
             addAnnotationsFromDefaultForType(TreeUtils.elementFromTree(tree), type);
-            log("%s GATF.addComputedTypeAnnotations#5(%s, %s)%n", thisClass, treeString, type);
+            if (debug) {
+                log("%s GATF.addComputedTypeAnnotations#5(%s, %s)%n", thisClass, treeString, type);
+            }
         }
         typeAnnotator.visit(type, null);
-        log(
-                "%s GATF.addComputedTypeAnnotations#6(%s, %s)%n  typeAnnotator=%s%n",
-                thisClass, treeString, type, typeAnnotator);
+        if (debug) {
+            log(
+                    "%s GATF.addComputedTypeAnnotations#6(%s, %s)%n  typeAnnotator=%s%n",
+                    thisClass, treeString, type, typeAnnotator);
+        }
         defaults.annotate(tree, type);
-        log("%s GATF.addComputedTypeAnnotations#7(%s, %s)%n", thisClass, treeString, type);
+        if (debug) {
+            log("%s GATF.addComputedTypeAnnotations#7(%s, %s)%n", thisClass, treeString, type);
+        }
 
         if (this.useFlow) {
             Value inferred = getInferredValueFor(tree);
             if (inferred != null) {
                 applyInferredAnnotations(type, inferred);
-                log(
-                        "%s GATF.addComputedTypeAnnotations#8(%s, %s), inferred=%s%n",
-                        thisClass, treeString, type, inferred);
+                if (debug) {
+                    log(
+                            "%s GATF.addComputedTypeAnnotations#8(%s, %s), inferred=%s%n",
+                            thisClass, treeString, type, inferred);
+                }
             }
         }
-        log(
-                "%s GATF.addComputedTypeAnnotations#9(%s, %s, %s) done%n",
-                thisClass, treeString, type, this.useFlow);
+        if (debug) {
+            log(
+                    "%s GATF.addComputedTypeAnnotations#9(%s, %s, %s) done%n",
+                    thisClass, treeString, type, this.useFlow);
+        }
     }
 
     /**


### PR DESCRIPTION
The `log` message already checks the flag, BUT to call the method a varargs array is created. Checking debug before the call avoids the allocation of the extra array, in frequently executed code.