### PR TITLE
Use more `IdentityHashMap`s to avoid thrashing of caches

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,6 +71,17 @@ list's iterator; the read-only iterator now walks the backing list by index. Thi
 single largest remaining source of `Iterator` allocation in type checking. No user-visible
 behavior change.
 
+Performance: the `AnnotatedTypeFactory` tree-type caches (`classAndMethodTreeCache`,
+`fromExpressionTreeCache`, `fromMemberTreeCache`, `fromTypeTreeCache`, and `elementToTreeCache`) are
+now unbounded `IdentityHashMap`s cleared per compilation unit, rather than LRU caches capped at 2048
+entries. On a large compilation unit the live tree set overflowed the cap, so the LRU evicted
+still-needed entries and recomputed (and deep-copied) their annotated types; the per-compilation-unit
+`IdentityHashMap` removes that thrash. A single pass over each enclosing method/class now records all of
+its declaration trees instead of re-scanning per local variable, and `AnnotatedTypeCopier` reuses a
+thread-local map instead of allocating one per copy. Total allocation on large single-class files
+dropped 14-19% (e.g. -19% on a 1500-method class) and about 7% on a many-file corpus; wall clock is
+roughly unchanged, the gain being reduced GC pressure. No user-visible behavior change.
+
 Fixed a bug that caused an IndexOutOfBoundsException for lambdas in varargs,
 for type systems that had the Aliasing Checker as a subchecker, like the
 Optional Checker.

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -700,6 +700,40 @@ under "Short list"; this is the canonical applied summary.
   `declarationFromElement` −33%, **total on-CPU −5.1%**. Key distinction from the rejected
   `trees.getTree(localVar)` variant: `trees.getTree` on the *enclosing method* is cheap (position-based),
   whereas on the *local itself* it internally scans.
