### PR TITLE
Path-related performance optimizations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ respectively). Several optimizations also reduce GC pressure.
 
 **Implementation details:**
 
+Performance: when reporting a warning or error on a tree, the path used for the
+`@SuppressWarnings` lookup is now found starting from the visitor's current path
+rather than rescanning the whole compilation unit from its root. This was
+O(compilation unit) per reported message, hence quadratic for code that produces
+many messages (e.g. the Interning Checker on a file with many `==` comparisons);
+on a generated 3000-comparison file its on-CPU samples dropped about 2x.
+
 Performance: the synthetic array tree created for a varargs call is now given a tree
 path under the call site, so defaulting its type no longer rescans the whole
 compilation unit via `getPath`. This was O(compilation unit) per varargs call --

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,15 @@ respectively). Several optimizations also reduce GC pressure.
 
 **Implementation details:**
 
+Performance: `AnnotatedTypeFactory.declarationFromElement` no longer calls
+`Trees.getTree` to locate the enclosing declaration of a member or variable,
+which made javac scan the enclosing class on every call (O(class) per call,
+O(class^2) across a class's members). It now obtains the enclosing method/class
+tree from the current visitor path when available, and `DeclarationScanner`
+caches declarations under their raw symbol. Reduces `declarationFromElement`
+from 8.4% to 1.5% of `checkNullness` self time and is about 7% faster
+end-to-end; worst-case (a single large class) improves by roughly half.
+
 Enabled the Gradle configuration cache, speeding up build times.
 
 `AnnotationMirrorSet` has a new `get(int)` method that returns the element at a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ respectively). Several optimizations also reduce GC pressure.
 
 **Implementation details:**
 
