### PR TITLE
Use `ElementUtils.isElementFromSourceCode` and deprecate `isElementFromByteCode`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessTreeAnnotator.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationFieldAccessTreeAnnotator.java
@@ -3,13 +3,13 @@ package org.checkerframework.checker.initialization;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
-import com.sun.source.tree.Tree;
 
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.InternalUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
@@ -129,15 +129,14 @@ public class InitializationFieldAccessTreeAnnotator extends TreeAnnotator {
         // Here, we will get an error for the first assignment, but we won't get another
         // error for the second assignment.
         // See the AssignmentDuringInitialization test case.
-        Tree fieldDeclarationTree = initFactory.declarationFromElement(element);
         InitializationStore store = initFactory.getStoreBefore(tree);
-        // If the field declaration is null (because the field is declared in bytecode),
+        // If the field is not from source code (e.g. because the field is declared in bytecode),
         // or the store is null (because flow-sensitive refinement is turned off),
         // the field is considered uninitialized.
         // Fields of objects other than this are not tracked and thus also considered uninitialized.
         // Otherwise, check if the field is initialized in the given store.
         boolean isFieldInitialized =
-                fieldDeclarationTree != null
+                ElementUtils.isElementFromSourceCode(element)
                         && store != null
                         && TreeUtils.isSelfAccess(tree)
                         && store.isFieldInitialized(element);

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserRecordTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserRecordTest.java
@@ -6,7 +6,24 @@ import org.junit.runners.Parameterized;
 import java.io.File;
 import java.util.List;
 
-/** Tests for stub parsing with records. */
+/**
+ * Tests for stub parsing with records.
+ *
+ * <p>The records these stub files annotate are compiled from source, in this same directory, so the
+ * test needs {@code -AmergeStubsWithSource}: that is what makes an annotation file apply to a class
+ * that is being compiled.
+ *
+ * <p>Without it the test passed, but only by accident, and it was order-dependent. {@code
+ * AnnotatedTypeFactory.fromElement} consults the stub files only when {@code
+ * declarationFromElement} finds no tree for the element, so whether a source-declared element gets
+ * its stub annotations depends on whether javac still has its tree at the moment of the element's
+ * first use -- and whichever type is computed first is frozen into {@code elementCache} for the
+ * rest of the compilation. Adding a file to this directory whose name sorts before {@code
+ * PairRecord.java} was enough to change the answer: {@code new PairRecord(null)} in {@code
+ * RecordUsage.java} began reporting {@code argument.type.incompatible}, because the constructor's
+ * type was cached from its source declaration, without the {@code @Nullable} its stub file gives
+ * it.
+ */
 public class StubparserRecordTest extends CheckerFrameworkPerDirectoryTest {
 
     /**
@@ -19,7 +36,8 @@ public class StubparserRecordTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "stubparser-records",
-                "-Astubs=tests/stubparser-records");
+                "-Astubs=tests/stubparser-records",
+                "-AmergeStubsWithSource");
     }
 
     @Parameterized.Parameters

--- a/framework/src/main/java/org/checkerframework/common/initializedfields/InitializedFieldsAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/initializedfields/InitializedFieldsAnnotatedTypeFactory.java
@@ -141,7 +141,7 @@ public class InitializedFieldsAnnotatedTypeFactory extends AccumulationAnnotated
             Set<Contract.Postcondition> result = super.getPostconditions(executableElement);
 
             // Only process constructors defined in source code being type-checked.
-            if (declarationFromElement(executableElement) != null
+            if (ElementUtils.isElementFromSourceCode(executableElement)
                     && executableElement.getKind() == ElementKind.CONSTRUCTOR) {
                 String[] fieldsToInitialize =
                         fieldsToInitialize((TypeElement) executableElement.getEnclosingElement());

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1862,7 +1862,18 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         Tree decl = declarationFromElement(elt);
 
         if (decl == null) {
-            type = stubTypes.getAnnotatedTypeMirror(elt);
+            // An annotation file annotates code that is not being compiled: "if file A.java is
+            // being compiled, then by default any stub for class A is ignored" (the manual,
+            // "Using stub classes"); -AmergeStubsWithSource, handled below, is how a user asks for
+            // both. Test that by where the element is declared, not by the absence of a tree:
+            // declarationFromElement returns null for a source element too, whenever `root` is
+            // unset and for a member javac synthesizes and has no tree for, such as a record's
+            // canonical constructor and its accessors.
+            if (!ElementUtils.isElementFromSourceCode(elt)) {
+                type = stubTypes.getAnnotatedTypeMirror(elt);
+            } else {
+                type = null;
+            }
             if (type == null) {
                 type = toAnnotatedType(elt.asType(), ElementUtils.isTypeDeclaration(elt));
                 ElementAnnotationApplier.apply(type, elt, this);
@@ -4787,14 +4798,25 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns true if the element is from bytecode and the if the element did not appear in a stub
-     * file. Currently only works for methods, constructors, and fields.
+     * Returns true if the element is from bytecode -- that is, it is not being compiled -- and did
+     * not appear in a stub file.
+     *
+     * <p>"Not being compiled" is decided by where the element is declared ({@link
+     * ElementUtils#isElementFromSourceCode}), not by whether a classfile happens to exist for it
+     * ({@link ElementUtils#isElementFromByteCode}, which is true even when the element is also
+     * being compiled from source), and not by whether a tree happens to be available for it ({@link
+     * #declarationFromElement}, which returns null for a source element too: whenever {@code root}
+     * is unset, and for a member javac synthesizes and has no tree for, such as a record's
+     * canonical constructor and its accessors).
+     *
+     * @param element an element
+     * @return true if the element is from bytecode and did not appear in a stub file
      */
     public boolean isFromByteCode(Element element) {
         if (isFromStubFile(element)) {
             return false;
         }
-        return ElementUtils.isElementFromByteCode(element);
+        return !ElementUtils.isElementFromSourceCode(element);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -840,17 +840,8 @@ public class QualifierDefaults {
             return false;
         }
 
-        // TODO: I would expect this:
-        //   atypeFactory.isFromByteCode(annotationScope)) {
-        // to work instead of the
-        // isElementFromByteCode/declarationFromElement/isFromStubFile calls,
-        // but it doesn't work correctly and tests fail.
-
         boolean isFromStubFile = atypeFactory.isFromStubFile(annotationScope);
-        boolean isBytecode =
-                ElementUtils.isElementFromByteCode(annotationScope)
-                        && atypeFactory.declarationFromElement(annotationScope) == null
-                        && !isFromStubFile;
+        boolean isBytecode = atypeFactory.isFromByteCode(annotationScope);
         if (isBytecode) {
             return useConservativeDefaultsBytecode
                     && !isElementAnnotatedForThisChecker(annotationScope);

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -445,6 +445,10 @@ public class ElementUtils {
      * <p>By contrast, {@link ElementUtils#isElementFromByteCode(Element)} returns true if there is
      * a classfile for the given element, even if there is also a source file.
      *
+     * <p>An element with no enclosing type element is not from a source file that is being
+     * compiled, so this returns false for it: a package, or the type variable of a captured
+     * wildcard, which javac synthesizes and which no source file declares.
+     *
      * @param element the element to check, or null
      * @return true if a source file containing the element is being compiled
      */
@@ -454,7 +458,7 @@ public class ElementUtils {
         }
         TypeElement enclosingTypeElement = enclosingTypeElement(element);
         if (enclosingTypeElement == null) {
-            throw new BugInCF("enclosingTypeElement(%s) is null", element);
+            return false;
         }
         return isElementFromSourceCodeImpl((Symbol.ClassSymbol) enclosingTypeElement);
     }
@@ -482,7 +486,13 @@ public class ElementUtils {
      *
      * @param elt some element
      * @return true if the element is declared in ByteCode
+     * @deprecated Use {@code !isElementFromSourceCode(elt)} to check if an element is not being
+     *     compiled from source. If you also need to account for stub files, use {@link
+     *     org.checkerframework.framework.type.AnnotatedTypeFactory#isFromByteCode(Element)}. This
+     *     method is deprecated because its semantics are rarely what is desired: it returns true if
+     *     a classfile exists for the given element, even if it is also being compiled from source.
      */
+    @Deprecated // 2026-07-15
     public static boolean isElementFromByteCode(@Nullable Element elt) {
         if (elt == null) {
             return false;


### PR DESCRIPTION
- Replaced brittle `declarationFromElement(...) != null` checks with `ElementUtils.isElementFromSourceCode(...)` in initialization checkers.
- Deprecated `ElementUtils.isElementFromByteCode` as it doesn't correctly distinguish source from bytecode elements.
- Cleaned up bytecode checks in `AnnotatedTypeFactory` and `QualifierDefaults` to fix synthesized elements (like record components) being incorrectly classified.