### PR TITLE
Use the `TreePathCacher` in `CFCFGBuilder`

### DIFF
--- a/.claude/skills/cf-performance/SKILL.md
+++ b/.claude/skills/cf-performance/SKILL.md
@@ -170,6 +170,60 @@ combined samples). `getThread()` is `null` in these traces, so per-thread
 filtering does not work — but the compilation is single-threaded, so every
 `ExecutionSample` is real work and no filtering is needed.
 
+## Measuring allocation deterministically (when TLAB sampling is too noisy)
+
+JFR's allocation events (`jdk.ObjectAllocationSample`, TLAB) are **sampled**: two
+identical runs of these workloads vary ~2× in per-class allocation counts (real example:
+`TreePath` read 3060 vs. 1376 samples across two identical runs), which buries any sub-2%
+allocation change. The `alloc`/`top` modes above are for **attribution** (which CF frame
+allocates a class), *not* for the magnitude of a small change.
+
+For magnitude, read `jdk.ThreadAllocationStatistics` instead — it reports each thread's
+**cumulative** bytes allocated (not sampled), so a deterministic single-process workload
+reproduces to ~0.15%. Run one forked `javac` over a fixed source set and read it back:
+
+```
+checker/bin/javac \
+  -J-XX:StartFlightRecording=settings=profile,filename=run.jfr,dumponexit=true \
+  -processor nullness -d /tmp/out  Foo.java ...
+java .claude/skills/cf-performance/alloc-total.java run.jfr
+```
+
+Median of ≥3 runs/side; a real change clears the ~0.5% run-to-run band. This is the
+allocation analogue of the wall-clock A/B below and caught a −4% change TLAB sampling
+could not resolve. (`-J` forwards the flag to the forked compiler JVM — `checker/bin/javac`
+is `CheckerMain`, which forks. Use a single source set so there is one compile thread.)
+It measures exactly the checker + javac allocation, independent of GC/JIT scheduling.
+
+## Detecting super-linear (quadratic) costs with a size sweep
+
+The all-systems corpus is 267 **tiny** files (1–3 method bodies each): a good
+getPath / per-file-fixed-cost stressor, but **blind to any cost that is super-linear in a
+per-compilation-unit dimension** — those wash out at small N. The per-body `Trees.getPath`
+search in CFG construction (PR #1786) was **quadratic in methods-per-file** yet measured
+**~0% on all-systems**; only a size sweep exposed it:
+
+| methods/file | master | after | reduction |
+| --- | --- | --- | --- |
+| 100  |    524 MB |    506 MB |  −3.5% |
+| 600  |  3525 MB |  2737 MB | −22.4% |
+| 1500 | 15192 MB | 10193 MB | −32.9% |
+
+Generate the inputs and sweep with the deterministic reader:
+
+```
+for n in 100 300 600 1500; do
+  .claude/skills/cf-performance/gen-sized-program.py $n > /tmp/Big$n.java
+done
+# A/B each Big$n.java per side (allocation reader above); plot allocation/wall vs. n.
+```
+
+A curve that is super-linear on master and flattens after the change is the quadratic's
+signature. **Report both ends:** small-N is the realistic per-file cost (typically
+low-single-digit), large-N is worst-case protection (machine-generated / giant
+single-class files). Tune the generator's method body for other mechanisms (deep
+expression nesting, many fields, large `switch`).
+
 ## Measuring wall-clock effects (the A/B that decides if a change is worth it)
 
 JFR self-time / `phase` percentages are for **mechanism** ("which leaf
@@ -208,6 +262,24 @@ added footprint. Caveat learned: shrinking a cache to reclaim that memory is
 **not free** — a `directSupertypes` cap halving recovered ~half its footprint
 but cost ≈10% wall clock (far more than its hit-rate delta implied). Cut
 *per-entry weight*, not entry count, when memory matters.
+
+## Two habits that paid off
+
+- **Size a risky change before building it — instrument and *simulate*.** Before
+  rewriting a hot path, add pure-counting instrumentation that *also* simulates the
+  proposed variant's metric, changing no behavior. A counter on the eager `new TreePath`
+  in `CFGTranslationPhaseOne.scan` that *also* simulated a lazy-stack alternative showed
+  the lazy version would save 47.9% of only **0.56%** of `TreePath` allocation (~0.01% of
+  total) — rejected in minutes, no risky rewrite of dataflow's central traversal. The JFR
+  `alloc` nearest-CF attribution is what tells you which line to instrument (here it
+  separated the per-tree `scan`, 0.56%, from the body-path `process`, 70%).
+- **Re-measure marginal or "rejected" optimizations after a related change lands.** An
+  optimization's value scales with the **traffic** through the code it touches, and another
+  change can amplify it. A lazy `TreePathCacher` was ~1–4% standalone, but layered on
+  PR #1786 (which routes one `getPath` per body through the cacher) it was **−51%** on a
+  1500-method file — synergy, not additivity. A "not worth it" verdict is not permanent
+  across an evolving hot path; the *Tried and rejected* section is a starting point, not a
+  closed book.
 
 ## What to look for
 
@@ -251,7 +323,11 @@ Before submitting, always:
 1. `./gradlew assemble` — must succeed.
 2. `./gradlew :framework:test :javacutil:test :dataflow:test` — fast.
 3. The relevant checker test, e.g. `./gradlew :checker:NullnessTest`.
-4. Ideally `./gradlew alltests` — the canonical regression catch.
+4. Ideally `./gradlew alltests` — the canonical regression catch. If it fails *only*
+   on `:checker:jtregTests` / `:checker:jtregJdk11Tests` with `No java executable at
+   java`, that is an environment issue, **not a regression**: `JAVA_HOME` is unset. Set
+   it (`JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))`) and re-run those
+   two tasks; the JUnit suites are unaffected.
 5. Re-capture JFR on the **full** workload (`./gradlew --no-daemon
    checknullness`, all subprojects — confirm `phase` shows no scope warning)
    and confirm the targeted metric moved. Report the **whole-worker sample

--- a/.claude/skills/cf-performance/alloc-total.java
+++ b/.claude/skills/cf-performance/alloc-total.java
@@ -1,0 +1,56 @@
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Deterministic total-allocation reader for a single forked-javac JFR recording.
+ *
+ * <p>JFR's {@code jdk.ObjectAllocationSample} / TLAB events are *sampled*: on these workloads two
+ * identical runs vary by ~2x in per-class allocation counts, which drowns any sub-2% allocation
+ * change (see the {@code alloc} mode of jfr-analyze, which is for *attribution*, not magnitude).
+ * {@code jdk.ThreadAllocationStatistics} instead reports each thread's *cumulative* bytes
+ * allocated — it is not sampled, so for a deterministic single-process workload it reproduces to
+ * ~0.15%. That makes it the right tool for an allocation A/B of a small change.
+ *
+ * <p>Capture (the forked compiler JVM, single source set so there is one compile thread):
+ *
+ * <pre>
+ *   checker/bin/javac \
+ *     -J-XX:StartFlightRecording=settings=profile,filename=run.jfr,dumponexit=true \
+ *     -processor nullness -d /tmp/out  Foo.java ...
+ *   java .claude/skills/cf-performance/alloc-total.java run.jfr
+ * </pre>
+ *
+ * Take the median of >=3 runs per side; a real change is the one that clears the ~0.5% run-to-run
+ * band. This measures the single compilation thread (javac is single-threaded), so it is the exact
+ * bytes the checker + javac allocated, independent of GC/JIT scheduling.
+ */
+public class alloc_total {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.err.println("usage: java alloc-total.java <recording.jfr> [more.jfr ...]");
+            System.exit(2);
+        }
+        // Sum the maximum cumulative ThreadAllocationStatistics.allocated per thread = total bytes.
+        Map<Long, Long> maxByThread = new HashMap<>();
+        long events = 0;
+        for (String path : args) {
+            for (RecordedEvent e : RecordingFile.readAllEvents(Paths.get(path))) {
+                if (e.getEventType().getName().equals("jdk.ThreadAllocationStatistics")) {
+                    long allocated = e.getLong("allocated");
+                    long tid = e.getThread() != null ? e.getThread().getId() : -1;
+                    maxByThread.merge(tid, allocated, Math::max);
+                    events++;
+                }
+            }
+        }
+        long total = maxByThread.values().stream().mapToLong(Long::longValue).sum();
+        System.out.printf(
+                "ThreadAllocationStatistics events=%d threads=%d  TOTAL ALLOCATED = %,d bytes ="
+                        + " %.1f MB%n",
+                events, maxByThread.size(), total, total / 1048576.0);
+    }
+}

