### PR TITLE
Re-instantiate `IdentityHashMap`s to avoid the cost of `clear()`

### DIFF
--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -348,6 +348,26 @@ so small per-call wins paid back substantially.
   invariant; `private` field; storage strategy decoupled from subclasses), not for a perf number.
   One source-compat note: `visitedNodes` going `protected` → `private` is incompatible for any
   third-party `AnnotatedTypeScanner` subclass that referenced the field directly.
+- **PR #1815 — re-instantiate `IdentityHashMap`s instead of `clear()` (June 2026).**
+  Applies the same principle as PR #1794 (fresh TLAB allocation is cheaper than an explicit
+  `Arrays.fill` over the existing backing array) to four additional sites:
+  (1) **`AnnotatedTypeCopier.visit`**: removes the PR #1791 thread-local map pool entirely.
+  The pool's `finally { map.clear() }` was profiled at ~2.6% of `checknullness` self-time
+  (see *Tried and rejected*: `AnnotatedTypeCopier.visit` pooled-map clear ratchet). The pool
+  also required a re-entrancy fallback that allocated a new map anyway. Now `visit` always
+  allocates a fresh `new IdentityHashMap<>(VISITED_NODES_INITIAL_CAPACITY)` and discards it
+  on return — no pool, no clear, no re-entrancy guard.
+  (2) **`AbstractQualifierPolymorphism.AnnotationMirrorMap.reset()`**: `visitedTypes.clear()` →
+  re-instantiate `Collections.newSetFromMap(new IdentityHashMap<>())`.
+  (3) **`EquivalentAtmComboScanner.Visited.clear()`**: `visits.clear()` → re-instantiate
+  `new IdentityHashMap<>()`.
+  (4) **`AtmLubVisitor.visit()`**: `visited.clear()` → re-instantiate.
+  **Quick A/B** (cold-JVM wall clock, 3 reps/side, `gen-sized-program.py --shape generic`):
+  master 300-method median ~5.9 s vs. branch ~6.2 s; 600-method ~8.3 s vs. ~8.2 s —
+  **within cold-JVM noise (±0.7 s), no measurable wall-clock difference**. The win, if any,
+  is GC pressure / allocation throughput rather than wall clock on heap-generous single-file
+  runs; the `checknullness` JFR self-time attribution for `IdentityHashMap.clear` (2.6%)
+  suggests the benefit would be clearest on a multi-CU warm-daemon workload.
 
 ### Element and name caching
 
@@ -1138,7 +1158,9 @@ the prior finding. A fresh hypothesis is not new evidence.
   by *count* (called 1.7M+ times) but the actual time saved by a smaller table is negligible (same
   lesson as the `AnnotatedTypeScanner.markVisited` array sizing). Don't pursue without a workload
   where a genuinely large table is filled enough times that the byte-volume, not the call count,
