### PR TITLE
Performance: eliminate `Objects.hash` boxing and fix zero-hash caching

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayAccess.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayAccess.java
@@ -4,8 +4,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.Store;
 import org.checkerframework.javacutil.AnnotationProvider;
 
-import java.util.Objects;
-
 import javax.lang.model.type.TypeMirror;
 
 /** An array access. */
@@ -113,7 +111,10 @@ public class ArrayAccess extends JavaExpression {
     @Override
     public int hashCode() {
         if (hashCodeCache == 0) {
-            hashCodeCache = Objects.hash(array, index);
+            int h = 1;
+            h = 31 * h + (array != null ? array.hashCode() : 0);
+            h = 31 * h + (index != null ? index.hashCode() : 0);
+            hashCodeCache = h == 0 ? 1 : h;
         }
         return hashCodeCache;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/BinaryOperation.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/BinaryOperation.java
@@ -8,8 +8,6 @@ import org.checkerframework.dataflow.cfg.node.BinaryOperationNode;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.BugInCF;
 
-import java.util.Objects;
-
 import javax.lang.model.type.TypeMirror;
 
 /** JavaExpression for binary operations. */
@@ -136,14 +134,18 @@ public class BinaryOperation extends JavaExpression {
     @Override
     public int hashCode() {
         if (hashCodeCache == 0) {
+            int h = 1;
+            h = 31 * h + (operationKind != null ? operationKind.hashCode() : 0);
             if (isCommutative()) {
                 // equals() ignores operand order for commutative operations, so the hash code
                 // must not depend on operand order either.  Use a symmetric combination of the
                 // operand hash codes (addition) so that "a OP b" and "b OP a" hash identically.
-                hashCodeCache = Objects.hash(operationKind, left.hashCode() + right.hashCode());
+                h = 31 * h + (left.hashCode() + right.hashCode());
             } else {
-                hashCodeCache = Objects.hash(operationKind, left, right);
+                h = 31 * h + (left != null ? left.hashCode() : 0);
+                h = 31 * h + (right != null ? right.hashCode() : 0);
             }
+            hashCodeCache = h == 0 ? 1 : h;
         }
         return hashCodeCache;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/ClassName.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/ClassName.java
@@ -4,8 +4,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.Store;
 import org.checkerframework.javacutil.AnnotationProvider;
 
-import java.util.Objects;
-
 import javax.lang.model.type.TypeMirror;
 
 /**
@@ -47,7 +45,7 @@ public class ClassName extends JavaExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeString);
+        return typeString.hashCode();
     }
 
     @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/FormalParameter.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/FormalParameter.java
@@ -7,8 +7,6 @@ import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TypeAnnotationUtils;
 
-import java.util.Objects;
-
 import javax.lang.model.element.VariableElement;
 
 /**
@@ -74,12 +72,12 @@ public class FormalParameter extends JavaExpression {
     public int hashCode() {
         if (hashCodeCache == 0) {
             VarSymbol vs = (VarSymbol) element;
-            hashCodeCache =
-                    Objects.hash(
-                            index,
-                            vs.name.toString(),
-                            TypeAnnotationUtils.unannotatedType(vs.type).toString(),
-                            vs.owner.toString());
+            int h = 1;
+            h = 31 * h + Integer.hashCode(index);
+            h = 31 * h + vs.name.toString().hashCode();
+            h = 31 * h + TypeAnnotationUtils.unannotatedType(vs.type).toString().hashCode();
+            h = 31 * h + vs.owner.toString().hashCode();
+            hashCodeCache = h == 0 ? 1 : h;
         }
         return hashCodeCache;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -8,8 +8,6 @@ import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
-import java.util.Objects;
-
 import javax.lang.model.element.VariableElement;
 
 /**
@@ -89,7 +87,11 @@ public class LocalVariable extends JavaExpression {
     public int hashCode() {
         if (hashCodeCache == 0) {
             VarSymbol vs = (VarSymbol) element;
-            hashCodeCache = Objects.hash(vs.pos, vs.name, vs.owner);
+            int h = 1;
+            h = 31 * h + Integer.hashCode(vs.pos);
+            h = 31 * h + (vs.name != null ? vs.name.hashCode() : 0);
+            h = 31 * h + (vs.owner != null ? vs.owner.hashCode() : 0);
+            hashCodeCache = h == 0 ? 1 : h;
         }
         return hashCodeCache;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
@@ -7,7 +7,6 @@ import org.checkerframework.javacutil.AnnotationProvider;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.StringJoiner;
 
 import javax.lang.model.element.ElementKind;
@@ -180,12 +179,17 @@ public class MethodCall extends JavaExpression {
     @Override
     public int hashCode() {
         if (hashCodeCache == 0) {
+            int h;
             if (method.getKind() == ElementKind.CONSTRUCTOR) {
                 // No two constructor instances have the same hashcode.
-                hashCodeCache = System.identityHashCode(this);
+                h = System.identityHashCode(this);
             } else {
-                hashCodeCache = Objects.hash(method, receiver, arguments);
+                h = 1;
+                h = 31 * h + (method != null ? method.hashCode() : 0);
+                h = 31 * h + (receiver != null ? receiver.hashCode() : 0);
+                h = 31 * h + (arguments != null ? arguments.hashCode() : 0);
             }
+            hashCodeCache = h == 0 ? 1 : h;
         }
         return hashCodeCache;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/UnaryOperation.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/UnaryOperation.java
@@ -8,8 +8,6 @@ import org.checkerframework.dataflow.cfg.node.UnaryOperationNode;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.BugInCF;
 
-import java.util.Objects;
-
 import javax.lang.model.type.TypeMirror;
 
 /** JavaExpression for unary operations. */
@@ -111,7 +109,10 @@ public class UnaryOperation extends JavaExpression {
     @Override
     public int hashCode() {
         if (hashCodeCache == 0) {
-            hashCodeCache = Objects.hash(operationKind, operand);
+            int h = 1;
+            h = 31 * h + (operationKind != null ? operationKind.hashCode() : 0);
+            h = 31 * h + (operand != null ? operand.hashCode() : 0);
+            hashCodeCache = h == 0 ? 1 : h;
         }
         return hashCodeCache;
     }

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -533,6 +533,23 @@ so small per-call wins paid back substantially.
   `Objects.hash(kind, left.hashCode() + right.hashCode())` so that `a OP b`
   and `b OP a` hash identically. This is a correctness fix for the `equals`/`hashCode`
   contract that also improves cache hit rates for commutative expressions.
+- **PR #1812 — eliminate `Objects.hash` boxing and fix zero-hash caching.** Two
+  related fixes applied across the remaining `JavaExpression`
+  subclasses (`ArrayAccess`, `BinaryOperation`, `FormalParameter`, `LocalVariable`,
+  `MethodCall`, `UnaryOperation`, `ClassName`) and several framework/javacutil classes
+  (`CFAbstractValue`, `DiagMessage`, `AnnotationMirrorSet`):
+  (1) **`Objects.hash` removal.** Each `hashCode()` that used `Objects.hash(...)` was
+  rewritten to the equivalent `h = 31 * h + field.hashCode()` polynomial, eliminating
+  the varargs `Object[]` allocation and autoboxing per call (see the "Gotcha" entry
+  in Generic map/lookup patterns for the general rule).
+  (2) **Zero-hash sentinel fix.** The lazy `hashCodeCache == 0` guard used by
+  PR #1643 treats 0 as "not yet computed". A hash that genuinely computes to 0 would
+  be recomputed on every call, defeating the cache. Fixed throughout with
+  `hashCodeCache = h == 0 ? 1 : h`, remapping the all-zero case to 1.
+  (3) **`QualifierVar` gains a cached hash code.** `QualifierVar.hashCode()` was
+  previously uncached despite calling `Objects.hash(id, invocation, polyQualifier)`
+  (where `invocation.hashCode()` can itself be expensive). Added a `cachedHashCode`
+  field with the same lazy + zero-sentinel pattern.
 
 ### Dataflow stores, analysis, and transfer
 
@@ -645,6 +662,10 @@ so small per-call wins paid back substantially.
   invocation. The two-arg `Objects.equals` is fine (no array/boxing); only the
   varargs `hash`/`Arrays.hashCode` family allocates. Precompute the result into a
   `final int hash` field when the key is immutable, as both new cache keys do.
+  A follow-up sweep (PR #1812) applied the same rewrite to the remaining
+  `JavaExpression` subclasses and framework classes still using `Objects.hash` in
+  their cached `hashCode()` implementations, and also fixed the zero-hash sentinel
+  bug (see Dataflow expressions above).
 
 ### CFG-builder body-path lookup
 

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -205,7 +205,7 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements A
         if (!hashCodeComputed) {
             int h = annotations.hashCode();
             h = 31 * h + (underlyingType == null ? 0 : underlyingType.hashCode());
-            hashCodeCache = h;
+            hashCodeCache = h == 0 ? 1 : h;
             hashCodeComputed = true;
         }
         return hashCodeCache;

--- a/framework/src/main/java/org/checkerframework/framework/source/DiagMessage.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/DiagMessage.java
@@ -121,7 +121,7 @@ public class DiagMessage {
             int h = (kind == null ? 0 : kind.hashCode());
             h = 31 * h + (messageKey == null ? 0 : messageKey.hashCode());
             h = 31 * h + Arrays.hashCode(args);
-            hashCodeCache = h;
+            hashCodeCache = h == 0 ? 1 : h;
             hashCodeComputed = true;
         }
         return hashCodeCache;

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/QualifierVar.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/QualifierVar.java
@@ -74,9 +74,19 @@ public class QualifierVar extends AbstractQualifier {
                 && Objects.equals(polyQualifier, that.polyQualifier);
     }
 
+    /** Cached hash code to prevent repeated recomputation of complex deep-hashes. */
+    private int cachedHashCode = 0;
+
     @Override
     public int hashCode() {
-        return Objects.hash(id, invocation, polyQualifier);
+        if (cachedHashCode == 0) {
+            int h = 1;
+            h = 31 * h + id;
+            h = 31 * h + (invocation != null ? invocation.hashCode() : 0);
+            h = 31 * h + (polyQualifier != null ? polyQualifier.hashCode() : 0);
+            cachedHashCode = h == 0 ? 1 : h;
+        }
+        return cachedHashCode;
     }
 
     @Override

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationMirrorSet.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationMirrorSet.java
@@ -376,7 +376,7 @@ public class AnnotationMirrorSet
                 // This is a set, so ordering is not considered.
                 result += AnnotationUtils.hashCode(shadowList.get(i));
             }
-            hashCodeCache = result;
+            hashCodeCache = result == 0 ? 1 : result;
             hashCodeComputed = true;
         }
         return hashCodeCache;


### PR DESCRIPTION
This commit avoids implicit Object[] allocation when computing hash codes and correctly handles the case where the computed hash code is 0 to avoid constant recalculation.

Changes developed with Antigravity, reviewed and performance notes updated with Claude.