### PR TITLE
Fix jspecify-conformance build

### DIFF
--- a/checker/bin-devel/test-jspecify-conformance.sh
+++ b/checker/bin-devel/test-jspecify-conformance.sh
@@ -19,7 +19,7 @@ source "$SCRIPT_DIR"/clone-related.sh
 # This duplicates logic from jspecify-conformance/.github/workflows/workflow.yml
 
 trap 'rm -f /tmp/publish-helper.gradle' EXIT
-cat > /tmp/publish-helper.gradle <<'INIT'
+cat > /tmp/publish-helper.gradle << 'INIT'
 allprojects {
   pluginManager.apply('maven-publish')
   tasks.withType(Sign).configureEach { enabled = false }
@@ -30,7 +30,7 @@ cd ../jspecify
 ./gradlew --console=plain --warning-mode=all --init-script /tmp/publish-helper.gradle :conformance-tests:publishToMavenLocal
 
 cd ../jspecify-reference-checker
-cat > conformance-test-framework/settings.gradle <<'SETTINGS'
+cat > conformance-test-framework/settings.gradle << 'SETTINGS'
 rootProject.name = 'conformance-test-framework'
 dependencyResolutionManagement {
   versionCatalogs {
@@ -44,7 +44,7 @@ dependencyResolutionManagement {
 }
 SETTINGS
 ./gradlew --project-dir conformance-test-framework \
-   --console=plain --warning-mode=all --init-script /tmp/publish-helper.gradle publishToMavenLocal
+  --console=plain --warning-mode=all --init-script /tmp/publish-helper.gradle publishToMavenLocal
 
 cd ../jspecify-conformance
 # This does not use "-PcfVersion=local", because that project does not

--- a/checker/bin-devel/test-jspecify-conformance.sh
+++ b/checker/bin-devel/test-jspecify-conformance.sh
@@ -12,6 +12,39 @@ source "$SCRIPT_DIR"/clone-related.sh
 ./gradlew assembleForJavac --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 "$SCRIPT_DIR/.git-scripts/git-clone-related" eisop jspecify-conformance
+"$SCRIPT_DIR/.git-scripts/git-clone-related" jspecify jspecify
+"$SCRIPT_DIR/.git-scripts/git-clone-related" jspecify jspecify-reference-checker
+
+# Build conformance test artifacts locally.
+# This duplicates logic from jspecify-conformance/.github/workflows/workflow.yml
+
+cat > /tmp/publish-helper.gradle <<'INIT'
+allprojects {
+  pluginManager.apply('maven-publish')
+  tasks.withType(Sign).configureEach { enabled = false }
+}
+INIT
+
+cd ../jspecify
+./gradlew --init-script /tmp/publish-helper.gradle :conformance-tests:publishToMavenLocal
+
+cd ../jspecify-reference-checker
+cat > conformance-test-framework/settings.gradle <<'SETTINGS'
+rootProject.name = 'conformance-test-framework'
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      library('guava', 'com.google.guava:guava:33.6.0-jre')
+      library('jspecify', 'org.jspecify:jspecify:1.0.0')
+      library('truth', 'com.google.truth:truth:1.4.5')
+      library('junit', 'junit:junit:4.13.2')
+    }
+  }
+}
+SETTINGS
+./gradlew --project-dir conformance-test-framework \
+   --init-script /tmp/publish-helper.gradle publishToMavenLocal
+
 cd ../jspecify-conformance
 # This does not use "-PcfVersion=local", because that project does not
 # use the CF gradle plugin.

--- a/checker/bin-devel/test-jspecify-conformance.sh
+++ b/checker/bin-devel/test-jspecify-conformance.sh
@@ -18,6 +18,7 @@ source "$SCRIPT_DIR"/clone-related.sh
 # Build conformance test artifacts locally.
 # This duplicates logic from jspecify-conformance/.github/workflows/workflow.yml
 
+trap 'rm -f /tmp/publish-helper.gradle' EXIT
 cat > /tmp/publish-helper.gradle <<'INIT'
 allprojects {
   pluginManager.apply('maven-publish')
@@ -26,7 +27,7 @@ allprojects {
 INIT
 
 cd ../jspecify
-./gradlew --init-script /tmp/publish-helper.gradle :conformance-tests:publishToMavenLocal
+./gradlew --console=plain --warning-mode=all --init-script /tmp/publish-helper.gradle :conformance-tests:publishToMavenLocal
 
 cd ../jspecify-reference-checker
 cat > conformance-test-framework/settings.gradle <<'SETTINGS'
@@ -43,9 +44,9 @@ dependencyResolutionManagement {
 }
 SETTINGS
 ./gradlew --project-dir conformance-test-framework \
-   --init-script /tmp/publish-helper.gradle publishToMavenLocal
+   --console=plain --warning-mode=all --init-script /tmp/publish-helper.gradle publishToMavenLocal
 
 cd ../jspecify-conformance
 # This does not use "-PcfVersion=local", because that project does not
 # use the CF gradle plugin.
-./gradlew test --console=plain -PcfLocal
+./gradlew test --console=plain --warning-mode=all -PcfLocal


### PR DESCRIPTION
This duplicates the extra build logic from https://github.com/eisop/jspecify-conformance/pull/141.
Let https://github.com/eisop/jspecify-conformance/issues/143 clean this up, too.