+Performance: the synthetic array tree created for a varargs call is now given a tree
+path under the call site, so defaulting its type no longer rescans the whole
+compilation unit via `getPath`. This was O(compilation unit) per varargs call --
+quadratic over a file of varargs calls; on a 3000-call file the nullness checker's
+on-CPU samples dropped about 4x. Only checkers that default heavily (e.g. nullness)
+were affected.
+
 Performance: `AnnotatedTypeFactory.declarationFromElement` no longer calls
 `Trees.getTree` to locate the enclosing declaration of a member or variable,
 which made javac scan the enclosing class on every call (O(class) per call,

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -962,6 +962,73 @@ under "Short list"; this is the canonical applied summary.
   regression. Same flattening signature as the PR #1786 body-path quadratic; like that one it is
   invisible on the tiny-file all-systems corpus and only a size sweep exposes it.
 
+### Tree-search quadratics: `declarationFromElement`, varargs arrays, and warning paths (PR #1803, June 2026)
+
+Three independent O(n²)-in-compilation-unit-size scans, each a per-element or per-message
+`Trees.getTree` / `getPath` / `TreePathCacher` search that rescanned the whole enclosing class
+or compilation unit. All three are **worst-case protection** — super-linear only on large or
+machine-generated single-class files, or on message-dense code — found by a shape × size ×
+checker sweep (`gen-sized-program.py` `{generic,vararg,deep-nesting,many-fields}` ×
+N=300/1000/3000 × `{nullness,interning,value}`) and each confirmed by instrumenting the
+scanner's node-visit count: **nodes-per-`getPath` growing with N** is the signature (e.g. the
+varargs case scanned ~6,400 nodes/call at N=300 and ~31,600 at N=1500 — the whole unit each time).
+
+- **`declarationFromElement` member/variable lookup via the visitor path.** Even after
+  PR #1791/#1793's `DeclarationScanner` and subtree fallback, `declarationFromElement` still
+  called `trees.getTree(elt)` (member) and `trees.getTree(enclosing)` (a variable's enclosing
+  method), and javac implements `Trees.getTree(Element)` as a `TreeInfo.declarationFor` scan of
+  the enclosing class — O(class) per call, O(class²) across a class's members. (The in-code
+  comment claiming `getTree` on a method is "position-based cheap" is wrong; it scans.) Fix:
+  obtain the enclosing method/class tree from the factory's `visitorTreePath` (already set to
+  the method body during flow analysis — the path through which these lookups arrive) instead of
+  `trees.getTree`; the path is only a search-start hint, so the result is unchanged. Also fixed
+  `DeclarationScanner` to cache by the raw `JCTree.sym`, not `TreeInfo.symbolFor`'s
+  `baseSymbol()` — under `baseSymbol()` a generic method or a parameter is stored at a key no
+  lookup ever uses. Full-build `checknullness` JFR: `declarationFromElement` 8.4% → 1.5%
+  inclusive, `DeclScanner.scan` 200 → 21 samples; warm-daemon wall ~1m51s → ~1m43s (~7%, median
+  of ≥3 reps/side, `shadowJar` rebuilt per side); a 1500-method single class 21.95s → 11.56s
+  (−47%). `alltests` passes.
+
+- **Varargs synthetic-array path.** `checkVarargs` → `getAnnotatedTypeVarargsArray` computes the
+  type of the synthetic `NewArrayTree` the CFG builder wraps a varargs call's arguments in. That
+  tree is not in the compilation unit, so defaulting it (`QualifierDefaults.nearestEnclosingExceptLocal`
+  → `getPath`) made `TreePathCacher` scan the whole unit to fail to find it — O(unit) per varargs
+  call. (`CFGTranslationPhaseOne`'s `handleArtificialTree` registers the same tree's path, but that
+  registration does not reach this consumer.) Fix: register the array's path under the call site —
+  `setPathForArtificialTree(arrayTree, new TreePath(getPath(callTree), arrayTree))` — before typing
+  it; the call tree's own path is cheap because the call is being visited. Nullness vararg-shape
+  on-CPU samples 12,306 → 2,597 at N=3000 (growth ~20× → ~4× over a 10× size increase);
+  `TreeScanner.scan` under `getPath` 1,016 → 10 at N=1500. Only heavily-defaulting checkers
+  (nullness) were affected; interning and the Value Checker default little and were already flat.
+
+- **`@SuppressWarnings` / precise-position path lookup.** Reporting a message calls
+  `SourceChecker.shouldSuppressWarnings(tree)` (and `getSourceWithPrecisePosition`), which looked
+  up the tree's path with `getTreePathCacher().getPath(currentRoot, tree)` — a scan from the
+  compilation-unit root — for the suppression walk. O(unit) per reported message, so a
+  message-dense checker is quadratic in file size. The Interning Checker reports on every `==`, so
+  a 3000-comparison file spent ~46% of on-CPU samples scanning for paths and grew ~6.6× over a 10×
+  size increase (nullness, which does not report on those expressions, was unaffected). Fix: new
+  `SourceChecker.pathToTree`, which starts the search from `visitor.getCurrentPath()` (public on
+  `TreePathScanner`; an ancestor of the reported tree, which is being visited) and falls back to
+  the root scan otherwise — same path result, local search. Interning generic-shape on-CPU samples
+  1,567 → 715 at N=3000, growth ~6.6× → ~2.9× (linear). **This helps any checker that emits many
+  messages, not just interning.**
+
+A unifying lesson: a per-element or per-message `Trees.getTree` / `getPath` that re-derives a
+tree's position scans the enclosing class or whole unit, which is super-linear when the caller
+iterates members or messages. The fix is to **reuse position context the program already has** —
+the visitor path, or a registered path for a synthetic tree — so the lookup localizes, rather
+than to add another cache. Diagnostic caution: the JDK `TreePath.getPath(path, target)` "is it
+under this path?" check is unreliable here — it searches the whole compilation unit of `path` and
+returns non-null if `target` is found anywhere, not only under the leaf, so it does not confirm
+locality. Instrument the cacher's node-visit count instead.
+
+A post-fix verification sweep (the same shape × size × checker matrix) confirmed every
+shape is linear/sublinear across all three checkers, with the top leaves at N=3000 being
+irreducible framework work (`HashMap`/`IdentityHashMap` lookups, `AnnotatedTypeScanner`) rather
+than tree scans. The sole remaining super-linear shape is `deep-nesting` (typeinference8; see
+the Short list).
+
 ---
 
 ## Tried and rejected
