### PR TITLE
Add missing `TypeKind.MODULE` that was covered by `AnnotatedNoType`

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -979,7 +979,8 @@ public class QualifierDefaults {
                     && k != TypeKind.WILDCARD
                     && k != TypeKind.TYPEVAR
                     && k != TypeKind.VOID
-                    && k != TypeKind.PACKAGE;
+                    && k != TypeKind.PACKAGE
+                    && k != TypeKind.MODULE;
         }
 
         /**

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -962,7 +962,8 @@ public class QualifierDefaults {
 
         /**
          * Returns true if the given qualifier should be applied to the given type. Currently we do
-         * not apply defaults to void types, packages, wildcards, and type variables.
+         * not apply defaults to void types, none types, wildcards, type variables, packages, and
+         * modules.
          *
          * @param type type to which qual would be applied
          * @return true if this application should proceed


### PR DESCRIPTION
Hopefully, this will work on Java 8, as we use Error Prone javac.