+- **PR #1791** — *Per-CU `IdentityHashMap` tree caches, one-pass declaration scan, pooled copier map.*
+  Three changes that remove cache thrash and redundant recomputation on large compilation units:
+  (1) **LRU → `IdentityHashMap`.** `classAndMethodTreeCache`, `fromExpressionTreeCache`,
+  `fromMemberTreeCache`, `fromTypeTreeCache`, and `elementToTreeCache` were bounded
+  `CollectionsPlume.createLruCache(2048)` maps. On a large CU the live tree set overflows 2048, so the
+  LRU evicts still-needed entries and re-`getAnnotatedType`s them — each miss recomputes *and*
+  `deepCopy()`s the ATM (`classAndMethodTreeCache.put(tree, type.deepCopy())`). Plain `IdentityHashMap`s
+  (Tree/Element keys are identity-compared anyway) remove the eviction thrash; they stay bounded in
+  practice because `setRoot` already clears all five per compilation unit, so peak size is one CU's tree
+  count, not the whole build. This swap alone is the bulk of the win.
+  (2) **`DeclarationScanner` (extends PR #1780).** Rather than `TreeInfo.declarationFor(sym,
+  enclosingTree)` per local/parameter, the first lookup into a given enclosing method/class scans that
+  subtree once and records every variable/method/class declaration into `elementToTreeCache`; a
+  `scannedEnclosingTrees` identity set (also cleared in `setRoot`) makes the scan once-per-subtree so
+  sibling lookups hit the cache. Falls back to the full-CU `TreeInfo.declarationFor` if the scan misses.
+  (3) **`AnnotatedTypeCopier` map pool.** `visit` allocated a fresh `IdentityHashMap` per copy; it now
+  borrows a thread-local pooled map (cleared after use, fresh-map fallback if re-entrant).
+  **Deterministic allocation A/B** (single forked `javac`, `jdk.ThreadAllocationStatistics`; see
+  Reproducing measurements): total bytes allocated **−14.5% / −17.1% / −19.2%** on 300- / 600- /
+  1500-method single-class files and **−6.6%** on an 80-file (15-method) corpus — the win grows with
+  per-CU size, since that is when the 2048 LRU thrashes. The LRU→`IdentityHashMap` swap on its own is
+  −10% to −13.5%; the scanner and copier pool add the rest. **Wall clock is roughly neutral** (≈ −3% at
+  1500 methods, within noise) on heap-generous single-file compiles — these are not GC-bound, so the
+  reduced allocation does not shorten them; the payoff is GC pressure / memory headroom, most relevant
+  under default heap on a many-CU warm-daemon build. *Build/measure caveat:* flipping sides with `git
+  stash` does **not** reliably recompile — `:framework:compileJava` reports `UP-TO-DATE` and serves the
+  other side's classes — so force `--rerun-tasks` and gate each run by decompiling the shipped
+  `checker/dist/checker.jar` (e.g. count `createLruCache` call sites in `AnnotatedTypeFactory`: 9 on
+  master, 4 with this change). An un-gated early A/B read this change as ~0%, a false negative from two
+  stale shadowJars. Dropped from the original proposal as separately risky and *not* part of the
+  allocation win: a never-cleared `IdentityHashMap<AnnotationMirror, QualifierKind>` in the qualifier
+  hierarchies (unbounded over a whole build) and disabling the per-CU
+  `defaultQualifierForUseTypeAnnotator.clearCache()` (cross-CU staleness — the cache reads element
+  annotated types that stubs/ajava refine).
 
 ---
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -90,10 +90,31 @@ public class AnnotatedTypeCopier
         this(true);
     }
 
+    /**
+     * Thread-local pool for the IdentityHashMap used during copy operations to avoid allocation.
+     */
+    private static final ThreadLocal<IdentityHashMap<AnnotatedTypeMirror, AnnotatedTypeMirror>>
+            mapPool =
+                    ThreadLocal.withInitial(
+                            () ->
+                                    new IdentityHashMap<>(
+                                            AnnotatedTypeScanner.VISITED_NODES_INITIAL_CAPACITY));
+
     @Override
     public AnnotatedTypeMirror visit(AnnotatedTypeMirror type) {
-        return type.accept(
-                this, new IdentityHashMap<>(AnnotatedTypeScanner.VISITED_NODES_INITIAL_CAPACITY));
+        IdentityHashMap<AnnotatedTypeMirror, AnnotatedTypeMirror> map = mapPool.get();
+        boolean mustClear = !map.isEmpty();
+        if (mustClear) {
+            // Safe fallback if re-entrant or map was not properly cleared.
+            map = new IdentityHashMap<>(AnnotatedTypeScanner.VISITED_NODES_INITIAL_CAPACITY);
+        }
+        try {
+            return type.accept(this, map);
+        } finally {
+            if (!mustClear) {
+                map.clear();
+            }
+        }
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -6601,6 +6601,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * unit, which would be much more expensive.
      */
     private class DeclarationScanner extends com.sun.source.util.TreeScanner<Void, Void> {
+        /** Create a DeclarationScanner. */
+        DeclarationScanner() {}
+
         @Override
         public Void visitVariable(VariableTree node, Void p) {
             com.sun.tools.javac.code.Symbol sym =

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -504,25 +504,25 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     private static final int DEFAULT_CACHE_SIZE = 2048;
 
     /** Mapping from a Tree to its annotated type; defaults have been applied. */
-    private final Map<Tree, AnnotatedTypeMirror> classAndMethodTreeCache;
+    private final IdentityHashMap<Tree, AnnotatedTypeMirror> classAndMethodTreeCache;
 
     /**
      * Mapping from an expression tree to its annotated type; before defaults are applied, just what
      * the programmer wrote.
      */
-    protected final Map<Tree, AnnotatedTypeMirror> fromExpressionTreeCache;
+    protected final IdentityHashMap<Tree, AnnotatedTypeMirror> fromExpressionTreeCache;
 
     /**
      * Mapping from a member tree to its annotated type; before defaults are applied, just what the
      * programmer wrote.
      */
-    protected final Map<Tree, AnnotatedTypeMirror> fromMemberTreeCache;
+    protected final IdentityHashMap<Tree, AnnotatedTypeMirror> fromMemberTreeCache;
 
     /**
      * Mapping from a type tree to its annotated type; before defaults are applied, just what the
      * programmer wrote.
      */
-    protected final Map<Tree, AnnotatedTypeMirror> fromTypeTreeCache;
+    protected final IdentityHashMap<Tree, AnnotatedTypeMirror> fromTypeTreeCache;
 
     /**
      * Mapping from an Element to its annotated type; before defaults are applied, just what the
@@ -543,7 +543,12 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     private final @Nullable Map<Element, AnnotatedTypeMirror> elementTypeCache;
 
     /** Mapping from an Element to the source Tree of the declaration. */
-    private final Map<Element, Tree> elementToTreeCache;
+    private final IdentityHashMap<Element, Tree> elementToTreeCache;
+
+    /**
+     * Set of enclosing trees (like MethodTree/ClassTree) already scanned for variable declarations.
+     */
+    private final @Nullable Set<Tree> scannedEnclosingTrees;
 
     /**
      * Cache for the substituted method type from {@link #computeMethodTypeAsMemberOf} — the
@@ -643,13 +648,14 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         this.shouldCache = !checker.hasOption("atfDoNotCache");
         if (shouldCache) {
             int cacheSize = getCacheSize();
-            this.classAndMethodTreeCache = CollectionsPlume.createLruCache(cacheSize);
-            this.fromExpressionTreeCache = CollectionsPlume.createLruCache(cacheSize);
-            this.fromMemberTreeCache = CollectionsPlume.createLruCache(cacheSize);
-            this.fromTypeTreeCache = CollectionsPlume.createLruCache(cacheSize);
+            this.classAndMethodTreeCache = new IdentityHashMap<>();
+            this.fromExpressionTreeCache = new IdentityHashMap<>();
+            this.fromMemberTreeCache = new IdentityHashMap<>();
+            this.fromTypeTreeCache = new IdentityHashMap<>();
             this.elementCache = CollectionsPlume.createLruCache(cacheSize);
             this.elementTypeCache = CollectionsPlume.createLruCache(cacheSize);
-            this.elementToTreeCache = CollectionsPlume.createLruCache(cacheSize);
+            this.elementToTreeCache = new IdentityHashMap<>();
+            this.scannedEnclosingTrees = Collections.newSetFromMap(new IdentityHashMap<>());
             this.methodAsMemberOfCache = CollectionsPlume.createLruCache(cacheSize);
             this.directSupertypesCache = CollectionsPlume.createLruCache(cacheSize);
             this.annotationClassNames = new IdentityHashMap<>();
@@ -661,6 +667,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             this.elementCache = null;
             this.elementTypeCache = null;
             this.elementToTreeCache = null;
+            this.scannedEnclosingTrees = null;
             this.methodAsMemberOfCache = null;
             this.directSupertypesCache = null;
             this.annotationClassNames = null;
@@ -1065,6 +1072,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             // Clear the caches with trees because once the compilation unit changes,
             // the trees may be modified and lose type arguments.
             elementToTreeCache.clear();
+            scannedEnclosingTrees.clear();
             fromExpressionTreeCache.clear();
             fromMemberTreeCache.clear();
             fromTypeTreeCache.clear();
@@ -4323,12 +4331,12 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 // does not contain the declaration.
                 Element enclosing = elt.getEnclosingElement();
                 Tree enclosingTree = enclosing == null ? null : trees.getTree(enclosing);
-                fromElt =
-                        enclosingTree instanceof com.sun.tools.javac.tree.JCTree
-                                ? com.sun.tools.javac.tree.TreeInfo.declarationFor(
-                                        (com.sun.tools.javac.code.Symbol) elt,
-                                        (com.sun.tools.javac.tree.JCTree) enclosingTree)
-                                : null;
+                if (shouldCache
+                        && enclosingTree != null
+                        && scannedEnclosingTrees.add(enclosingTree)) {
+                    new DeclarationScanner().scan(enclosingTree, null);
+                }
+                fromElt = shouldCache ? elementToTreeCache.get(elt) : null;
                 if (fromElt == null) {
                     fromElt =
                             com.sun.tools.javac.tree.TreeInfo.declarationFor(
@@ -6582,5 +6590,48 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             }
         }
         return false;
+    }
+
+    /**
+     * A scanner that maps symbols to their declaration trees and populates {@link
+     * #elementToTreeCache}.
+     *
+     * <p>This scanner is used to look up trees for variables, methods, and classes within an
+     * enclosing scope (such as a method or a class) rather than scanning the entire compilation
+     * unit, which would be much more expensive.
+     */
+    private class DeclarationScanner extends com.sun.source.util.TreeScanner<Void, Void> {
+        @Override
+        public Void visitVariable(VariableTree node, Void p) {
+            com.sun.tools.javac.code.Symbol sym =
+                    com.sun.tools.javac.tree.TreeInfo.symbolFor(
+                            (com.sun.tools.javac.tree.JCTree) node);
+            if (sym != null) {
+                elementToTreeCache.put(sym, node);
+            }
+            return super.visitVariable(node, p);
+        }
+
+        @Override
+        public Void visitMethod(MethodTree node, Void p) {
+            com.sun.tools.javac.code.Symbol sym =
+                    com.sun.tools.javac.tree.TreeInfo.symbolFor(
+                            (com.sun.tools.javac.tree.JCTree) node);
+            if (sym != null) {
+                elementToTreeCache.put(sym, node);
+            }
+            return super.visitMethod(node, p);
+        }
+
+        @Override
+        public Void visitClass(ClassTree node, Void p) {
+            com.sun.tools.javac.code.Symbol sym =
+                    com.sun.tools.javac.tree.TreeInfo.symbolFor(
+                            (com.sun.tools.javac.tree.JCTree) node);
+            if (sym != null) {
+                elementToTreeCache.put(sym, node);
+            }
+            return super.visitClass(node, p);
+        }
     }
 }


### PR DESCRIPTION
Originally proposed, together with a few other changes I'll handle separately, by Antigravity, then reviewed and measured with Claude.