### PR TITLE
Several performance experiments that did not work out

### DIFF
--- a/.claude/skills/cf-performance/SKILL.md
+++ b/.claude/skills/cf-performance/SKILL.md
@@ -390,15 +390,15 @@ but cost ≈10% wall clock (far more than its hit-rate delta implied). Cut
   (`CheckerFrameworkAnnotationMirror`) already caches the decoded interned name, so the decode the
   change "removed" was never happening. **Before optimizing a lookup, ask what the common carrier
   already caches.**
-- **Two traps when measuring whether a per-tree type is stable enough to cache** (both produced a
-  *wrong, committed* conclusion this session — the pre-flow `getAnnotatedType` split-cache was
-  rejected as "25–59% unstable," then re-measuring correctly showed value leaves are **0%** unstable).
-  Postscript: even with 0% instability the built cache was *still* rejected — it was unsound for
-  checkers that override `addComputedTypeAnnotations` (Index/Lock/Optional/Signedness add annotations
-  after `super`, which a `getAnnotatedType` cache hit bypasses → `IndexTest` failed) and flat-to-mixed
-  on nullness where it was correct. **Stability ≠ cacheable: a `getAnnotatedType` cache must compose
-  with subclass overrides, and the per-hit `deepCopy` can cancel the saved work. Validate correctness
-  on the override-checkers, not just nullness.** The measurement traps:
+- **Caching a per-tree annotated type: stability ≠ cacheable, and two measurement traps.** The
+  pre-flow `getAnnotatedType` split-cache (June 2026, *Tried and rejected* → getAnnotatedType #2) is
+  the cautionary tale. **Stability ≠ cacheable:** even after correctly measuring value-leaf pre-flow
+  types as **0%** unstable, the built cache was rejected — it was unsound for checkers that override
+  `addComputedTypeAnnotations` (Index/Lock/Optional/Signedness add annotations after `super`, which a
+  `getAnnotatedType` cache hit bypasses → `IndexTest` failed), and flat-to-mixed on nullness where it
+  was correct. A framework-level type cache must **compose with subclass overrides**, and the per-hit
+  `deepCopy` can cancel the saved work — so validate correctness on the override-checkers, not just
+  nullness. Two traps nearly produced the *opposite* wrong verdict ("25–59% unstable, unsound") first:
   1. **Compare PER HIERARCHY, never via `AnnotatedTypeMirror.toString()`.** `toString()` over-reports
      instability by counting *cross-hierarchy completeness* — an `int` literal printing as `int` vs
      `@Initialized int` is just the Initialization hierarchy's annotation absent vs present, harmless

--- a/.claude/skills/cf-performance/SKILL.md
+++ b/.claude/skills/cf-performance/SKILL.md
@@ -390,18 +390,21 @@ but cost ≈10% wall clock (far more than its hit-rate delta implied). Cut
   (`CheckerFrameworkAnnotationMirror`) already caches the decoded interned name, so the decode the
   change "removed" was never happening. **Before optimizing a lookup, ask what the common carrier
   already caches.**
-- **To decide if a per-tree type can be cached, compare its annotations PER HIERARCHY — never via
-  `AnnotatedTypeMirror.toString()`.** `toString()` over-reports "instability" by conflating (i)
-  cross-hierarchy *completeness* (an `int` literal printing as `int` vs `@Initialized int` is the
-  Initialization hierarchy's annotation absent vs present — not a within-hierarchy change; harmless
-  to a per-hierarchy cache) with real within-hierarchy disagreement. And **never index a qualifier
-  `Set` (`getTopAnnotations()`) positionally across calls** — its iteration order is unstable, so
-  slot *i* silently compares different hierarchies. This trap produced a *wrong, committed*
-  conclusion this session: the pre-flow `getAnnotatedType` split-cache was rejected as "25–59%
-  unstable" on a `toString()` signature; re-measuring per hierarchy (keyed by top-annotation name,
-  splitting present-disagree from completeness) showed value-leaf pre-flow types are **0%** unstable
-  and compound ~0.46% — reopening it as a candidate (see *Tried and rejected* → getAnnotatedType #2).
-  The right signature is a map {hierarchy → annotation-in-that-hierarchy}, compared key-by-key.
+- **Two traps when measuring whether a per-tree type is stable enough to cache** (both produced a
+  *wrong, committed* conclusion this session — the pre-flow `getAnnotatedType` split-cache was
+  rejected as "25–59% unstable," then re-measuring correctly showed value leaves are **0%** unstable):
+  1. **Compare PER HIERARCHY, never via `AnnotatedTypeMirror.toString()`.** `toString()` over-reports
+     instability by counting *cross-hierarchy completeness* — an `int` literal printing as `int` vs
+     `@Initialized int` is just the Initialization hierarchy's annotation absent vs present, harmless
+     to a per-hierarchy cache — as if it were a within-hierarchy disagreement. The right signature is
+     a map {hierarchy-top-name → annotation-in-that-hierarchy}, compared key-by-key. (`getTopAnnotations()`
+     order is *not* a hazard — it is a build-once `ArrayList`-backed `AnnotationMirrorSet` over a
+     `TreeMap`, already stable.)
+  2. **A checker runs SEVERAL `AnnotatedTypeFactory` instances — never key shared/`static` state on
+     `Tree`.** A `nullness` compile drives four GATFs (`NullnessNoInit`, `Initialization`,
+     `InitializationFieldAccess`, `KeyFor`), each with its own qualifier hierarchy. A `static`
+     per-`Tree` map (or cache) mixes one type system's result for a tree with another's. Keep such
+     state on the factory instance; confirm by logging `this.getClass().getSimpleName()`.
 
 ## Removing a defensive copy (the opposite of adding a cache)
 

--- a/.claude/skills/cf-performance/SKILL.md
+++ b/.claude/skills/cf-performance/SKILL.md
@@ -376,6 +376,20 @@ but cost ≈10% wall clock (far more than its hit-rate delta implied). Cut
   guard is a counter on the code you changed — if it never fires, "no effect" is a workload
   bug, not a verdict on the change. Pair this with picking a workload that *maximizes* traffic
   through the target (the size-sweep / shape generators exist for this).
+- **Measure the *ceiling* before micro-optimizing a dispatch — profile the adversarial
+  workload, not the typical one.** When tempted to change *how* something is represented or
+  compared (string vs. `Name`, a "kind" tag, a second-level cache), first bound the maximum
+  possible win: build a workload that *maximizes* traffic through the target and check whether the
+  target's frames even appear above the sample floor. If they don't, no variant can help and you
+  stop in one profile instead of an A/B per variant. The String→`Name` annotation-name migration
+  (see *Tried and rejected*) died this way: an annotation-saturated, checker-bound workload (400
+  methods × 40 explicitly-annotated locals) at 2596 samples showed `annotationName` /
+  `annotationNameAsName` / `areSameByName` / `isSupportedQualifier` / `Name.toString` / `intern`
+  at **0 samples** — and the hot leaf that *did* surface (`IdentityHashMap.get` → `getQualifierKind`)
+  was itself an already-rejected target. The reason the ceiling was ~0: the hot representation
+  (`CheckerFrameworkAnnotationMirror`) already caches the decoded interned name, so the decode the
+  change "removed" was never happening. **Before optimizing a lookup, ask what the common carrier
+  already caches.**
 
 ## Removing a defensive copy (the opposite of adding a cache)
 
@@ -499,6 +513,12 @@ In order of historical hit rate on this codebase:
 - Switching map implementations purely on micro-benchmark intuition —
   measure on a real workload.
 - Lock-removal changes without auditing all reachable threads.
+- Rerepresenting annotation *names* for dispatch (`String`→`Name` + `==`,
+  per-qualifier "kind" tags) or caching `getQualifierKind` — both measured
+  flat (see *Tried and rejected*). `CheckerFrameworkAnnotationMirror`
+  already caches the decoded interned name, so the decode you would remove
+  is not on the hot path; identity-comparing `Name`s is no cheaper than the
+  existing interned-`String` comparison.
 
 ## Producing the patch
 

--- a/.claude/skills/cf-performance/SKILL.md
+++ b/.claude/skills/cf-performance/SKILL.md
@@ -392,7 +392,13 @@ but cost ≈10% wall clock (far more than its hit-rate delta implied). Cut
   already caches.**
 - **Two traps when measuring whether a per-tree type is stable enough to cache** (both produced a
   *wrong, committed* conclusion this session — the pre-flow `getAnnotatedType` split-cache was
-  rejected as "25–59% unstable," then re-measuring correctly showed value leaves are **0%** unstable):
+  rejected as "25–59% unstable," then re-measuring correctly showed value leaves are **0%** unstable).
+  Postscript: even with 0% instability the built cache was *still* rejected — it was unsound for
+  checkers that override `addComputedTypeAnnotations` (Index/Lock/Optional/Signedness add annotations
+  after `super`, which a `getAnnotatedType` cache hit bypasses → `IndexTest` failed) and flat-to-mixed
+  on nullness where it was correct. **Stability ≠ cacheable: a `getAnnotatedType` cache must compose
+  with subclass overrides, and the per-hit `deepCopy` can cancel the saved work. Validate correctness
+  on the override-checkers, not just nullness.** The measurement traps:
   1. **Compare PER HIERARCHY, never via `AnnotatedTypeMirror.toString()`.** `toString()` over-reports
      instability by counting *cross-hierarchy completeness* — an `int` literal printing as `int` vs
      `@Initialized int` is just the Initialization hierarchy's annotation absent vs present, harmless