-  dominates.
+  dominates. **Follow-up (PR #1815):** the pool was subsequently removed entirely (always fresh
+  allocation) — also measured neutral on cold-JVM wall clock, but removes the re-entrancy fallback
+  complexity. See Applied optimizations → `AnnotatedTypeScanner` and visitor state.
 - **Per-CU tree-defaults memoization in `QualifierDefaults` (June 2026).** A full prototype of
   short-list item #4 — a per-compilation-unit cache from `(scope element, pre-defaulting type
   structure)` to the defaulted type, keyed by a sound `AppliedDefaultsKey` (identity scope +

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -90,31 +90,13 @@ public class AnnotatedTypeCopier
         this(true);
     }
 
-    /**
-     * Thread-local pool for the IdentityHashMap used during copy operations to avoid allocation.
-     */
-    private static final ThreadLocal<IdentityHashMap<AnnotatedTypeMirror, AnnotatedTypeMirror>>
-            mapPool =
-                    ThreadLocal.withInitial(
-                            () ->
-                                    new IdentityHashMap<>(
-                                            AnnotatedTypeScanner.VISITED_NODES_INITIAL_CAPACITY));
-
     @Override
     public AnnotatedTypeMirror visit(AnnotatedTypeMirror type) {
-        IdentityHashMap<AnnotatedTypeMirror, AnnotatedTypeMirror> map = mapPool.get();
-        boolean mustClear = !map.isEmpty();
-        if (mustClear) {
-            // Safe fallback if re-entrant or map was not properly cleared.
-            map = new IdentityHashMap<>(AnnotatedTypeScanner.VISITED_NODES_INITIAL_CAPACITY);
-        }
-        try {
-            return type.accept(this, map);
-        } finally {
-            if (!mustClear) {
-                map.clear();
-            }
-        }
+        // PERF: Deliberately do not pool this map. IdentityHashMap.clear() is expensive
+        // (iterates all slots) whereas a new allocation benefits from JVM TLAB bulk-zeroing.
+        IdentityHashMap<AnnotatedTypeMirror, AnnotatedTypeMirror> map =
+                new IdentityHashMap<>(AnnotatedTypeScanner.VISITED_NODES_INITIAL_CAPACITY);
+        return type.accept(this, map);
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
@@ -401,8 +401,11 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
          * <p>Uses reference equality rather than equals because the visitor may visit two types
          * that are structurally equal, but not actually the same. For example, the wildcards in
          * {@code IPair<?,?>} may be equal, but they both should be visited.
+         *
+         * <p>This set is re-instantiated in {@link #reset()} instead of cleared to avoid the O(N)
+         * cost of IdentityHashMap.clear().
          */
-        private final Set<AnnotatedTypeMirror> visitedTypes =
+        private Set<AnnotatedTypeMirror> visitedTypes =
                 Collections.newSetFromMap(new IdentityHashMap<AnnotatedTypeMirror, Boolean>());
 
         /**
@@ -607,7 +610,8 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
 
         /** Resets the state. */
         void reset() {
-            this.visitedTypes.clear();
+            this.visitedTypes =
+                    Collections.newSetFromMap(new IdentityHashMap<AnnotatedTypeMirror, Boolean>());
             this.visited.clear();
         }
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/EquivalentAtmComboScanner.java
@@ -232,8 +232,13 @@ public abstract class EquivalentAtmComboScanner<RETURN_TYPE, PARAM>
         /** Default constructor. */
         Visited() {}
 
-        /** The backing history of type pairs. */
-        private final IdentityHashMap<
+        /**
+         * The backing history of type pairs.
+         *
+         * <p>This map is re-instantiated in {@link #clear()} instead of cleared to avoid the O(N)
+         * cost of IdentityHashMap.clear().
+         */
+        private IdentityHashMap<
                         AnnotatedTypeMirror, IdentityHashMap<AnnotatedTypeMirror, RETURN_TYPE>>
                 visits = new IdentityHashMap<>();
 
@@ -248,7 +253,7 @@ public abstract class EquivalentAtmComboScanner<RETURN_TYPE, PARAM>
 
         /** Clears the history. */
         public void clear() {
-            visits.clear();
+            visits = new IdentityHashMap<>();
         }
 
         public boolean contains(AnnotatedTypeMirror type1, AnnotatedTypeMirror type2) {

--- a/framework/src/main/java/org/checkerframework/framework/util/AtmLubVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AtmLubVisitor.java
@@ -47,9 +47,11 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
      * visited. Reference equality is used rather than {@link #equals(Object)} because the visitor
      * may visit two types that are structurally equal but not actually the same. For example, the
      * wildcards in {@code IPair<?,?>} may be equal, but they both should be visited.
+     *
+     * <p>This set is re-instantiated in {@link #visit} instead of cleared to avoid the O(N) cost of
+     * IdentityHashMap.clear().
      */
-    private final Set<AnnotatedTypeMirror> visited =
-            Collections.newSetFromMap(new IdentityHashMap<>());
+    private Set<AnnotatedTypeMirror> visited = Collections.newSetFromMap(new IdentityHashMap<>());
 
     /**
      * Construct an AtmLubVisitor.
@@ -81,7 +83,7 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
         AnnotatedTypeMirror type2AsLub = AnnotatedTypes.asSuper(atypeFactory, type2, lub);
 
         visit(type1AsLub, type2AsLub, lub);
-        visited.clear();
+        visited = Collections.newSetFromMap(new IdentityHashMap<>());
         return lub;
     }
 


### PR DESCRIPTION
Changes developed with Antigravity, reviewed and performance notes updated with Claude.

This complements what #1791 did, but the simpler code seems much better.

Claude review:

Review: The change removes the PR #1791 thread-local copier map pool and switches three other IdentityHashMap-backed
  visitors from clear() to re-instantiation. Correctness looks fine — the pool's re-entrancy fallback already allocated
  fresh anyway, so removing it is safe. The final → non-final field changes in AbstractQualifierPolymorphism,
  EquivalentAtmComboScanner, and AtmLubVisitor are safe since all writes are in single-threaded reset paths.

  Measurement: Neutral on cold-JVM wall clock (within ±0.7 s noise on generic 300/600-method files). Any real benefit
  would show on a warm multi-CU workload where the 2.6% IdentityHashMap.clear self-time attribution is realized.