@@ -1227,6 +1294,39 @@ the prior finding. A fresh hypothesis is not new evidence.
   allocation totals. See the Short list for the one way to make the same-size `equals` cheap enough
   (a maintained content hash) and why it was not pursued.
 
+- **`declarationFromElement` eager whole-class `DeclarationScanner` batch (PR #1803 session).**
+  Before the visitor-path fix shipped (Applied optimizations), the first attempt located the
+  outermost enclosing class and scanned it once with `DeclarationScanner` to cache every member's
+  tree. It helped a 1500-method single class (~11%) but **regressed realistic `checknullness`:
+  `declarationFromElement` 8.4% → 14.4% inclusive, warm wall 2m15s → 2m26s (~+8%)**. Cause: the
+  eager scan recurses into every method body (once per each nullness subchecker factory) — overhead
+  that does not pay off on realistic many-small-class CUs — and javac's symbol-identity instability
+  (queries arrive with view / `baseSymbol` symbols, not the declaration symbol) means parameters
+  and locals miss the batch cache and fall back to a class-level scan anyway. The visitor-path fix
+  replaced it: it adds **zero** scans, so it helps large classes and never regresses small ones.
+  Lesson reaffirmed: a giant-single-class A/B can read as a big win while the realistic full build
+  regresses; always A/B the full build.
+
+- **Pointing `visitorTreePath` at the inference expression during type-argument inference
+  (PR #1803 session).** A hypothesis for the varargs `getPath` quadratic: set the factory's
+  `visitorTreePath` to `pathToExpression` around `DefaultTypeArgumentInference.inferTypeArgs`.
+  **No effect** — only ~8% of the hot `getPath` scans were under inference; the real sources were
+  the synthetic varargs array and (for interning) the warning-report path, both fixed separately.
+
+- **typeinference8 incorporation: removing redundant `applyInstantiations` work (two attempts,
+  both measured-neutral, PR #1803 session).** Deeply nested generic invocations
+  (`id(id(...id(x)))`) make Java-8 type-argument inference super-linear in nesting *depth*
+  (`VariableBounds.applyInstantiationsToBounds` is ~14% self-time on the `deep-nesting` shape; a
+  depth-80 single method does not finish in 25 minutes). (1) Computing `bound.applyInstantiations()`
+  once instead of twice (the change-check, then the rebuild) was **neutral** — the fast-path
+  already breaks on the first changed bound, so the redundancy was ~1 bound, not 2×. (2) Deleting
+  the redundant per-iteration full apply-pass in `BoundSet.incorporateToFixedPoint` (the loop that
+  re-applies to every variable before the per-variable loop) was **neutral** — those calls are
+  individually cheap no-ops. The cost is **not** redundant work: 69% of self-time is in
+  `applyInstantiationsToBounds`'s own loops over cheap `UseOfVariable` bounds, i.e. the O(depth³)
+  *count* of (variable × bound × fixpoint-iteration) tuples the JLS-18 incorporation fixpoint
+  processes. The only direction that could change the complexity is in the Short list.
+
 ---
 
 ## Short list
@@ -1234,6 +1334,21 @@ the prior finding. A fresh hypothesis is not new evidence.
 Candidates raised in profiling sessions but not yet implemented. Capture
 format: hot method, hypothesis, blockers/open questions.
 
+- **typeinference8 incorporation is O(depth³) on deeply nested generic invocations.** Java-8
+  type-argument inference (`BoundSet.incorporateToFixedPoint` → `VariableBounds.applyInstantiationsToBounds`)
+  re-applies instantiations to *every* inference variable on *every* fixpoint iteration; for a
+  depth-D nested-`id` chain that is O(D) iterations × O(D) variables × O(D) bounds. Measured on the
+  `--shape deep-nesting` generator (`gen-sized-program.py`): a 1500-method file (depth-20 bodies)
+  times out (>8 min) under nullness; depth-80 in a single method does not finish in 25 min. The
+  per-method constant scales with the qualifier hierarchy (nullness ≫ interning ≈ value). Real but
+  **worst-case-only** — deeply nested generic chains are not in the realistic `checkNullness` top
+  leaves. Two safe micro-optimizations were tried and measured neutral (see Tried and rejected); the
+  cost is the fixpoint's tuple *count*, not redundant work. The only direction that could change the
+  complexity is **dependency-based incremental incorporation**: re-process only the variables whose
+  bounds reference a newly-instantiated variable, cutting the O(variables)-per-iteration factor. That
+  is a substantial, correctness-critical change to JLS-18 inference (a subtly wrong incorporation
+  order yields wrong inferred types that `alltests` need not catch); pursue only as a dedicated,
+  downstream-validated effort, not a patch.
 - **`ElementUtils.qualifiedNameCache` backing map.** Hot method
   (`getQualifiedName` underlies `annotationName`, `getBinaryName`, the `isX`
   type predicates, etc.). Today it is a

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1607,7 +1607,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
             return tree;
         }
 
-        TreePath path = getTreePathCacher().getPath(currentRoot, tree);
+        TreePath path = pathToTree(tree);
         if (path == null) {
             return tree;
         }
@@ -2757,9 +2757,28 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
         }
 
         assert this.currentRoot != null : "this.currentRoot == null";
-        TreePath path = getTreePathCacher().getPath(currentRoot, tree);
+        TreePath path = pathToTree(tree);
 
         return shouldSuppressWarnings(path, errKey);
+    }
+
+    /**
+     * Returns the path to {@code tree} within the current compilation unit. Uses the visitor's
+     * current path as a search-start hint when available, so the lookup is local rather than
+     * rescanning the whole compilation unit from its root. {@code tree} is almost always at or
+     * under the tree the visitor is currently processing (e.g. when reporting a warning on it), so
+     * the hint avoids an O(compilation unit) scan; without it, reporting many warnings is quadratic
+     * in the file size.
+     *
+     * @param tree a tree in the current compilation unit
+     * @return the path to {@code tree}, or null if it is not in the current compilation unit
+     */
+    private @Nullable TreePath pathToTree(Tree tree) {
+        TreePath hint = visitor == null ? null : visitor.getCurrentPath();
+        if (hint != null && hint.getCompilationUnit() == currentRoot) {
+            return getTreePathCacher().getPath(hint, tree);
+        }
+        return getTreePathCacher().getPath(currentRoot, tree);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -4319,6 +4319,38 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
+     * Returns the declaration tree of {@code target} if it is a class or method on the current
+     * visitor path, or null otherwise. This is a cheap (path-walking) alternative to {@link
+     * Trees#getTree(Element)}, which scans the enclosing class for a member. It is used to obtain
+     * the enclosing method/class tree of a queried element during flow analysis, when the visitor
+     * path is set to a tree inside that method.
+     *
+     * @param target a class or method element, compared by reference against the path's symbols
+     * @return the declaration tree of {@code target} if found on the current visitor path, else
+     *     null
+     */
+    private @Nullable Tree declarationTreeFromVisitorPath(@FindDistinct @Nullable Element target) {
+        if (target == null) {
+            return null;
+        }
+        for (TreePath path = getVisitorTreePath(); path != null; path = path.getParentPath()) {
+            Tree leaf = path.getLeaf();
+            com.sun.tools.javac.code.Symbol leafSym;
+            if (leaf instanceof com.sun.tools.javac.tree.JCTree.JCMethodDecl) {
+                leafSym = ((com.sun.tools.javac.tree.JCTree.JCMethodDecl) leaf).sym;
+            } else if (leaf instanceof com.sun.tools.javac.tree.JCTree.JCClassDecl) {
+                leafSym = ((com.sun.tools.javac.tree.JCTree.JCClassDecl) leaf).sym;
+            } else {
+                continue;
+            }
+            if (leafSym == target) {
+                return leaf;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Gets the declaration tree for the element, if the source is available.
      *
      * <p>TODO: would be nice to move this to InternalUtils/TreeUtils.
@@ -4372,7 +4404,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 Element enclosing = elt.getEnclosingElement();
                 Tree enclosingTree = null;
                 while (enclosing != null) {
-                    enclosingTree = trees.getTree(enclosing);
+                    // Prefer the enclosing method/class tree from the current visitor path
+                    // (cheap, just walking the path), since trees.getTree on a member scans the
+                    // enclosing class for it.
+                    enclosingTree = declarationTreeFromVisitorPath(enclosing);
+                    if (enclosingTree == null) {
+                        enclosingTree = trees.getTree(enclosing);
+                    }
                     if (enclosingTree != null) {
                         break;
                     }
@@ -6660,8 +6698,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         @Override
         public Void visitVariable(VariableTree node, Void p) {
             com.sun.tools.javac.code.Symbol sym =
-                    com.sun.tools.javac.tree.TreeInfo.symbolFor(
-                            (com.sun.tools.javac.tree.JCTree) node);
+                    ((com.sun.tools.javac.tree.JCTree.JCVariableDecl) node).sym;
             if (sym != null) {
                 elementToTreeCache.put(sym, node);
             }
@@ -6671,8 +6708,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         @Override
         public Void visitMethod(MethodTree node, Void p) {
             com.sun.tools.javac.code.Symbol sym =
-                    com.sun.tools.javac.tree.TreeInfo.symbolFor(
-                            (com.sun.tools.javac.tree.JCTree) node);
+                    ((com.sun.tools.javac.tree.JCTree.JCMethodDecl) node).sym;
             if (sym != null) {
                 elementToTreeCache.put(sym, node);
             }
@@ -6682,8 +6718,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         @Override
         public Void visitClass(ClassTree node, Void p) {
             com.sun.tools.javac.code.Symbol sym =
-                    com.sun.tools.javac.tree.TreeInfo.symbolFor(
-                            (com.sun.tools.javac.tree.JCTree) node);
+                    ((com.sun.tools.javac.tree.JCTree.JCClassDecl) node).sym;
             if (sym != null) {
                 elementToTreeCache.put(sym, node);
             }

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1992,7 +1992,21 @@ public abstract class GenericAnnotatedTypeFactory<
 
         assert !args.isEmpty() : "Arguments are empty";
         Node varargsArray = args.get(args.size() - 1);
-        AnnotatedTypeMirror varargtype = getAnnotatedType(varargsArray.getTree());
+        Tree varargsArrayTree = varargsArray.getTree();
+        // The synthetic vararg array tree (created during CFG construction) is not part of the
+        // compilation unit, so getPath -- called when defaulting its type just below -- would
+        // rescan the whole unit to (fail to) find it. That is O(unit) per vararg call and therefore
+        // quadratic over a file of vararg calls. Register the array's path under the call site so
+        // the lookup is a cache hit instead. The call tree's own path is cheap here: the vararg
+        // call is being visited, so it is on or just above the current visitor path.
+        if (varargsArrayTree != null) {
+            TreePath callPath = getPath(tree);
+            if (callPath != null) {
+                setPathForArtificialTree(
+                        varargsArrayTree, new TreePath(callPath, varargsArrayTree));
+            }
+        }
+        AnnotatedTypeMirror varargtype = getAnnotatedType(varargsArrayTree);
         return varargtype;
     }
 


### PR DESCRIPTION
This removed code that had super-linear scaling. The last one remaining is deep-nesting with typeinference8, which we'll try separately. From the commits:

* Avoid O(class^2) tree scans in declarationFromElement

declarationFromElement located a member's or variable's declaration tree by
calling Trees.getTree, which javac implements as a TreeInfo.declarationFor scan
of the enclosing class -- O(class) per call, so O(class^2) across all of a
class's members. On a 1500-method class this was the dominant cost, and a JFR
full-build checkNullness trace attributed 8.4% of self time to it (DeclScanner
scanning under declarationFromElement).

Obtain the enclosing method/class tree from the current visitor path instead,
which is already set during flow analysis when these lookups happen; the path
is only a locality hint, so getPath still returns the correct result. Also fix
DeclarationScanner to cache declarations under the raw JCTree.sym (the symbol
declarationFor matches and callers query with) rather than TreeInfo.symbolFor's
baseSymbol(), under which members and generic methods were stored at a key no
lookup used. declarationFromElement drops from 8.4% to 1.5% of self time, the
build is about 7% faster warm, and a single large class improves by roughly
half. alltests passes.

* Give varargs array a tree path to avoid O(unit) getPath rescans

checkVarargs computes the type of the synthetic array tree that the CFG builder
creates for a varargs call (via getAnnotatedTypeVarargsArray). That tree is not
part of the compilation unit, so when defaulting its type calls getPath on it,
TreePathCacher rescans the whole compilation unit to (fail to) find it. That is
O(compilation unit) per varargs call, hence quadratic over a file of varargs
calls: on a generated 3000-call file the nullness checker spent ~half its on-CPU
samples in TreeScanner.scan under getPath, and on-CPU samples grew ~20x for a 10x
file-size increase. Only checkers that default heavily (nullness) hit this;
interning and the Value Checker barely default, so they did not.

Register the synthetic array's path under the call site before computing its
type, mirroring CFCFGBuilder.handleArtificialTree. The call tree's own path is
cheap here because the varargs call is being visited. The path gives the array
the call site's defaulting scope, so this is behavior-neutral. On the 3000-call
file, on-CPU samples drop from 12306 to 2597 (the growth is now linear) and
TreeScanner.scan under getPath drops from ~1000 to ~10 at 1500 calls. alltests
passes.

* Find the @SuppressWarnings path from the visitor path, not the root

When reporting a message on a tree, shouldSuppressWarnings and
getSourceWithPrecisePosition looked up the tree's path with
TreePathCacher.getPath(currentRoot, tree), which scans the whole compilation
unit from its root to locate the tree. That is O(compilation unit) per reported
message, so a checker that reports many messages is quadratic in file size. The
Interning Checker reports on every == comparison, so on a generated file of 3000
comparisons it spent ~46% of its on-CPU samples scanning for paths, and on-CPU
samples grew ~6.6x for a 10x file-size increase. Nullness was unaffected because
it does not report on those expressions.

A message is reported while visiting the tree (or a subtree of it), so the
visitor's current path is an ancestor of the tree. Add SourceChecker.pathToTree,
which starts the search from visitor.getCurrentPath() when available -- making
the lookup local -- and falls back to the root scan otherwise. The returned path
is the same; only the search start changes. On the 3000-comparison file the
Interning Checker's on-CPU samples drop from 1567 to 715 and the growth is now
linear (2.8x). This helps any checker that reports many messages. alltests
passes.

* Document the PR #1803 tree-search quadratics in performance-notes

Record the three shipped fixes (declarationFromElement via the visitor path,
the varargs synthetic-array path, and the @SuppressWarnings path lookup) under
Applied optimizations, the reverted attempts (the eager declarationFromElement
class batch that regressed the realistic build, the no-op inference visitorTreePath
hypothesis, and the two neutral typeinference8 incorporation tweaks) under Tried
and rejected, and the remaining O(depth^3) typeinference8 incorporation cost under
Short list.