--- a/.claude/skills/cf-performance/SKILL.md
+++ b/.claude/skills/cf-performance/SKILL.md
@@ -390,6 +390,18 @@ but cost ≈10% wall clock (far more than its hit-rate delta implied). Cut
   (`CheckerFrameworkAnnotationMirror`) already caches the decoded interned name, so the decode the
   change "removed" was never happening. **Before optimizing a lookup, ask what the common carrier
   already caches.**
+- **To decide if a per-tree type can be cached, compare its annotations PER HIERARCHY — never via
+  `AnnotatedTypeMirror.toString()`.** `toString()` over-reports "instability" by conflating (i)
+  cross-hierarchy *completeness* (an `int` literal printing as `int` vs `@Initialized int` is the
+  Initialization hierarchy's annotation absent vs present — not a within-hierarchy change; harmless
+  to a per-hierarchy cache) with real within-hierarchy disagreement. And **never index a qualifier
+  `Set` (`getTopAnnotations()`) positionally across calls** — its iteration order is unstable, so
+  slot *i* silently compares different hierarchies. This trap produced a *wrong, committed*
+  conclusion this session: the pre-flow `getAnnotatedType` split-cache was rejected as "25–59%
+  unstable" on a `toString()` signature; re-measuring per hierarchy (keyed by top-annotation name,
+  splitting present-disagree from completeness) showed value-leaf pre-flow types are **0%** unstable
+  and compound ~0.46% — reopening it as a candidate (see *Tried and rejected* → getAnnotatedType #2).
+  The right signature is a map {hierarchy → annotation-in-that-hierarchy}, compared key-by-key.
 
 ## Removing a defensive copy (the opposite of adding a cache)
 

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2073,29 +2073,39 @@ Capture format: hot method, hypothesis, blockers.
      Hypothesis: cache the *pre-flow* (post-2a) type per tree and recompute only 2b, since 2b is where
      flow lives.
 
-     **Correction to an earlier rejection.** A first pass keyed the per-tree signature on
-     `AnnotatedTypeMirror.toString()` and concluded the pre-flow type was "unstable 25–40% (leaves) /
-     26–59% (compound, even checking-phase)," i.e. that no tree-keyed cache could be sound. **That was
-     a measurement artifact, not a property of the code.** `toString()` conflates two non-issues with
-     real instability: (i) *cross-hierarchy completeness* — a primitive literal printing as `int` vs
-     `@Initialized int` is the Initialization hierarchy's annotation absent vs present, not a
-     within-hierarchy disagreement; and (ii) the comparison read `getTopAnnotations()` (a `Set` with
-     unstable iteration order) *positionally*, so slot *i* compared different hierarchies across calls.
-     Re-measured *per hierarchy* (keyed by top-annotation name; counting "present-disagree" = same
-     hierarchy, two different non-∅ annotations, and "completeness" = ∅-vs-present, separately):
+     **Correction to an earlier rejection (and to a wrong root-cause in a prior revision of this very
+     entry).** A first pass keyed the per-tree signature on `AnnotatedTypeMirror.toString()` and a
+     *static* `IdentityHashMap<Tree, …>`, and concluded the pre-flow type was "unstable 25–59%," i.e.
+     that no tree-keyed cache could be sound. **That was a measurement artifact.** Two confounds, both
+     in the instrumentation, not the code: (i) `toString()` conflates *cross-hierarchy completeness* —
+     a primitive literal printing as `int` vs `@Initialized int` is the Initialization hierarchy's
+     annotation absent vs present, not a within-hierarchy disagreement; and (ii) — the big one — the
+     per-tree map was **`static`, shared across the *multiple sub-factories* a checker runs.** A
+     `nullness` compile runs four `GenericAnnotatedTypeFactory` instances
+     (`NullnessNoInitAnnotatedTypeFactory`, `InitializationAnnotatedTypeFactory`,
+     `InitializationFieldAccessAnnotatedTypeFactory`, `KeyForAnnotatedTypeFactory`), each with its own
+     qualifier hierarchy; the static map compared *one type system's* snapshot of a tree against
+     *another's* (e.g. `@UnknownKeyFor` from the KeyFor factory vs `@Initialized` from the
+     Initialization factory). (`getTopAnnotations()` itself is **not** the problem — it returns a
+     build-once `final AnnotationMirrorSet` backed by an `ArrayList` over a `TreeMap<QualifierKind,…>`,
+     i.e. already a stable, deterministic order; an earlier draft of this entry wrongly blamed it.)
+     Re-measured correctly — *per factory* (instance map) and *per hierarchy* (keyed by top-annotation
+     name; "present-disagree" = same hierarchy, two different non-∅ annotations; "completeness" =
+     ∅-vs-present):
 
      | category | all-systems (120f) | loops |
      | --- | --- | --- |
-     | value leaf (literal / var / field / param id) | disagree 0, compl 0 / 69,557 repeats | 0 / 0 / 207,940 |
-     | compound expression | disagree 211 (0.46%), compl 0 / 46,166 | 0 / 0 / 57,928 |
-     | type-name identifier (class/enum) | 86 (0.7%) | 0 |
+     | value leaf (literal / var / field / param id) | disagree 0, compl 0 / 58,447 repeats | 0 / 0 / 130,894 |
+     | compound expression | disagree 213 (0.69%), compl 0 / 30,949 | 0 / 0 / 33,604 |
+     | type-name identifier (class/enum) | excluded (≈0.7% context-dependent) | — |
 
-     So per hierarchy the pre-flow type is **stable**: value leaves never disagree, compound
-     expressions disagree ~0.46% (the genuinely context-dependent residual — `NewClass`/`NewArray`/
-     conditionals, the #602 set in #3 below), type-name identifiers ~0.7% (excludable by element
-     kind). The flow-dependence is entirely in 2b, exactly as the split assumed. **This reopens the
-     split cache as a *sound* candidate** — provided it returns a deep copy (callers mutate) and skips
-     the ~0.5–0.7% context-dependent kinds.
+     So per factory, per hierarchy, the pre-flow type is **stable**: value leaves never disagree or
+     under-annotate, compound expressions disagree ~0.69% (the genuinely context-dependent residual —
+     `NewClass`/`NewArray`/conditionals, the #602 set in #3 below), type-name identifiers ~0.7%
+     (excludable by element kind). The flow-dependence is entirely in 2b, exactly as the split
+     assumed. **This reopens the split cache as a *sound* candidate** — provided it is per-factory
+     (each ATF has its own cache, as all the existing tree caches already are), returns a deep copy
+     (callers mutate), and skips the ~0.5–0.7% context-dependent kinds.
 
      **Value is NOT yet confirmed; do an implemented-cache A/B before adoption.** Instrumented 2a
      self-time for value leaves alone is ~0.55 s (~4% of a 12.6 s all-systems compile) and ~1.16 s
@@ -2107,8 +2117,11 @@ Capture format: hot method, hypothesis, blockers.
      compound kinds) and measure deterministic allocation + wall on all-systems and loops. Until that
      A/B exists this is a *candidate*, not a win. (The companion "phase-scoped full cache" idea was
      rejected on the same flawed `toString()` measure and should likewise be re-measured per hierarchy
-     if revisited.) **Method lesson: never measure annotated-type stability via `toString()` — compare
-     per hierarchy, and never index a qualifier `Set` positionally across calls.**
+     if revisited.) **Method lessons: (1) never measure annotated-type stability via `toString()` —
+     compare per hierarchy (top-name → annotation), since `toString()` conflates cross-hierarchy
+     completeness; (2) a checker runs *several* `AnnotatedTypeFactory` instances — never key
+     instrumentation (or a cache) on `Tree` in `static` state, or you compare/mix different type
+     systems' results for the same tree.**
   3. **Split flow-independent structure from flow-dependent annotations — MEASURED, ALREADY
      IMPLEMENTED (June 2026).** The hypothesis was: `fromExpression` (~24% inclusive) builds a
      deterministic-per-tree skeleton, so cache the frozen skeleton and re-apply only the

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2066,32 +2066,12 @@ Capture format: hot method, hypothesis, blockers.
      the soundness crux flagged here. And the instability is *highest where the redundancy is
      highest* (loops). A per-analysis memo would cache stale/wrong types; a per-*iteration* memo would
      be sound but the within-iteration redundancy is ~0. Low value and unsound — do not pursue.
