### PR TITLE
Avoid bnd warning by properly exporting content

### DIFF
--- a/checker-qual/build.gradle
+++ b/checker-qual/build.gradle
@@ -43,7 +43,7 @@ tasks.named('javadoc') {
 
 tasks.named('jar') {
     manifest {
-        attributes('Export-Package': '*')
+        attributes('-exportcontents': '*')
     }
 }
 


### PR DESCRIPTION
In build output I sometimes see:

```
checker-qual/build/tmp/jar/bnd7462218119675157734.bnd:0:
  warning: Classpath is empty. Private-Package, -privatepackage, and Export-Package can only expand from the classpath
  when there is one
```

Explanation of the fix by Antigravity:

```
  The warning happens because  checker-qual  has no dependencies, meaning its  compileClasspath  is perfectly empty.
  When BND encounters the instruction  Export-Package: * , its default behavior is to try and expand that  *  by
  looking at the packages on the project's dependency classpath. Since the classpath is empty, BND warns you that it
  can't expand anything from it.

  Instead of suppressing the warning, the correct OSGi instruction to use here is  -exportcontents: * . This tells
  BND to export all packages that are already included in the jar (i.e. the project's own compiled classes) instead
  of trying to pull and export packages from the dependency classpath.
```