--- a/.claude/skills/cf-performance/gen-sized-program.py
+++ b/.claude/skills/cf-performance/gen-sized-program.py
@@ -23,6 +23,7 @@ triggers CFG construction, flow analysis, and getPath/type-argument inference --
 machinery that exercises the tree-path and dataflow hot paths. Tune `body` for other
 mechanisms (deep expression nesting, many fields, large switch, etc.).
 """
+
 import sys
 
 

--- a/.claude/skills/cf-performance/gen-sized-program.py
+++ b/.claude/skills/cf-performance/gen-sized-program.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Generate a single-class Java program with N methods, for perf size sweeps.
+
+Some costs are super-linear in a per-compilation-unit dimension (e.g. the per-body
+`Trees.getPath` search in CFG construction was quadratic in methods-per-file) and are
+therefore *invisible* on the all-systems corpus, whose files are tiny (1-3 method bodies
+each). Sweeping N and plotting allocation/wall vs N exposes the quadratic and separates
+the realistic case (small N) from the worst case (large N).
+
+Usage:
+    gen-sized-program.py 1500 > Big1500.java          # one size
+    for n in 100 300 600 1500; do                     # a sweep
+        gen-sized-program.py $n > Big$n.java
+    done
+
+Then A/B each side with the deterministic allocation reader:
+    checker/bin/javac -J-XX:StartFlightRecording=settings=profile,filename=r.jfr,dumponexit=true \\
+        -processor nullness -d /tmp/out Big$n.java
+    java .claude/skills/cf-performance/alloc-total.java r.jfr
+
+Each method has a non-trivial body (locals, a generic call, a branch, a return) so it
+triggers CFG construction, flow analysis, and getPath/type-argument inference -- the
+machinery that exercises the tree-path and dataflow hot paths. Tune `body` for other
+mechanisms (deep expression nesting, many fields, large switch, etc.).
+"""
+import sys
+
+
+def generate(n: int) -> str:
+    lines = ["class Big {", "    static <T> T id(T x) { return x; }"]
+    for i in range(n):
+        lines += [
+            f"    Object m{i}(Object a{i}, Object b{i}) {{",
+            f"        Object x{i} = id(a{i});",
+            f"        Object y{i} = id(b{i});",
+            f"        if (x{i} == y{i}) {{ return x{i}; }}",
+            f"        return id(y{i});",
+            "    }",
+        ]
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: gen-sized-program.py <method-count>")
+    sys.stdout.write(generate(int(sys.argv[1])))

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -523,7 +523,12 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
      * @return a PhaseOneResult
      */
     public PhaseOneResult process(CompilationUnitTree root, UnderlyingAST underlyingAST) {
-        // TODO: Isn't this costly? Is there no cache we can reuse?
+        // This Trees.getPath is an uncached full-tree search (a PathFinder scan from the
+        // compilation-unit root down to the body), so calling it once per body is quadratic in
+        // bodies-per-file. The checker pipeline avoids it: CFCFGBuilder.build serves the body
+        // path from the checker's shared TreePathCacher and calls process(TreePath, ...)
+        // directly. This overload is the uncached fallback for callers that have no cacher (the
+        // standalone CFGProcessor tool); there it runs once per body and is not on a hot path.
         TreePath bodyPath = trees.getPath(root, underlyingAST.getCode());
         assert bodyPath != null;
         return process(bodyPath, underlyingAST);
@@ -559,6 +564,11 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
         @SuppressWarnings("interning:not.interned") // Looking for exact match.
         boolean treeIsLeaf = path.getLeaf() != tree;
         if (treeIsLeaf) {
+            // One TreePath is allocated per visited tree to maintain getCurrentPath(). Despite the
+            // volume, this is not a hotspot: a JFR allocation trace attributes only ~0.56% of
+            // TreePath allocation (~0.01% of total) to this line. Materializing the path lazily (a
+            // Tree stack built on demand in getCurrentPath()) was measured to save <0.01% of total
+            // allocation and rejected; see docs/developer/performance-notes.md ("Lazy path stack").
             path = new TreePath(path, tree);
         }
         try {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,14 @@ and most scans visit only a few nodes; the smaller pre-size cuts that allocation
 substantially and lowers GC pressure with no wall-clock cost. Also pre-sized the
 small `wildcardToAnnos` map in `ElementAnnotationUtil` to 4.
 
+Performance: `CFCFGBuilder` now obtains each method/lambda body's `TreePath` from the
+checker's shared `TreePathCacher` instead of an uncached `Trees.getPath` search per
+body. The old search was quadratic in bodies-per-file (each rescanned the preceding
+bodies) and was the largest `TreePath` allocator; caching it removes that quadratic.
+The effect scales with methods-per-file: negligible on small files, but large on very
+large or machine-generated single-class files (e.g. −33% allocation, −6.5% wall clock
+on a 1500-method class).
+
 Fixed a bug that caused an IndexOutOfBoundsException for lambdas in varargs,
 for type systems that had the Aliasing Checker as a subchecker, like the
 Optional Checker.

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -450,6 +450,75 @@ so small per-call wins paid back substantially.
   varargs `hash`/`Arrays.hashCode` family allocates. Precompute the result into a
   `final int hash` field when the key is immutable, as both new cache keys do.
 
+### CFG-builder body-path lookup
+
+- **PR #1786 — cache the per-body `TreePath` lookup in `CFCFGBuilder` (June 2026).**
+  `CFGTranslationPhaseOne.process(CompilationUnitTree, UnderlyingAST)` (line ~527)
+  computed the body's path with an *uncached* `trees.getPath(root, code)` — a JDK
+  `Trees.PathFinder` `TreeScanner` that allocates a `new TreePath` per node visited
+  while searching from the compilation-unit root down to the body, **once per method
+  / lambda / initializer body**. For the *k*-th body in a file it re-scans the
+  preceding *k*−1 bodies, so cost is **quadratic in bodies-per-compilation-unit**.
+  This was the single largest `TreePath` allocator: on a full `checknullness`
+  `--no-daemon` trace, `CFGTranslationPhaseOne.process` was the nearest-CF frame for
+  **70%** of `com.sun.source.util.TreePath` allocation samples (2146 of 3057), vs. the
+  per-tree path extension at `CFGTranslationPhaseOne.scan` (line ~562) at only
+  **0.56%** (17 samples) — see the rejected "lazy path stack" note below.
+
+  **Fix.** `CFCFGBuilder.build` already holds `checker` and `atypeFactory`, so it
+  owns the checker's shared `TreePathCacher` (the same instance the `AnnotatedTypeFactory`
+  populates during visiting). Replace the uncached search with
+  `checker.getTreePathCacher().getPath(root, underlyingAST.getCode())` and feed the
+  result into the existing `process(TreePath, UnderlyingAST)` overload. The cacher
+  serves the enclosing class/method prefix from cache (warmed by visiting) and caches
+  each node's path once, collapsing the per-body re-scan from O(bodies × file) toward
+  O(file). **No class move is needed** — the framework-side caller already has the
+  cache; the dataflow `CFGBuilder.build` standalone-tool path (used by `CFGProcessor`,
+  which has no checker) is left on `trees.getPath`. This is a ~6-line change at one
+  call site, no dataflow API change. It only does `getPath(root, realBodyTree)`
+  lookups against the real AST keyed by tree identity, so none of the artificial-tree
+  / bulk-population hazards of caching from the per-tree CFG traversal apply.
+
+  **Measured allocation (deterministic `ThreadMXBean.getThreadAllocatedBytes` via JFR
+  `ThreadAllocationStatistics`, single forked `javac`, one class of *N* trivial
+  generic-call methods).** The win scales with methods-per-file, exactly as the
+  quadratic predicts:
+
+  | methods / file | master | cached | reduction |
+  | --- | --- | --- | --- |
+  | 100  |    524 MB |    506 MB |  −3.5% |
+  | 300  |  1,453 MB |  1,251 MB | −13.9% |
+  | 600  |  3,525 MB |  2,737 MB | −22.4% |
+  | 1500 | 15,192 MB | 10,193 MB | −32.9% (wall −6.5%, 46.3 → 43.3 s) |
+
+  On the all-systems corpus (267 *tiny* files, 1–3 bodies each) the effect is **~0%
+  (noise)** — there is no per-file body reuse to exploit. On the realistic CF build the
+  site is ~1.4% of total allocation (70% of `TreePath`, which is ~2% of TLAB events),
+  so a normal mixed codebase sees a low-single-digit allocation reduction; the large
+  numbers are worst-case protection for machine-generated or very large single-class
+  files, where it removes a genuine quadratic. Wall clock tracks allocation (only
+  measurable where allocation is large). The shared cache now retains the body-prefix
+  paths it builds (bounded by the compilation unit — the same eager-scan caching the
+  cacher already does on `AnnotatedTypeFactory.getPath` fallbacks). Validated with
+  `framework`/`dataflow`/`NullnessTest` and `alltests`.
+
+  **Synergy with a lazy `TreePathCacher` (follow-up candidate).** The eager
+  `TreePathCacher.getPath` caches a `TreePath` for *every* node it DFS-traverses while
+  searching for the target — so each per-body lookup added here caches the preceding
+  bodies' internal nodes too, even though only body trees are ever queried. On large
+  files that is O(file-nodes) of needless cached allocation. A lazy cacher whose scan
+  allocates only the path *to the target* (the uncommitted `buildPathForStack` rewrite,
+  "State A") removes it. Measured **on top of** this body-path caching (deterministic
+  harness): **−4.0%** allocation on all-systems and **−51.6%** on the 1500-method class
+  (−67.5% vs. master combined; `NullnessTest`/`framework:test` pass). Standalone — without
+  this body-path caching — the same lazy rewrite was only ~1% on realistic builds (its
+  `getPath` traffic was just the rare `AnnotatedTypeFactory` fallback), so the two changes
+  are **synergistic**: routing per-body lookups through the cacher is what makes the lazy
+  scan pay off. Caveat: the lazy rewrite's second `getPath(TreePath, Tree)` overload is
+  subtle (its correctness rests on non-obvious cache-collapse behavior — small "cleanups"
+  to it crashed type-argument inference during review); pursue it as a separate,
+  carefully-reviewed change gated on `alltests`, not bundled with this one.
+
 ### Value Checker
 
 - **PR #1647** — *Cache a frequent conversion in the Value Checker.*
@@ -575,6 +644,22 @@ the prior finding. A fresh hypothesis is not new evidence.
 - **`AnnotatedTypeMirror.getEffectiveAnnotations` caching.** JFR-
   attributed self-time was ~0.05% on the alltests trace and ~0.1% on
   the Oscar EMR (~4000 file) trace. Not a hotspot.
+- **Lazy path stack in `CFGTranslationPhaseOne.scan` (June 2026, during PR #1786).** `scan` eagerly does
+  `new TreePath(path, tree)` for *every* tree it visits to maintain `getCurrentPath()`,
+  and most of those paths are never queried (only `MethodInvocationNode`, 1 of 78 node
+  types, retains one; the other 22 of 23 `getCurrentPath()` call sites feed
+  `TreePathUtil` helpers that extract a fact and drop the path). The proposed fix: keep
+  a `Tree` stack and materialize the `TreePath` lazily on `getCurrentPath()`, allocating
+  nothing for unqueried trees. **Rejected as not worth it: the target is negligible.**
+  Pure-counting instrumentation (no behavior change; it also *simulates* the lazy stack's
+  allocation count) on the all-systems corpus measured **eagerAllocs = 11,665 (~373 KB)**
+  for the whole 267-file run, of which the lazy stack would save 47.9% — i.e. ~178 KB
+  against a ~6 GB total. The JFR agrees: `CFGTranslationPhaseOne.scan` (line ~562) is
+  only **0.56%** of `TreePath` allocation (17 samples), ≈0.01% of total. The "70% of
+  `TreePath` allocs in the CFG builder" headline is **not** this line — it is the body-path
+  *search* at `process` / line ~527 (see the applied "CFG-builder body-path lookup" note),
+  which caching fixes for ~6 lines instead of a risky rewrite of dataflow's central
+  traversal.
 - **Pre-sizing `AnnotationMirrorSet`'s backing array (June 2026, during PR #1785).**
   `AnnotationMirrorSet.<init>` was the 2nd-largest `Object[]` source in the `checknullness`
   worker (18.77%, 6,901 samples, behind only the visitor maps). But it is not oversized: the

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFCFGBuilder.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFCFGBuilder.java
@@ -68,6 +68,11 @@ public class CFCFGBuilder extends CFGBuilder {
         }
 
         CFTreeBuilder builder = new CFTreeBuilder(env);
+        // Serve the body path from the checker's shared TreePathCacher (populated during visiting)
+        // instead of an uncached Trees.getPath full-tree search per body (the old hotspot at
+        // CFGTranslationPhaseOne.process / line 527).
+        TreePath bodyPath = checker.getTreePathCacher().getPath(root, underlyingAST.getCode());
+        assert bodyPath != null;
         PhaseOneResult phase1result =
                 new CFCFGTranslationPhaseOne(
                                 builder,
@@ -76,7 +81,7 @@ public class CFCFGBuilder extends CFGBuilder {
                                 assumeAssertionsEnabled,
                                 assumeAssertionsDisabled,
                                 env)
-                        .process(root, underlyingAST);
+                        .process(bodyPath, underlyingAST);
         ControlFlowGraph phase2result = CFGTranslationPhaseTwo.process(phase1result);
         ControlFlowGraph phase3result = CFGTranslationPhaseThree.process(phase2result);
         if (atypeFactory instanceof GenericAnnotatedTypeFactory) {


### PR DESCRIPTION
Use the existing TreePath to optimize very large classes.