-  2. **Pre-flow expression-type ("split") cache — RE-MEASURED, then BUILT AND REJECTED (June 2026).**
-     Split `addComputedTypeAnnotations(Tree, ATM)` at the `if (this.useFlow)`
-     boundary into the prefix 2a (`applyQualifierParameterDefaults` → tree/type annotators →
-     `defaults.annotate`) and the flow suffix 2b (`getInferredValueFor` + `applyInferredAnnotations`).
-     Hypothesis: cache the *pre-flow* (post-2a) type per tree and recompute only 2b, since 2b is where
-     flow lives.
-
-     **Correction to an earlier rejection (and to a wrong root-cause in a prior revision of this very
-     entry).** A first pass keyed the per-tree signature on `AnnotatedTypeMirror.toString()` and a
-     *static* `IdentityHashMap<Tree, …>`, and concluded the pre-flow type was "unstable 25–59%," i.e.
-     that no tree-keyed cache could be sound. **That was a measurement artifact.** Two confounds, both
-     in the instrumentation, not the code: (i) `toString()` conflates *cross-hierarchy completeness* —
-     a primitive literal printing as `int` vs `@Initialized int` is the Initialization hierarchy's
-     annotation absent vs present, not a within-hierarchy disagreement; and (ii) — the big one — the
-     per-tree map was **`static`, shared across the *multiple sub-factories* a checker runs.** A
-     `nullness` compile runs four `GenericAnnotatedTypeFactory` instances
-     (`NullnessNoInitAnnotatedTypeFactory`, `InitializationAnnotatedTypeFactory`,
-     `InitializationFieldAccessAnnotatedTypeFactory`, `KeyForAnnotatedTypeFactory`), each with its own
-     qualifier hierarchy; the static map compared *one type system's* snapshot of a tree against
-     *another's* (e.g. `@UnknownKeyFor` from the KeyFor factory vs `@Initialized` from the
-     Initialization factory). (`getTopAnnotations()` itself is **not** the problem — it returns a
-     build-once `final AnnotationMirrorSet` backed by an `ArrayList` over a `TreeMap<QualifierKind,…>`,
-     i.e. already a stable, deterministic order; an earlier draft of this entry wrongly blamed it.)
-     Re-measured correctly — *per factory* (instance map) and *per hierarchy* (keyed by top-annotation
-     name; "present-disagree" = same hierarchy, two different non-∅ annotations; "completeness" =
-     ∅-vs-present):
+  2. **Pre-flow expression-type ("split") cache — BUILT AND REJECTED (June 2026).** Hypothesis:
+     `addComputedTypeAnnotations(Tree, ATM)` splits at the `if (this.useFlow)` boundary into a prefix
+     2a (`applyQualifierParameterDefaults` → tree/type annotators → `defaults.annotate`) and a flow
+     suffix 2b (`getInferredValueFor` + `applyInferredAnnotations`); since flow lives only in 2b, cache
+     the *pre-flow* (post-2a) type per tree and recompute only 2b. Per-factory, per-hierarchy
+     measurement shows the pre-flow type *is* stable, so the cache looked sound:
 
      | category | all-systems (120f) | loops |
      | --- | --- | --- |
@@ -2099,46 +2079,47 @@ Capture format: hot method, hypothesis, blockers.
      | compound expression | disagree 213 (0.69%), compl 0 / 30,949 | 0 / 0 / 33,604 |
      | type-name identifier (class/enum) | excluded (≈0.7% context-dependent) | — |
 
