### PR TITLE
Fix viewpoint adaptation of unbounded wildcards for bounded type variables

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -231,11 +231,7 @@ median of four warm-daemon reps per side).
 
 **Closed issues:**
 
-<<<<<<< eisop-issue-863
-eisop#433, eisop#792, eisop#863.
-=======
-eisop#433, eisop#792, eisop#1801.
->>>>>>> master
+eisop#433, eisop#792, eisop#863, eisop#1801.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -231,7 +231,7 @@ median of four warm-daemon reps per side).
 
 **Closed issues:**
 
-eisop#433, eisop#792.
+eisop#433, eisop#792, eisop#863.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
@@ -513,7 +513,20 @@ public abstract class AbstractViewpointAdapter implements ViewpointAdapter {
 
         List<AnnotatedTypeMirror> tas = decltype.getTypeArguments();
         // return a copy, as we want to modify the type later.
-        return tas.get(foundindex).shallowCopy(true);
+        AnnotatedTypeMirror result = tas.get(foundindex).shallowCopy(true);
+        if (result.getKind() == TypeKind.WILDCARD) {
+            AnnotatedWildcardType wildcard = (AnnotatedWildcardType) result;
+            // When substituting an unbounded wildcard for a bounded type variable, the shallow
+            // copy may no longer know the formal type variable that supplies its effective
+            // extends bound. Preserve that bound so later subtype checks do not treat the
+            // wildcard as simply ? extends Object.
+            if (wildcard.getUnderlyingType().getExtendsBound() == null
+                    && wildcard.getTypeVariable() == null
+                    && wildcard.getSuperBound().getKind() == TypeKind.NULL) {
+                wildcard.setExtendsBound(var.getUpperBound().deepCopy(true));
+            }
+        }
+        return result;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
@@ -517,9 +517,9 @@ public abstract class AbstractViewpointAdapter implements ViewpointAdapter {
         if (result.getKind() == TypeKind.WILDCARD) {
             AnnotatedWildcardType wildcard = (AnnotatedWildcardType) result;
             // When substituting an unbounded wildcard for a bounded type variable, the shallow
-            // copy may no longer know the formal type variable that supplies its effective
-            // extends bound. Preserve that bound so later subtype checks do not treat the
-            // wildcard as simply ? extends Object.
+            // copy might lose the reference to the formal type variable that provides its
+            // effective extends bound. Preserve this bound so that subsequent subtype checks
+            // do not treat the wildcard as implicitly bounded by Object.
             if (wildcard.getUnderlyingType().getExtendsBound() == null
                     && wildcard.getTypeVariable() == null
                     && wildcard.getSuperBound().getKind() == TypeKind.NULL) {

--- a/framework/tests/viewpointtest/WildcardBoundSubstitution.java
+++ b/framework/tests/viewpointtest/WildcardBoundSubstitution.java
@@ -8,9 +8,7 @@ public class WildcardBoundSubstitution<
 
     static class Store<V extends Value<V>, S extends Store<V, S>> {}
 
-    public abstract static class FactoryBase<
-            V extends Value<V>,
-            S extends Store<V, S>> {
+    public abstract static class FactoryBase<V extends Value<V>, S extends Store<V, S>> {
         abstract S getStore();
     }
 

--- a/framework/tests/viewpointtest/WildcardBoundSubstitution.java
+++ b/framework/tests/viewpointtest/WildcardBoundSubstitution.java
@@ -1,0 +1,20 @@
+// Test case for EISOP Issue 863:
+// https://github.com/eisop/checker-framework/issues/863
+
+public class WildcardBoundSubstitution<
+        Factory extends WildcardBoundSubstitution.FactoryBase<?, ?>> {
+
+    static class Value<V extends Value<V>> {}
+
+    static class Store<V extends Value<V>, S extends Store<V, S>> {}
+
+    public abstract static class FactoryBase<
+            V extends Value<V>,
+            S extends Store<V, S>> {
+        abstract S getStore();
+    }
+
+    void use(Factory factory) {
+        Store<?, ?> store = factory.getStore();
+    }
+}


### PR DESCRIPTION
Fixes #863.

The failing case occurs when viewpoint adaptation substitutes an unbounded wildcard actual type argument for a bounded formal type variable. The wildcard can lose the formal type variable context that supplies its effective upper bound, causing later subtype checks to treat it as `? extends Object` instead of preserving the formal bound.
In the regression test, `FactoryBase<?, ?>.getStore()` returns a type variable whose formal bound is `Store<V, S>`. Without the fix, assigning that result to `Store<?, ?>` crashes the checker with an AsSuperVisitor error.