### PR TITLE
Use `IdentityHashMap` for `Element` and `Tree` keys

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -24,7 +24,6 @@ import org.checkerframework.javacutil.ElementUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Objects;
 import java.util.PriorityQueue;
@@ -75,7 +74,7 @@ public abstract class AbstractAnalysis<
     private @Nullable IdentityHashMap<Node, V> syncedFrom;
 
     /** Map from (effectively final) local variable elements to their abstract value. */
-    protected final HashMap<VariableElement, V> finalLocalValues = new HashMap<>();
+    protected final IdentityHashMap<VariableElement, V> finalLocalValues = new IdentityHashMap<>();
 
     /**
      * The node that is currently handled in the analysis (if it is running). The following

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3674,7 +3674,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
      * map is necessary because dataflow does not create a {@code Node} for a {@code
      * ParenthesizedTree}.
      */
-    private final Map<Tree, ParenthesizedTree> parenMapping = new HashMap<>();
+    private final IdentityHashMap<Tree, ParenthesizedTree> parenMapping = new IdentityHashMap<>();
 
     @Override
     public Node visitParenthesized(ParenthesizedTree tree, Void p) {

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -361,6 +361,55 @@ so small per-call wins paid back substantially.
   and `AnnotationConverter`: iterate `map.entrySet()` instead of `map.keySet()`
   followed by `map.get(key)`, eliminating a redundant second hash lookup per
   iteration.
+- **PR #1781** — *`IdentityHashMap` for caches keyed by `Element`/`Tree`.* javac `Symbol`s
+  and `JCTree`s use identity `equals`/`hashCode` (they do not override `Object`'s),
+  so a `HashMap` keyed by them was *already* an identity map — switching to
+  `IdentityHashMap` does not change behavior, it just drops the per-entry `Node`
+  allocation (open addressing) and replaces the virtual `hashCode()`/`equals()`
+  dispatch with `System.identityHashCode`/`==`. Converted six long-lived,
+  identity-keyed maps that had been left as `HashMap`:
+  - `AnnotatedTypeFactory.cacheDeclAnnos` (`Element` → `AnnotationMirrorSet`;
+    populated by the hot `getDeclAnnotations`),
+  - `GenericAnnotatedTypeFactory.subcheckerSharedCFG` (`Tree` → `ControlFlowGraph`;
+    pre-sized to `getCacheSize()`),
+  - `GenericAnnotatedTypeFactory.scannedClasses` (`ClassTree` → `ScanState`),
+  - `TreePathCacher.foundPaths` (`Tree` → `TreePath`),
+  - `CFGTranslationPhaseOne.parenMapping` (`Tree` → `ParenthesizedTree`; built
+    per-method during CFG construction),
+  - `AbstractAnalysis.finalLocalValues` (`VariableElement` → abstract value) —
+    this one was the lone `HashMap` among siblings (`nodeValues`, `inputs`,
+    `treeLookup`, `postfixLookup`) that were *already* `IdentityHashMap`.
+
+  **Safety rule for this conversion.** `IdentityHashMap.equals`/`hashCode` compare
+  *values* by reference too (they intentionally violate the `Map.equals` contract),
+  so only convert a map that is never `Map.equals`-compared. The dataflow *fixpoint*
+  compares `CFAbstractStore`s, not these maps, and none of the six is passed to
+  `Map.equals` — verify this before converting any further map. Audited but **left
+  as `HashMap`**: method-local short-lived maps (`InferenceResult`,
+  `DependentTypesHelper.checkTypesForErrorKey`, `BaseTypeVisitor` javaparser pairing)
+  where there is no entry-allocation pressure to remove, the stub-parser
+  `AnnotationFileParser.atypes` (cold for real workloads — stub parsing only
+  dominates in test-harness amplification), and the 4-entry
+  `LombokSupport.defaultedElements`.
+
+  **Measured impact (full-build A/B, June 2026).** This is an allocation/dispatch
+  reduction, not a measurable speedup. Wall clock on `./gradlew checknullness` (all
+  ~10 subprojects, warm daemon, processor `shadowJar` rebuilt each side, median of
+  ≥3 warm reps) was **~2m34 s with vs. ~2m32 s without — within run-to-run noise**;
+  the build-level gain is below the wall-clock floor. The mechanism is real but small
+  in the JFR profile (full-build `--no-daemon` traces): `HashMap$Node` dropped from
+  **3.21% → 2.76%** of TLAB allocation events (6,856 vs. 7,315 absolute — fewer even
+  though that branch trace sampled ~10% *more* total allocation), and with the
+  `[Ljava.util.HashMap$Node;` backing arrays the HashMap internals fell **4.66% →
+  4.02%**. Leaf self-time in `HashMap.getNode` fell **3.38% → 2.27%**, partly offset by
+  `IdentityHashMap.get` rising **1.28% → 1.50%** (cheaper per call: `identityHashCode`
+  + `==` + flat-array probe vs. virtual `hashCode`/`equals` + `Node` chase). Retained
+  memory was **unchanged**: post-GC live heap maxed at 512 MB on both sides with p90/median
+  within noise, and GC count/summed-pause were flat (647/7.86 s vs. 660/7.93 s) — the flat
+  `Object[]` of `IdentityHashMap` is roughly memory-neutral against `HashMap`'s
+  `Node[]`-plus-`Node`s for these small, long-lived maps. The takeaway: file such
+  identity-map conversions for their cumulative GC-pressure relief, not for a standalone
+  wall-clock win.
 - **Gotcha — avoid `Objects.hash(...)` / `Arrays.hashCode(...)` on hot paths.**
   `Objects.hash(a, b, ...)` is varargs, so each call allocates an `Object[]` *and*
   autoboxes every primitive argument to its wrapper — e.g. `Objects.hash(int, int)`

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -341,7 +341,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * A cache used to store elements whose declaration annotations have already been stored by
      * calling the method {@link #getDeclAnnotations(Element)}.
      */
-    private final Map<Element, AnnotationMirrorSet> cacheDeclAnnos;
+    private final IdentityHashMap<Element, AnnotationMirrorSet> cacheDeclAnnos;
 
     /**
      * A set containing declaration annotations that should be inherited. A declaration annotation
@@ -634,7 +634,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         this.ajavaTypes = new AnnotationFileElementTypes(this);
         this.currentFileAjavaTypes = null;
 
-        this.cacheDeclAnnos = new HashMap<>();
+        this.cacheDeclAnnos = new IdentityHashMap<>();
         this.methodDeclaresPolyCache = new IdentityHashMap<>();
 
         // get the shared instance from the checker

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -324,7 +324,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * <p>The initial capacity of the map is set by {@link #getCacheSize()}.
      */
-    protected @MonotonicNonNull Map<Tree, ControlFlowGraph> subcheckerSharedCFG;
+    protected @MonotonicNonNull IdentityHashMap<Tree, ControlFlowGraph> subcheckerSharedCFG;
 
     /**
      * If true, {@link #setRoot(CompilationUnitTree)} should clear the {@link #subcheckerSharedCFG}
@@ -1123,7 +1123,7 @@ public abstract class GenericAnnotatedTypeFactory<
     }
 
     /** Map from ClassTree to their dataflow analysis state. */
-    protected final Map<ClassTree, ScanState> scannedClasses = new HashMap<>();
+    protected final IdentityHashMap<ClassTree, ScanState> scannedClasses = new IdentityHashMap<>();
 
     /*
      * A set of trees whose corresponding nodes are reachable. This is not an exhaustive set of
@@ -3181,7 +3181,7 @@ public abstract class GenericAnnotatedTypeFactory<
         if (parentIsThisChecker) {
             // This is the ultimate parent.
             if (this.subcheckerSharedCFG == null) {
-                this.subcheckerSharedCFG = new HashMap<>(getCacheSize());
+                this.subcheckerSharedCFG = new IdentityHashMap<>(getCacheSize());
             }
             if (!this.subcheckerSharedCFG.containsKey(tree)) {
                 this.subcheckerSharedCFG.put(tree, cfg);

--- a/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
@@ -8,8 +8,7 @@ import com.sun.source.util.TreeScanner;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.IdentityHashMap;
 
 /**
  * TreePathCacher is a TreeScanner that creates and caches a TreePath for a target Tree.
@@ -20,7 +19,7 @@ import java.util.Map;
  */
 public class TreePathCacher extends TreeScanner<TreePath, Tree> {
 
-    private final Map<Tree, @Nullable TreePath> foundPaths = new HashMap<>(32);
+    private final IdentityHashMap<Tree, @Nullable TreePath> foundPaths = new IdentityHashMap<>(32);
 
     /**
      * The TreePath of the previous tree scanned. It is always set back to null after a scan has

--- a/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
@@ -40,6 +40,9 @@ public class TreePathCacher extends TreeScanner<TreePath, Tree> {
      */
     private @Nullable TreePath path;
 
+    /** Construct a TreePathCacher. */
+    public TreePathCacher() {}
+
     /**
      * Returns true if the tree is cached.
      *

--- a/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
@@ -19,6 +19,19 @@ import java.util.IdentityHashMap;
  */
 public class TreePathCacher extends TreeScanner<TreePath, Tree> {
 
+    /**
+     * Caches the {@link TreePath} of every {@link Tree} scanned so far, including the intermediate
+     * trees on the way to a search target; these are reused when later targets share a prefix. A
+     * {@code null} value is meaningful: it records that a target was searched for via {@link
+     * #getPath} but is not present in the compilation unit, so the unit is not re-scanned for it.
+     * See {@link #getCachedPath} for how the two readings of a {@code null} lookup are
+     * distinguished.
+     *
+     * <p>This is an {@link IdentityHashMap} rather than a {@link java.util.HashMap} because javac
+     * {@link Tree}s do not override {@code Object}'s identity {@code equals}/{@code hashCode};
+     * keying by identity is therefore equivalent in behavior while avoiding the per-entry node
+     * allocation and virtual {@code equals}/{@code hashCode} dispatch.
+     */
     private final IdentityHashMap<Tree, @Nullable TreePath> foundPaths = new IdentityHashMap<>(32);
 
     /**


### PR DESCRIPTION
Antigravity proposed the change with three changed files. Then Claude expanded it with two more places.

The performance trace shows minimal impact, but it does reduce some hash computations and is conceptually consistent.