-     So per factory, per hierarchy, the pre-flow type is **stable**: value leaves never disagree or
-     under-annotate, compound expressions disagree ~0.69% (the genuinely context-dependent residual —
-     `NewClass`/`NewArray`/conditionals, the #602 set in #3 below), type-name identifiers ~0.7%
-     (excludable by element kind). The flow-dependence is entirely in 2b, exactly as the split
-     assumed. The per-hierarchy stability made it look like a sound candidate.
-
-     **BUILT AND REJECTED (June 2026) — unsound across checkers, and flat where it is sound.** A
-     working cache was implemented: a per-factory `IdentityHashMap<Tree, AnnotatedTypeMirror>` of
-     frozen pre-flow types, populated just before the `useFlow` block in
-     `GenericAnnotatedTypeFactory.addComputedTypeAnnotations`; `getAnnotatedType` was overridden to,
-     on a hit for a value-leaf, return `cached.deepCopy()` + re-applied flow (2b); cleared per CU;
-     toggled by `-Dcf.preflowcache`. Two findings killed it:
+     (Value leaves never disagree or under-annotate; the compound ~0.69% residual is the genuinely
+     context-dependent `NewClass`/`NewArray`/conditional set — the #602 trees of #3 below; type-name
+     identifiers ~0.7%, excludable by element kind.) A working cache was then implemented — a
+     per-factory `IdentityHashMap<Tree, AnnotatedTypeMirror>` of frozen pre-flow types populated just
+     before the `useFlow` block, with `getAnnotatedType` overridden to return `cached.deepCopy()` +
+     re-applied 2b on a value-leaf hit, cleared per CU, toggled by `-Dcf.preflowcache`. **Two
+     independent findings killed it:**
      - **Unsound for any checker that overrides `addComputedTypeAnnotations`.** `IndexTest` fails
-       (`PredecrementTest.java:8`, an extra `array.access.unsafe.low`). `UpperBoundAnnotatedTypeFactory`
+       (`PredecrementTest.java:8`, a spurious `array.access.unsafe.low`). `UpperBoundAnnotatedTypeFactory`
        (and Lower Bound, Optional, Lock, Signedness) override `addComputedTypeAnnotations` to add
-       flow-dependent annotations **after** `super` — e.g. Index pulls the Value Checker's type and
-       calls `addUpperBoundTypeFromValueType` (its own comment cites `"int i = 1; --i;"`, exactly the
-       failing test). Intercepting at `getAnnotatedType` and re-applying only the GATF-level flow step
-       bypasses that subclass logic, so cache hits drop the index refinement. Caching *inside*
+       flow-dependent annotations **after** `super` — Index pulls the Value Checker's type and calls
+       `addUpperBoundTypeFromValueType` (its comment cites `"int i = 1; --i;"`, exactly the failing
+       test). Intercepting at `getAnnotatedType` and re-applying only the GATF-level flow step bypasses
+       that subclass tail, so hits drop the index refinement. Caching *inside*
        `addComputedTypeAnnotations` so the subclass tail still runs would need a deep "replace
-       annotations onto the passed-in type" and only saves 2a (not `fromExpression`) — more complexity
-       for a smaller win. (A diff of cache-on vs -off diagnostics on nullness corpora *was* clean —
-       the bug is specific to the subclass-override checkers, which is why nullness-only validation
-       missed it.)
-     - **Flat-to-mixed even where it is sound (nullness).** Deterministic A/B (median of 5 alloc;
-       2nd-best of 4 wall), cache off vs on: all-systems alloc 2658.7 → 2616.1 MB (−1.6%), wall
-       12.12 → 12.10 s (~0); loops alloc 1078.2 → **1100.1 MB (+2.0%, worse)**, wall 7.18 → 6.84 s
-       (−4.7%). The projected ~4–15% (raw 2a self-time) did not materialize: the per-hit `deepCopy` +
-       `freeze` + map overhead roughly cancels the saved 2a, and on the realistic corpus the result
-       is noise. Do not pursue. **Lesson: per-hierarchy stability proved the cache *could* be sound in
-       isolation, but a framework-wide `getAnnotatedType` cache must compose with subclass
-       `addComputedTypeAnnotations` overrides — and even ignoring that, the deepCopy cost makes it a
-       wash. Validate correctness across the *override* checkers (Index/Lock/Optional/Signedness), not
-       just nullness.** (The companion "phase-scoped full cache" idea was rejected on the same flawed
-       `toString()` measure and would hit the same compose-with-overrides wall.) **Method lessons:
-     (1) never measure annotated-type stability via `toString()` —
-     compare per hierarchy (top-name → annotation), since `toString()` conflates cross-hierarchy
-     completeness; (2) a checker runs *several* `AnnotatedTypeFactory` instances — never key
-     instrumentation (or a cache) on `Tree` in `static` state, or you compare/mix different type
-     systems' results for the same tree.**
+       annotations onto the passed-in type" and saves only 2a (not `fromExpression`) — more complexity,
+       smaller win. A nullness-only diagnostic diff (cache on vs off) was clean, which is exactly why
+       nullness-only validation missed it.
+     - **Flat-to-mixed even where it is sound (nullness).** Deterministic A/B (median-of-5 alloc;
+       2nd-best-of-4 wall), off vs on: all-systems alloc 2658.7 → 2616.1 MB (−1.6%), wall 12.12 →
+       12.10 s (~0); loops alloc 1078.2 → **1100.1 MB (+2.0%, worse)**, wall 7.18 → 6.84 s (−4.7%). The
+       projected ~4–15% (raw 2a self-time) did not materialize — the per-hit `deepCopy` + `freeze` +
+       map overhead roughly cancels the saved 2a, and the realistic corpus is noise.
+
+     **Do not pursue.** The companion "phase-scoped full cache" idea would hit the same
+     compose-with-overrides wall. **Lessons:**
+     - *Stability ≠ cacheable.* Per-hierarchy stability proved the cache could be sound in isolation,
+       but a framework-level `getAnnotatedType` cache must **compose with subclass
+       `addComputedTypeAnnotations` overrides**, and even then the `deepCopy` cost makes it a wash.
+       Validate such a change on the override-checkers (Index/Lock/Optional/Signedness), not just
+       nullness.
+     - *Measuring per-tree type stability has two traps* (both nearly produced a false "unstable
+       25–59%, unsound" verdict): **(1)** never compare via `AnnotatedTypeMirror.toString()` — it
+       conflates *cross-hierarchy completeness* (a literal printing as `int` vs `@Initialized int` is
+       the Initialization annotation absent-vs-present, not a within-hierarchy change) with real
+       disagreement; compare per hierarchy as {top-name → annotation}. **(2)** a checker runs *several*
+       `AnnotatedTypeFactory` instances (a `nullness` compile drives `NullnessNoInit`, `Initialization`,
+       `InitializationFieldAccess`, `KeyFor`) — never key instrumentation or a cache on `Tree` in
+       `static` state, or you compare one type system's snapshot against another's. (Note:
+       `getTopAnnotations()` is *not* an ordering hazard — it returns a build-once `ArrayList`-backed
+       `AnnotationMirrorSet` over a `TreeMap<QualifierKind,…>`, a stable deterministic order.)
   3. **Split flow-independent structure from flow-dependent annotations — MEASURED, ALREADY
      IMPLEMENTED (June 2026).** The hypothesis was: `fromExpression` (~24% inclusive) builds a
      deterministic-per-tree skeleton, so cache the frozen skeleton and re-apply only the

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2066,45 +2066,49 @@ Capture format: hot method, hypothesis, blockers.
      the soundness crux flagged here. And the instability is *highest where the redundancy is
      highest* (loops). A per-analysis memo would cache stale/wrong types; a per-*iteration* memo would
      be sound but the within-iteration redundancy is ~0. Low value and unsound — do not pursue.
-  2. **Scope-bounded / pre-flow expression-type cache — MEASURED AND REJECTED (June 2026).** Two
-     forms tested by instrumenting `GenericAnnotatedTypeFactory.addComputedTypeAnnotations(Tree,
-     ATM)`, splitting it at the `if (this.useFlow)` boundary into the flow-independent prefix (2a:
-     `applyQualifierParameterDefaults` → tree/type annotators → `defaults.annotate`) and the
-     flow-dependent suffix (2b: `getInferredValueFor` + `applyInferredAnnotations`), with per-tree
-     `IdentityHashMap<Tree,String>` signature maps recording redundancy and the *unsound fraction*
-     (= repeats whose computed type differs from the prior result for the same tree). Single forked
-     `javac -processor nullness`, on all-systems (120 files) and a loop-heavy artificial workload.
-     (a) **Split-cache (cache the *pre-flow* 2a type, always recompute 2b) — unsound.** Redundancy is
-     high (repeats 91% all-systems / 86% loops of expression calls) but the pre-flow type is
-     **unstable 25% (all-systems) / 38% (loops)** of repeats, because the "flow-independent" tree
-     annotators transitively call `getAnnotatedType` on subexpressions whose types are flow-refined.
-     (b) **Phase-scoped full cache (cache the full type, but only when `analysis.isRunning()` is
-     false — i.e. the post-flow checking traversal with a frozen `flowResult`) — also unsound.**
-     Even restricted to the checking phase the full type is **unstable 26% (all-systems) / 59%
-     (loops)** of repeats (CHK repeats 91% / 68%). The same expression tree genuinely yields
-     different types across repeated queries even after flow analysis completes, so a
-     tree-identity-keyed cache would serve a stale/wrong type a quarter to a half of the time — worse
-     than the per-analysis `getValueFromFactory` memo (#1, 8–18%) already rejected. Cost context
-     confirms it is not even worth chasing the sound subset: the flow step 2b is cheap (~0.3 s
-     inclusive vs. a multi-second 2a), so the expense is entirely in the 2a computation **whose
-     result is the unstable thing** — and the stable trees (literals, simple identifiers) are exactly
-     the cheap-to-recompute ones (the "count ≠ cost" / #4 dead end). No safe getAnnotatedType-level
-     expression cache exists; the sound caches (skeleton `fromExpressionTreeCache`,
-     `methodAsMemberOfCache`, `classAndMethodTreeCache`) are already in place. Do not pursue.
-     (c) **Even the subexpression-free *leaf* subset (identifiers/literals), checking-phase only —
-     unsound, and immaterial.** The natural rescue ("the instability comes from tree annotators
-     querying flow-refined subexpressions, so restrict the cache to leaves that have none") was
-     measured: in the checking phase the pre-flow leaf type is still **unstable 22% (identifiers) /
-     40% (literals)** on all-systems, 58% / 43% on loops. The cause is *not* subexpression flow — it
-     is that the computed type is context-dependent in *which hierarchy's annotations are applied*:
-     the same `1` literal returns `int` in one query and `@Initialized int` in another (nullness runs
-     with the Initialization checker), so a tree-keyed cache would hand back an under-annotated type
-     and break subtyping. Independently, the cost ceiling is immaterial: the safely-cacheable
-     checking-phase leaf 2a self-time is only ~0.22 s (~1.5% of a 13.9 s 120-file compile); the large
-     leaf-2a figure (18× the deepCopy cost) is dominated by *dataflow-phase* leaf work, which is not
-     safe to cache. **Lesson: `getAnnotatedType`'s result is keyed by call *context*, not by tree
-     identity — even for a literal — so no tree-identity cache at this level is sound, at any
-     granularity.**
+  2. **Pre-flow expression-type ("split") cache — RE-MEASURED; a genuine candidate, value pending an
+     A/B (June 2026).** Split `addComputedTypeAnnotations(Tree, ATM)` at the `if (this.useFlow)`
+     boundary into the prefix 2a (`applyQualifierParameterDefaults` → tree/type annotators →
+     `defaults.annotate`) and the flow suffix 2b (`getInferredValueFor` + `applyInferredAnnotations`).
+     Hypothesis: cache the *pre-flow* (post-2a) type per tree and recompute only 2b, since 2b is where
+     flow lives.
+
+     **Correction to an earlier rejection.** A first pass keyed the per-tree signature on
+     `AnnotatedTypeMirror.toString()` and concluded the pre-flow type was "unstable 25–40% (leaves) /
+     26–59% (compound, even checking-phase)," i.e. that no tree-keyed cache could be sound. **That was
+     a measurement artifact, not a property of the code.** `toString()` conflates two non-issues with
+     real instability: (i) *cross-hierarchy completeness* — a primitive literal printing as `int` vs
+     `@Initialized int` is the Initialization hierarchy's annotation absent vs present, not a
+     within-hierarchy disagreement; and (ii) the comparison read `getTopAnnotations()` (a `Set` with
+     unstable iteration order) *positionally*, so slot *i* compared different hierarchies across calls.
+     Re-measured *per hierarchy* (keyed by top-annotation name; counting "present-disagree" = same
+     hierarchy, two different non-∅ annotations, and "completeness" = ∅-vs-present, separately):
+
+     | category | all-systems (120f) | loops |
+     | --- | --- | --- |
+     | value leaf (literal / var / field / param id) | disagree 0, compl 0 / 69,557 repeats | 0 / 0 / 207,940 |
+     | compound expression | disagree 211 (0.46%), compl 0 / 46,166 | 0 / 0 / 57,928 |
+     | type-name identifier (class/enum) | 86 (0.7%) | 0 |
+
+     So per hierarchy the pre-flow type is **stable**: value leaves never disagree, compound
+     expressions disagree ~0.46% (the genuinely context-dependent residual — `NewClass`/`NewArray`/
+     conditionals, the #602 set in #3 below), type-name identifiers ~0.7% (excludable by element
+     kind). The flow-dependence is entirely in 2b, exactly as the split assumed. **This reopens the
+     split cache as a *sound* candidate** — provided it returns a deep copy (callers mutate) and skips
+     the ~0.5–0.7% context-dependent kinds.
+
+     **Value is NOT yet confirmed; do an implemented-cache A/B before adoption.** Instrumented 2a
+     self-time for value leaves alone is ~0.55 s (~4% of a 12.6 s all-systems compile) and ~1.16 s
+     (~15%) on loop-heavy code, vs ~0.05–0.17 s deepCopy — a favorable projected ratio, and compound
+     2a (not separately timed) is larger. But projected savings have repeatedly evaporated in A/B this
+     session (the String→`Name` flat result; #4 applied-defaults). The next step is to *build* the
+     post-2a cache (store the type just before the `useFlow` block; on hit `deepCopy` + run only 2b;
+     key by `Tree`; clear per CU like the other tree caches; skip type-name identifiers and the #602
+     compound kinds) and measure deterministic allocation + wall on all-systems and loops. Until that
+     A/B exists this is a *candidate*, not a win. (The companion "phase-scoped full cache" idea was
+     rejected on the same flawed `toString()` measure and should likewise be re-measured per hierarchy
+     if revisited.) **Method lesson: never measure annotated-type stability via `toString()` — compare
+     per hierarchy, and never index a qualifier `Set` positionally across calls.**
   3. **Split flow-independent structure from flow-dependent annotations — MEASURED, ALREADY
      IMPLEMENTED (June 2026).** The hypothesis was: `fromExpression` (~24% inclusive) builds a
      deterministic-per-tree skeleton, so cache the frozen skeleton and re-apply only the

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2066,8 +2066,8 @@ Capture format: hot method, hypothesis, blockers.
      the soundness crux flagged here. And the instability is *highest where the redundancy is
      highest* (loops). A per-analysis memo would cache stale/wrong types; a per-*iteration* memo would
      be sound but the within-iteration redundancy is ~0. Low value and unsound — do not pursue.
-  2. **Pre-flow expression-type ("split") cache — RE-MEASURED; a genuine candidate, value pending an
-     A/B (June 2026).** Split `addComputedTypeAnnotations(Tree, ATM)` at the `if (this.useFlow)`
+  2. **Pre-flow expression-type ("split") cache — RE-MEASURED, then BUILT AND REJECTED (June 2026).**
+     Split `addComputedTypeAnnotations(Tree, ATM)` at the `if (this.useFlow)`
      boundary into the prefix 2a (`applyQualifierParameterDefaults` → tree/type annotators →
      `defaults.annotate`) and the flow suffix 2b (`getInferredValueFor` + `applyInferredAnnotations`).
      Hypothesis: cache the *pre-flow* (post-2a) type per tree and recompute only 2b, since 2b is where
@@ -2103,21 +2103,38 @@ Capture format: hot method, hypothesis, blockers.
      under-annotate, compound expressions disagree ~0.69% (the genuinely context-dependent residual —
      `NewClass`/`NewArray`/conditionals, the #602 set in #3 below), type-name identifiers ~0.7%
      (excludable by element kind). The flow-dependence is entirely in 2b, exactly as the split
-     assumed. **This reopens the split cache as a *sound* candidate** — provided it is per-factory
-     (each ATF has its own cache, as all the existing tree caches already are), returns a deep copy
-     (callers mutate), and skips the ~0.5–0.7% context-dependent kinds.
+     assumed. The per-hierarchy stability made it look like a sound candidate.
 
-     **Value is NOT yet confirmed; do an implemented-cache A/B before adoption.** Instrumented 2a
-     self-time for value leaves alone is ~0.55 s (~4% of a 12.6 s all-systems compile) and ~1.16 s
-     (~15%) on loop-heavy code, vs ~0.05–0.17 s deepCopy — a favorable projected ratio, and compound
-     2a (not separately timed) is larger. But projected savings have repeatedly evaporated in A/B this
-     session (the String→`Name` flat result; #4 applied-defaults). The next step is to *build* the
-     post-2a cache (store the type just before the `useFlow` block; on hit `deepCopy` + run only 2b;
-     key by `Tree`; clear per CU like the other tree caches; skip type-name identifiers and the #602
-     compound kinds) and measure deterministic allocation + wall on all-systems and loops. Until that
-     A/B exists this is a *candidate*, not a win. (The companion "phase-scoped full cache" idea was
-     rejected on the same flawed `toString()` measure and should likewise be re-measured per hierarchy
-     if revisited.) **Method lessons: (1) never measure annotated-type stability via `toString()` —
+     **BUILT AND REJECTED (June 2026) — unsound across checkers, and flat where it is sound.** A
+     working cache was implemented: a per-factory `IdentityHashMap<Tree, AnnotatedTypeMirror>` of
+     frozen pre-flow types, populated just before the `useFlow` block in
+     `GenericAnnotatedTypeFactory.addComputedTypeAnnotations`; `getAnnotatedType` was overridden to,
+     on a hit for a value-leaf, return `cached.deepCopy()` + re-applied flow (2b); cleared per CU;
+     toggled by `-Dcf.preflowcache`. Two findings killed it:
+     - **Unsound for any checker that overrides `addComputedTypeAnnotations`.** `IndexTest` fails
+       (`PredecrementTest.java:8`, an extra `array.access.unsafe.low`). `UpperBoundAnnotatedTypeFactory`
+       (and Lower Bound, Optional, Lock, Signedness) override `addComputedTypeAnnotations` to add
+       flow-dependent annotations **after** `super` — e.g. Index pulls the Value Checker's type and
+       calls `addUpperBoundTypeFromValueType` (its own comment cites `"int i = 1; --i;"`, exactly the
+       failing test). Intercepting at `getAnnotatedType` and re-applying only the GATF-level flow step
+       bypasses that subclass logic, so cache hits drop the index refinement. Caching *inside*
+       `addComputedTypeAnnotations` so the subclass tail still runs would need a deep "replace
+       annotations onto the passed-in type" and only saves 2a (not `fromExpression`) — more complexity
+       for a smaller win. (A diff of cache-on vs -off diagnostics on nullness corpora *was* clean —
+       the bug is specific to the subclass-override checkers, which is why nullness-only validation
+       missed it.)
+     - **Flat-to-mixed even where it is sound (nullness).** Deterministic A/B (median of 5 alloc;
+       2nd-best of 4 wall), cache off vs on: all-systems alloc 2658.7 → 2616.1 MB (−1.6%), wall
+       12.12 → 12.10 s (~0); loops alloc 1078.2 → **1100.1 MB (+2.0%, worse)**, wall 7.18 → 6.84 s
+       (−4.7%). The projected ~4–15% (raw 2a self-time) did not materialize: the per-hit `deepCopy` +
+       `freeze` + map overhead roughly cancels the saved 2a, and on the realistic corpus the result
+       is noise. Do not pursue. **Lesson: per-hierarchy stability proved the cache *could* be sound in
+       isolation, but a framework-wide `getAnnotatedType` cache must compose with subclass
+       `addComputedTypeAnnotations` overrides — and even ignoring that, the deepCopy cost makes it a
+       wash. Validate correctness across the *override* checkers (Index/Lock/Optional/Signedness), not
+       just nullness.** (The companion "phase-scoped full cache" idea was rejected on the same flawed
+       `toString()` measure and would hit the same compose-with-overrides wall.) **Method lessons:
+     (1) never measure annotated-type stability via `toString()` —
      compare per hierarchy (top-name → annotation), since `toString()` conflates cross-hierarchy
      completeness; (2) a checker runs *several* `AnnotatedTypeFactory` instances — never key
      instrumentation (or a cache) on `Tree` in `static` state, or you compare/mix different type

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2066,7 +2066,31 @@ Capture format: hot method, hypothesis, blockers.
      the soundness crux flagged here. And the instability is *highest where the redundancy is
      highest* (loops). A per-analysis memo would cache stale/wrong types; a per-*iteration* memo would
      be sound but the within-iteration redundancy is ~0. Low value and unsound — do not pursue.
-  2. **Scope-bounded expression-type cache** (per visitor-subtree) — broader, same soundness crux.
+  2. **Scope-bounded / pre-flow expression-type cache — MEASURED AND REJECTED (June 2026).** Two
+     forms tested by instrumenting `GenericAnnotatedTypeFactory.addComputedTypeAnnotations(Tree,
+     ATM)`, splitting it at the `if (this.useFlow)` boundary into the flow-independent prefix (2a:
+     `applyQualifierParameterDefaults` → tree/type annotators → `defaults.annotate`) and the
+     flow-dependent suffix (2b: `getInferredValueFor` + `applyInferredAnnotations`), with per-tree
+     `IdentityHashMap<Tree,String>` signature maps recording redundancy and the *unsound fraction*
+     (= repeats whose computed type differs from the prior result for the same tree). Single forked
+     `javac -processor nullness`, on all-systems (120 files) and a loop-heavy artificial workload.
+     (a) **Split-cache (cache the *pre-flow* 2a type, always recompute 2b) — unsound.** Redundancy is
+     high (repeats 91% all-systems / 86% loops of expression calls) but the pre-flow type is
+     **unstable 25% (all-systems) / 38% (loops)** of repeats, because the "flow-independent" tree
+     annotators transitively call `getAnnotatedType` on subexpressions whose types are flow-refined.
+     (b) **Phase-scoped full cache (cache the full type, but only when `analysis.isRunning()` is
+     false — i.e. the post-flow checking traversal with a frozen `flowResult`) — also unsound.**
+     Even restricted to the checking phase the full type is **unstable 26% (all-systems) / 59%
+     (loops)** of repeats (CHK repeats 91% / 68%). The same expression tree genuinely yields
+     different types across repeated queries even after flow analysis completes, so a
+     tree-identity-keyed cache would serve a stale/wrong type a quarter to a half of the time — worse
+     than the per-analysis `getValueFromFactory` memo (#1, 8–18%) already rejected. Cost context
+     confirms it is not even worth chasing the sound subset: the flow step 2b is cheap (~0.3 s
+     inclusive vs. a multi-second 2a), so the expense is entirely in the 2a computation **whose
+     result is the unstable thing** — and the stable trees (literals, simple identifiers) are exactly
+     the cheap-to-recompute ones (the "count ≠ cost" / #4 dead end). No safe getAnnotatedType-level
+     expression cache exists; the sound caches (skeleton `fromExpressionTreeCache`,
+     `methodAsMemberOfCache`, `classAndMethodTreeCache`) are already in place. Do not pursue.
   3. **Split flow-independent structure from flow-dependent annotations — MEASURED, ALREADY
      IMPLEMENTED (June 2026).** The hypothesis was: `fromExpression` (~24% inclusive) builds a
      deterministic-per-tree skeleton, so cache the frozen skeleton and re-apply only the

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1948,12 +1948,12 @@ super-linears — pathological depth, shallow in real code), or research-scale
 Index (entries are interleaved below; each is tagged with its status inline):
 - **Open, low-value:** `qualifiedNameCache` backing map; typeinference8 resolution #3
   (`getInstantiatedVariables`) and #4 (`getSmallestDependencySet`); the `cond` post-dataflow
-  conditional cache and `inherit` asSuper depth (size-sweep); `getAnnotatedType` #2 (scope-bounded
-  cache, same soundness crux) and #6 (parallelism).
+  conditional cache and `inherit` asSuper depth (size-sweep); `getAnnotatedType` #6 (parallelism).
 - **Open but correctness/cost-blocked:** `CFAbstractStore` content hash; lazy JDK-stub cascade; the
   immutability allocation win (load-bearing copy — see narrative).
 - **Closed, do not re-propose:** PR #1829 incorporation worklist (shipped); `getAnnotatedType` #1
-  (per-analysis gvff memo), #3 (already implemented), #4 (applied-defaults), #5
+  (per-analysis gvff memo), #2 (pre-flow split cache — built & rejected: unsound across
+  override-checkers + flat), #3 (already implemented), #4 (applied-defaults), #5
   (`methodFromUse`/`constructorFromUse`); typeinference8 resolution #1 (dependency graph) and #2
   (`saveBounds`); `AbstractAnalysis.getValue` subnode test (see Tried and rejected).
 

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1950,9 +1950,10 @@ Index (entries are interleaved below; each is tagged with its status inline):
   (`getInstantiatedVariables`) and #4 (`getSmallestDependencySet`); the `cond` post-dataflow
   conditional cache and `inherit` asSuper depth (size-sweep); `getAnnotatedType` #6 (parallelism).
 - **Open but correctness/cost-blocked:** `CFAbstractStore` content hash; lazy JDK-stub cascade; the
-  immutability allocation win — **copy-on-write now PROTOTYPED** (branch `cow-prototype`): solves the
-  soundness blocker (Guava-validated), allocation −4.8%, but wall +5.3% (per-access overhead); an
-  allocation/GC win, not a wall win — see the narrative's "Copy-on-write ATMs — PROTOTYPED" entry.
+  immutability allocation win — **copy-on-write PROTOTYPED and characterized** (branch
+  `cow-prototype`): solves the soundness blocker (Guava-validated), allocation −4.8%, but **no
+  configuration is wall-positive** (all-caches +5.3%, elementTypeCache-only +1.8%/noise) — a memory/GC
+  win only, not a wall win. See the narrative's "Copy-on-write ATMs — PROTOTYPED" entry.
 - **Closed, do not re-propose:** PR #1829 incorporation worklist (shipped); `getAnnotatedType` #1
   (per-analysis gvff memo), #2 (pre-flow split cache — built & rejected: unsound across
   override-checkers + flat), #3 (already implemented), #4 (applied-defaults), #5
@@ -2930,12 +2931,25 @@ off the hot path for the majority of (non-cache) types.
   access). This confirms the post-mortem: by now the copier is cheap, so eliminating it does not pay in
   wall clock — COW is an **allocation / GC-pressure** win (valuable at scale, on tight heaps), not a
   single-compile wall win.
-- **Verdict.** COW is the correct, complete solution to the soundness blocker and delivers the
-  allocation win, but as prototyped it is wall-negative. Before adopting: (1) confirm the wall sign on
-  the full warm-daemon `./gradlew checknullness` (single forked compile dilutes; the regression may
-  shrink or grow); (2) attack the diffuse per-access cost (e.g. cache `shallowCopy` results for
-  type-variables, or avoid `cowDirty` field reads on the very hottest accessors) — the prototype's
-  `cowChildren` fix shows the overhead is movable. Keep `cow-prototype` for whoever picks this up.
+- **Wall optimization attempted — COW cannot be made wall-positive (it is a memory win, not a wall
+  win).** Two levers tried (branch `cow-prototype`, second commit): (1) gate every child accessor with
+  `cowActive()` (`= COW && cowDirty`) so non-cache types skip the `cowChild` call and the field write —
+  removed the per-access *write* but did not move wall, so the write was not the cost; (2) flip **only
+  `elementTypeCache`** (the one cache with read-only-majority consumers, 65–88%) and revert the
+  full-walk caches (`element`/`fromMember`/`fromExpression`/`fromType`/`methodAsMemberOf`) to
+  `deepCopy`. Results (all-systems 269): all-six COW = alloc −4.8% / wall +5.3%; elementTypeCache-only
+  = alloc −0.2% / **wall +1.8% (noise)**. **No configuration is wall-positive**, for two structural
+  reasons: (a) the copier is already cheap (~1–2% — the post-mortem above), so eliminating it cannot
+  beat the *global per-accessor `cowActive()` tax* COW imposes on every type, not just cache results;
+  and (b) the cache consumers (defaulting/annotators) **fully walk** the result, so the read-only-skip
+  benefit never materializes and piecemeal per-child `cowCopy` is slower than one batched `deepCopy`.
+- **Verdict.** COW is the **correct, complete solution to the soundness blocker** (Guava-validated) and
+  delivers the **allocation win** (−4.8%), so it is the right tool if the goal is GC pressure / peak
+  memory at scale or a clean immutable end-state. It is **not** a wall-clock win — for wall, the
+  existing `deepCopy` is already optimal. Branch `cow-prototype` is kept as the reference
+  implementation. A wall win in this region, if one exists, is not here (copier already harvested) —
+  it is in *not producing* the types (the `getAnnotatedType`-redundancy family, already closed), not in
+  copying them more cheaply.
 
 ---
 

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2943,6 +2943,18 @@ off the hot path for the majority of (non-cache) types.
   beat the *global per-accessor `cowActive()` tax* COW imposes on every type, not just cache results;
   and (b) the cache consumers (defaulting/annotators) **fully walk** the result, so the read-only-skip
   benefit never materializes and piecemeal per-child `cowCopy` is slower than one batched `deepCopy`.
+- **Downstream / GC-bound win? — TESTED, no.** Hypothesis: the −4.8% allocation has no wall value on a
+  roomy single compile (GC ≈4%) but should pay off on a memory-pressured build. Heap sweep (all-systems
+  269, all-six COW): the wall penalty *shrinks* as the heap tightens (−Xmx 512m **+8.1%**, 320m +0.5%,
+  256m **+0.1%**) — which looks like the GC story — **but a clean GC measurement at −Xmx256m shows COW
+  does not reduce GC**: 0.77 s vs 0.76 s pauses, **225 collections both**. So the gap-closing is
+  tight-heap measurement variance (the *baseline* slows), not a COW GC saving — the −4.8% allocation
+  does not convert to fewer collections. Root cause: **CF compilation is CPU-bound** (~96% on-CPU, GC
+  ≤4% even on the large `checknullness` build), so the GC ceiling is ~4% and COW captures ~none of it
+  (−4.8% alloc → ≈−0.2% wall), nowhere near the +5% CPU tax. (COW reduces transient *churn*, not
+  *retained* heap — the cache masters are unchanged — so it does not relieve the OOM/footprint pressure
+  either; that needs per-entry-weight reduction, the original immutability goal.) No downstream timing
+  win.
 - **Verdict.** COW is the **correct, complete solution to the soundness blocker** (Guava-validated) and
   delivers the **allocation win** (−4.8%), so it is the right tool if the goal is GC pressure / peak
   memory at scale or a clean immutable end-state. It is **not** a wall-clock win — for wall, the

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2287,6 +2287,32 @@ wins did not move single-compile time — their value is GC pressure at scale); 
 (2) The largest non-obvious CPU slice is CF driving javac (symbol completion + name
 decoding + tree/path walks), bigger than dataflow + stubs + visitor combined.
 
+**Guava cross-check (first hotspot JFR of a large heavy-generics codebase, June 2026).**
+`test-guava-nullness.sh` (Nullness Checker on the `guava` module, 625 files; JFR injected
+via the forked-compiler `-J` args in the `checkerframework-local` profile; 7,814
+ExecutionSamples). Two findings:
+- **The leaf self-time profile generalizes — nothing new at the leaf.** Same flat shape as
+  `checkNullness`: no CF leaf above **3.85%**; the top is `IdentityHashMap.get`/`put` (≈6.8%
+  combined), the ATM traversal (`AnnotatedTypeScanner.scan`/`visitDeclared`/`reduce` ≈7%),
+  `Symbol.apiComplete`, `DefaultApplierElementImpl.scan`, `AnnotatedTypeCopier.visitDeclared`,
+  `AnnotatedTypeMirror.createType`. Allocation: `[Ljava.lang.Object;` 32%, `ArrayList` 8.7%,
+  `IdentityHashMap` 5.5%, `AnnotationMirrorSet` 4.5% — the same ATM-pipeline allocation.
+- **New *fact* (not a new lever): type-argument inference is a top-2 inclusive cost on heavy
+  generics, where it is negligible on `all-systems`/`checkNullness`.** `getAnnotatedType` 50%
+  inclusive (as usual), but then `methodFromUse` **24.6%** → `inferTypeArgs` **23.0%** →
+  `InvocationTypeInference.infer` 22.4% → `ConstraintSet.reduceOneStep` 14.1%. Decomposing the
+  23% inference slice (`cooccur`): **50% of it is under `getAnnotatedType`** (building
+  argument/receiver/bound types) and **28% under `incorporateToFixedPoint`** (the machinery
+  PR #1829 already optimized); the inference-*specific* self-time (`TypeConstraint.hashCode`,
+  `ConstraintSet`, constraint-collection churn — `LinkedHashMap`/`ListBuffer`/`List$2` ≈6% of
+  allocation) is small and diffuse. So Guava **reinforces** rather than overturns the Short
+  list: the biggest lever is still `getAnnotatedType` (now shown to dominate inference too, not
+  just checking), inference's big win already shipped (#1829), and the resolution items (#3/#4)
+  stay low-value — their self-time is tiny even here. Takeaway for future sessions: `all-systems`
+  and `checkNullness` **under-represent inference**; profile **Guava (or jspecify-conformance)**
+  for any inference work, but expect the cost to be the type pipeline it drives, not a clean
+  inference-specific frame.
+
 Open venues, roughly by tractability:
 
 - **Reduce ATM deep copying (`AnnotatedTypeCopier.visit` = 22% of `Object[]`).**

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -2091,6 +2091,20 @@ Capture format: hot method, hypothesis, blockers.
      the cheap-to-recompute ones (the "count ≠ cost" / #4 dead end). No safe getAnnotatedType-level
      expression cache exists; the sound caches (skeleton `fromExpressionTreeCache`,
      `methodAsMemberOfCache`, `classAndMethodTreeCache`) are already in place. Do not pursue.
+     (c) **Even the subexpression-free *leaf* subset (identifiers/literals), checking-phase only —
+     unsound, and immaterial.** The natural rescue ("the instability comes from tree annotators
+     querying flow-refined subexpressions, so restrict the cache to leaves that have none") was
+     measured: in the checking phase the pre-flow leaf type is still **unstable 22% (identifiers) /
+     40% (literals)** on all-systems, 58% / 43% on loops. The cause is *not* subexpression flow — it
+     is that the computed type is context-dependent in *which hierarchy's annotations are applied*:
+     the same `1` literal returns `int` in one query and `@Initialized int` in another (nullness runs
+     with the Initialization checker), so a tree-keyed cache would hand back an under-annotated type
+     and break subtyping. Independently, the cost ceiling is immaterial: the safely-cacheable
+     checking-phase leaf 2a self-time is only ~0.22 s (~1.5% of a 13.9 s 120-file compile); the large
+     leaf-2a figure (18× the deepCopy cost) is dominated by *dataflow-phase* leaf work, which is not
+     safe to cache. **Lesson: `getAnnotatedType`'s result is keyed by call *context*, not by tree
+     identity — even for a literal — so no tree-identity cache at this level is sound, at any
+     granularity.**
   3. **Split flow-independent structure from flow-dependent annotations — MEASURED, ALREADY
      IMPLEMENTED (June 2026).** The hypothesis was: `fromExpression` (~24% inclusive) builds a
      deterministic-per-tree skeleton, so cache the frozen skeleton and re-apply only the

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1950,7 +1950,9 @@ Index (entries are interleaved below; each is tagged with its status inline):
   (`getInstantiatedVariables`) and #4 (`getSmallestDependencySet`); the `cond` post-dataflow
   conditional cache and `inherit` asSuper depth (size-sweep); `getAnnotatedType` #6 (parallelism).
 - **Open but correctness/cost-blocked:** `CFAbstractStore` content hash; lazy JDK-stub cascade; the
-  immutability allocation win (load-bearing copy — see narrative).
+  immutability allocation win — **copy-on-write now PROTOTYPED** (branch `cow-prototype`): solves the
+  soundness blocker (Guava-validated), allocation −4.8%, but wall +5.3% (per-access overhead); an
+  allocation/GC win, not a wall win — see the narrative's "Copy-on-write ATMs — PROTOTYPED" entry.
 - **Closed, do not re-propose:** PR #1829 incorporation worklist (shipped); `getAnnotatedType` #1
   (per-analysis gvff memo), #2 (pre-flow split cache — built & rejected: unsound across
   override-checkers + flat), #3 (already implemented), #4 (applied-defaults), #5
@@ -2893,6 +2895,47 @@ CF-controllable clusters and their state, highest-leverage first:
    ~0.58%, blocked on a thread-reachability + daemon-memory audit — see Short list above). Annotation
    formatting in the hot path is now **resolved** (PR #1797 lazy `FoundRequired`); remaining utf2*
    at 0.89% is cold-path / first-visit-miss only.
+
+**Copy-on-write ATMs — PROTOTYPED (June 2026): solves the soundness blocker, allocation win real,
+but wall-clock-negative.** The blocker (above) was that returning a shared frozen cache master crashes
+when a consumer reparents a frozen *child* into a fresh non-frozen result and mutates it (root-level
+`deepCopy()` guards can't catch a non-frozen root holding a frozen child; Guava found what `alltests`
++ 9 fixes missed). A working COW prototype was built (branch `cow-prototype`, gated by `-Dcf.cow`):
+the six post-pipeline caches (`elementType`, `element`, `fromMember`, `fromExpression`, `fromType`,
+`methodAsMemberOf`) return `cowCopy()` — a non-frozen `shallowCopy()` that shares the master's frozen
+children — instead of `deepCopy()`; the ~13 child accessors (`getUpperBound`/`getTypeArguments`/…)
+**plus the three `fixupBoundAnnotations`** (which mutate bound *fields* directly, bypassing the
+accessors — the second class of reparenting path) lazily unshare a frozen child of a non-frozen parent
+(`cowChild`/`cowChildren`), so a mutation copies only the spine it touches and a read-only hit copies
+one node. A per-node `cowDirty` flag (set by `cowCopy`, checked in the accessors) keeps the COW scan
+off the hot path for the majority of (non-cache) types.
+- **Soundness: complete and validated.** Passes the regression test
+  `ElementTypeCacheWildcardBound`, all-systems (269 files, byte-identical diagnostics to COW-off),
+  and — the decisive test — a **full Guava nullness build (BUILD SUCCESS, 0 crashes)**, the venue that
+  caught the original flip crash. COW-on-access is the complete fix the narrative predicted: it makes
+  all six caches flippable and the whole reparenting bug class disappears. Two non-obvious lessons:
+  (a) the executable type's `getTypeVariables` and the union/intersection `getAlternatives`/`getBounds`
+  are easy accessors to miss; (b) the `fixupBoundAnnotations` field-level mutation is a *second*
+  reparenting surface that COW-on-access alone (intercepting only the public getters) does not cover —
+  it must be routed through `cowChild`/`cowChildren` too.
+- **Allocation: −4.8% (real).** Deterministic `ThreadAllocationStatistics`, all-systems 269, median of
+  5: 5709.6 → 5434.3 MB; loops −3.6%. Larger than the ~1% the old `elementType`+`classAndMethod`
+  boundary flips got, because COW flips all six caches and `shallowCopy` is far cheaper than `deepCopy`
+  on read-only hits.
+- **Wall clock: +5.3% (regression).** all-systems 269, min of 3: 19.81 → 20.86 s. The per-access COW
+  machinery costs more CPU than the allocation reduction returns. The `cowDirty` flag fixed the one hot
+  frame (`cowChildren` 3.74% → 0.50% self-time), but the residual is **diffuse** — the distributed
+  per-access checks plus per-child `cowCopy` allocations across the walk (note `shallowCopy` for
+  type-variables/wildcards is itself a `deepCopy`, so a generics-heavy type deep-copies each bound on
+  access). This confirms the post-mortem: by now the copier is cheap, so eliminating it does not pay in
+  wall clock — COW is an **allocation / GC-pressure** win (valuable at scale, on tight heaps), not a
+  single-compile wall win.
+- **Verdict.** COW is the correct, complete solution to the soundness blocker and delivers the
+  allocation win, but as prototyped it is wall-negative. Before adopting: (1) confirm the wall sign on
+  the full warm-daemon `./gradlew checknullness` (single forked compile dilutes; the regression may
+  shrink or grow); (2) attack the diffuse per-access cost (e.g. cache `shallowCopy` results for
+  type-variables, or avoid `cowDirty` field reads on the very hottest accessors) — the prototype's
+  `cowChildren` fix shows the overhead is movable. Keep `cow-prototype` for whoever picks this up.
 
 ---
 

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1874,6 +1874,61 @@ the prior finding. A fresh hypothesis is not new evidence.
   only sanctioned rescue in this basin is a maintained incremental content-hash on `CFAbstractStore`
   (see the Short list and the rejected equal-store merge short-circuit above), memory-A/B-gated.
 
+- **`String`→`Name` annotation-name migration: replace `AnnotationUtils.annotationName` (String)
+  with `annotationNameAsName` (javac `Name`) + `==` identity comparison, framework-wide (June
+  2026).** Branch converting the name-dispatch sites in `ValueAnnotatedTypeFactory`,
+  `ValueQualifierHierarchy`, `ValueTransfer`, the Index `UpperBound*` checkers, `Units`,
+  `BaseTypeVisitor`/`BaseTypeValidator` (`qualAllowedLocations`), `DependentTypesHelper`
+  (`annoToElements`), and `AnnotatedTypeFactory` (`aliases`, `declAliases`, `isSupportedQualifier`)
+  from value-based `String` comparison to `Name`-identity comparison, backing maps switched to
+  `IdentityHashMap<Name,…>`. Premise: "avoid the `Name.toString()` decode + `String.intern()` that
+  `annotationName` performs."
+
+  **Measured flat — alloc and wall — even after completing the half-finished form.** As proposed the
+  branch slightly *regresses*, because `annotationNameAsName` had no
+  `CheckerFrameworkAnnotationMirror` (CFAM) fast path (it pointer-chases
+  `getAnnotationType().asElement().getQualifiedName()` where `annotationName` reads a cached field)
+  and `isSupportedQualifier(Name)` still called `name.toString()` on every cache miss. To measure the
+  *approach* and not the artifacts, the branch was completed: cache a `Name` field on CFAM next to its
+  existing interned-`String` `annotationName`; give `annotationNameAsName` a CFAM fast path; replace
+  `isSupportedQualifier`'s `getSupportedTypeQualifierNames().contains(name.toString())` with a
+  one-time identity-backed companion `Set<Name>` membership test. A/B of that fully-realized version
+  vs. master (deterministic `jdk.ThreadAllocationStatistics`, single forked `javac`):
+
+  | corpus | metric | master | realized | delta |
+  | --- | --- | --- | --- | --- |
+  | nullness, `inherit` shape (~7.4k LoC) | alloc (median of 5) | 4488.0 MB | 4492.3 MB | +0.10% (noise) |
+  | nullness, `repeat` shape (~7.3k LoC) | alloc | 785.7 MB | 787.5 MB | +0.23% (noise) |
+  | Value, 8 test inputs batched | alloc | 312.6 MB | 312.9 MB | +0.10% (noise) |
+  | nullness, `inherit` | wall (2nd-best of 4) | 7.98 s | 8.18 s | noise |
+  | nullness, `repeat` | wall | 5.10 s | 5.05 s | noise |
+
+  **Root cause — the targeted allocation does not happen on hot paths.** CFAM, the representation the
+  framework manipulates for the overwhelming majority of annotations, already caches its name as an
+  `@Interned String` computed once in its constructor, so `annotationName(am)` was *already a field
+  read with zero allocation* for CFAM. The `toString().intern()` cost applies only to raw
+  `Attribute.Compound` source mirrors, and even there `getAnnotationType().asElement()` is two field
+  reads (`anno.type.tsym`). You cannot remove garbage that is not being produced.
+
+  **Ceiling proof.** A deliberately annotation-saturated, checker-bound workload (400 methods × 40
+  explicitly-`@Nullable`/`@NonNull`/`@MonotonicNonNull` locals each), profiled at 2596
+  `ExecutionSample`s, shows the name-handling frames — `annotationName`, `annotationNameAsName`,
+  `areSameByName`, `isSupportedQualifier`, `Name.toString`, `String.intern` — **entirely below the
+  sample floor (0 samples).** The hot leaf there is `IdentityHashMap.get` (7.8%), attributed
+  (`jfr-analyze self`) ~40% to `ElementQualifierHierarchy.getQualifierKind` — annotation→`QualifierKind`
+  resolution, *not* name handling — and caching *that* is itself already measured-and-rejected (see
+  "`AnnotationMirror → QualifierKind` second-level cache" above). **General lesson: annotation-name
+  comparison/dispatch is not a hotspot; CFAM already caches the decoded interned name, so any
+  String→`Name` rerepresentation is flat. This is the dispatch-level analogue of the `isStringEqual`
+  false premise (see "Element and name caching"). The annotation-name allocation that *does* show up
+  (`[B` UTF-8 decode, ~28% of dataflow allocation) is `Name.toString()` deep in dataflow/store
+  machinery, not in qualifier-name dispatch — optimize there, not here.** The branch also seeded three
+  anti-patterns worth recording: a `static IdentityHashMap<Name,…>` (Names are interned *per
+  compilation context*, so a static identity-map both leaks across compilation tasks and never hits
+  cross-context — keep such caches instance-scoped), unused cached-`Name` fields hidden behind a
+  class-wide `@SuppressWarnings("UnusedVariable")`, and `Name`-identity assumptions spread across the
+  public `javacutil` surface for no measured gain.
+
 ---
 
 ## Short list


### PR DESCRIPTION
This started with Antigravity proposing converting more `String`s to `Name`s. Claude reviewed it and showed no performance benefit. A few follow-on experiments eventually led to abandoning these changes.
Keeping just the performance notes as history.