### PR TITLE
nullness: Check for unsound side effects in `Arrays.copyOf` calls

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
@@ -1,20 +1,25 @@
 package org.checkerframework.checker.nullness;
 
 import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ArrayAccessTree;
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.CompoundAssignmentTree;
+import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.util.SimpleTreeVisitor;
 
 import org.checkerframework.checker.initialization.InitializationFieldAccessAnnotatedTypeFactory;
 import org.checkerframework.checker.initialization.InitializationFieldAccessSubchecker;
@@ -755,24 +760,117 @@ public class NullnessNoInitAnnotatedTypeFactory
                 List<? extends ExpressionTree> args = tree.getArguments();
                 ExpressionTree lengthArg = args.get(1);
                 if (TreeUtils.isArrayLengthAccess(lengthArg)) {
-                    // TODO: This syntactic test may not be not correct if the array expression has
-                    // a side effect that affects the array length.  This code could require that
-                    // the expression has no method calls, assignments, etc.
                     ExpressionTree arrayArg = args.get(0);
-                    if (TreeUtils.sameTree(
-                            arrayArg, ((MemberSelectTree) lengthArg).getExpression())) {
+                    if (TreeUtils.sameTree(arrayArg, ((MemberSelectTree) lengthArg).getExpression())
+                            && Boolean.TRUE.equals(pureExpressionVisitor.visit(arrayArg, null))) {
                         AnnotatedArrayType arrayArgType =
                                 (AnnotatedArrayType) getAnnotatedType(arrayArg);
                         AnnotatedTypeMirror arrayArgComponentType = arrayArgType.getComponentType();
-                        // Maybe this call is only necessary if argNullness is @NonNull.
                         ((AnnotatedArrayType) type)
-                                .getComponentType()
-                                .replaceAnnotations(arrayArgComponentType.getAnnotations());
+                                .setComponentType(arrayArgComponentType.deepCopy());
                     }
                 }
             }
             return super.visitMethodInvocation(tree, type);
         }
+    }
+
+    /**
+     * A visitor that determines if an expression is pure (i.e. side-effect-free and deterministic).
+     * Used for safely optimizing Arrays.copyOf assignments when the length argument matches the
+     * array.
+     */
+    private final SimpleTreeVisitor<Boolean, Void> pureExpressionVisitor =
+            new SimpleTreeVisitor<Boolean, Void>(false) {
+                @Override
+                public Boolean visitIdentifier(IdentifierTree node, Void p) {
+                    return true;
+                }
+
+                @Override
+                public Boolean visitMemberSelect(MemberSelectTree node, Void p) {
+                    return visit(node.getExpression(), p);
+                }
+
+                @Override
+                public Boolean visitArrayAccess(ArrayAccessTree node, Void p) {
+                    return visit(node.getExpression(), p) && visit(node.getIndex(), p);
+                }
+
+                @Override
+                public Boolean visitLiteral(LiteralTree node, Void p) {
+                    return true;
+                }
+
+                @Override
+                public Boolean visitTypeCast(TypeCastTree node, Void p) {
+                    return visit(node.getExpression(), p);
+                }
+
+                @Override
+                public Boolean visitParenthesized(ParenthesizedTree node, Void p) {
+                    return visit(node.getExpression(), p);
+                }
+
+                @Override
+                public Boolean visitMethodInvocation(MethodInvocationTree node, Void p) {
+                    ExecutableElement methodElement = TreeUtils.elementFromUse(node);
+                    if (methodElement == null
+                            || !isDeterministic(methodElement)
+                            || !isSideEffectFree(methodElement)) {
+                        return false;
+                    }
+                    if (!visit(node.getMethodSelect(), p)) {
+                        return false;
+                    }
+                    for (Tree arg : node.getArguments()) {
+                        if (!visit(arg, p)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+
+                @Override
+                public Boolean visitConditionalExpression(ConditionalExpressionTree node, Void p) {
+                    return visit(node.getCondition(), p)
+                            && visit(node.getTrueExpression(), p)
+                            && visit(node.getFalseExpression(), p);
+                }
+            };
+
+    /**
+     * Returns the message key for why a call to Arrays.copyOf cannot return an array of
+     * {@code @NonNull} elements, or null if the call is safe or not applicable.
+     *
+     * @param tree the method invocation tree to analyze
+     * @return the diagnostic message key explaining why the copy is unsafe, or null if it's safe or
+     *     not an Arrays.copyOf call
+     */
+    public String getCopyOfUnsafeReason(MethodInvocationTree tree) {
+        if (TreeUtils.isMethodInvocation(tree, copyOfMethods, processingEnv)) {
+            List<? extends ExpressionTree> args = tree.getArguments();
+            ExpressionTree arrayArg = args.get(0);
+            AnnotatedTypeMirror arrayArgType = getAnnotatedType(arrayArg);
+            if (arrayArgType instanceof AnnotatedArrayType) {
+                AnnotatedTypeMirror arrayArgComponentType =
+                        ((AnnotatedArrayType) arrayArgType).getComponentType();
+                if (arrayArgComponentType.hasEffectiveAnnotation(NonNull.class)) {
+                    ExpressionTree lengthArg = args.get(1);
+                    if (!TreeUtils.isArrayLengthAccess(lengthArg)) {
+                        return "arrays.copyof.size.mismatch";
+                    }
+                    if (!TreeUtils.sameTree(
+                            arrayArg, ((MemberSelectTree) lengthArg).getExpression())) {
+                        return "arrays.copyof.array.mismatch";
+                    }
+                    if (!Boolean.TRUE.equals(pureExpressionVisitor.visit(arrayArg, null))) {
+                        return "arrays.copyof.impure";
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
@@ -21,6 +21,7 @@ import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.SimpleTreeVisitor;
 
+import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.initialization.InitializationFieldAccessAnnotatedTypeFactory;
 import org.checkerframework.checker.initialization.InitializationFieldAccessSubchecker;
 import org.checkerframework.checker.initialization.InitializationFieldAccessTreeAnnotator;
@@ -847,7 +848,7 @@ public class NullnessNoInitAnnotatedTypeFactory
      * @return the diagnostic message key explaining why the copy is unsafe, or null if it's safe or
      *     not an Arrays.copyOf call
      */
-    public String getCopyOfUnsafeReason(MethodInvocationTree tree) {
+    public @Nullable @CompilerMessageKey String getCopyOfUnsafeReason(MethodInvocationTree tree) {
         if (TreeUtils.isMethodInvocation(tree, copyOfMethods, processingEnv)) {
             List<? extends ExpressionTree> args = tree.getArguments();
             ExpressionTree arrayArg = args.get(0);

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitVisitor.java
@@ -969,6 +969,24 @@ public class NullnessNoInitVisitor extends BaseTypeVisitor<NullnessNoInitAnnotat
     }
 
     @Override
+    protected void reportCommonAssignmentError(
+            AnnotatedTypeMirror varType,
+            AnnotatedTypeMirror valueType,
+            Tree valueTree,
+            @CompilerMessageKey String errorKey,
+            Object... extraArgs) {
+        super.reportCommonAssignmentError(varType, valueType, valueTree, errorKey, extraArgs);
+
+        if (valueTree instanceof MethodInvocationTree) {
+            String copyOfUnsafeReason =
+                    atypeFactory.getCopyOfUnsafeReason((MethodInvocationTree) valueTree);
+            if (copyOfUnsafeReason != null) {
+                checker.reportWarning(valueTree, copyOfUnsafeReason);
+            }
+        }
+    }
+
+    @Override
     protected TypeValidator createTypeValidator() {
         return new NullnessValidator(checker, this, atypeFactory);
     }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/messages.properties
@@ -14,6 +14,9 @@ switching.nullable=switching on a possibly-null value %s
 toarray.nullable.elements.not.newarray=call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor
 toarray.nullable.elements.mismatched.size=call of toArray on collection of non-null elements yields an array of possibly-null elements; cannot determine that the argument array has the same size as the receiver collection
 clear.system.property=call might clear a predefined system property; pass -Alint=permitClearProperty to permit it
+arrays.copyof.size.mismatch=call of Arrays.copyOf yields an array of possibly-null elements; the length argument is not an array length access
+arrays.copyof.array.mismatch=call of Arrays.copyOf yields an array of possibly-null elements; the length argument is the length of a different array
+arrays.copyof.impure=call of Arrays.copyOf yields an array of possibly-null elements; the array expression has side effects or is not deterministic
 
 # Unnecessary operations
 nulltest.redundant=redundant test against null; "%s" is non-null

--- a/checker/tests/nullness/CopyOfArray.java
+++ b/checker/tests/nullness/CopyOfArray.java
@@ -7,8 +7,79 @@ public class CopyOfArray {
         Object[] copyExact1 = Arrays.copyOf(args, args.length);
         @Nullable Object[] copyExact2 = Arrays.copyOf(args, args.length);
 
+        // :: warning: (arrays.copyof.size.mismatch)
         // :: error: (assignment.type.incompatible)
         Object[] copyInexact1 = Arrays.copyOf(args, i);
         @Nullable Object[] copyInexact2 = Arrays.copyOf(args, i);
+    }
+
+    static int callCount = 0;
+
+    static String[] getArray() {
+        callCount++;
+        if (callCount == 1) {
+            return new String[] {"a"};
+        } else {
+            return new String[] {"a", "b", "c"};
+        }
+    }
+
+    void testSideEffect() {
+        // getArray() has side effects, so Arrays.copyOf returns an array of @Nullable elements.
+        // Assigning it to an array of @NonNull elements should be an error.
+        // :: warning: (arrays.copyof.impure)
+        // :: error: (assignment.type.incompatible)
+        String[] result = Arrays.copyOf(getArray(), getArray().length);
+    }
+
+    @org.checkerframework.dataflow.qual.Pure
+    static String[] getPureArray() {
+        return new String[] {"a", "b", "c"};
+    }
+
+    void testPureMethod() {
+        // getPureArray() is pure, so this should not produce an error!
+        String[] result = Arrays.copyOf(getPureArray(), getPureArray().length);
+    }
+
+    String[] fieldArray = new String[] {"a"};
+
+    void testMemberSelect() {
+        String[] result = Arrays.copyOf(this.fieldArray, this.fieldArray.length);
+    }
+
+    void testArrayAccess(String[][] matrix) {
+        String[] result = Arrays.copyOf(matrix[0], matrix[0].length);
+    }
+
+    void testCast(Object[] args) {
+        String[] result = Arrays.copyOf((String[]) args, ((String[]) args).length);
+    }
+
+    void testParenthesized(String[] args) {
+        String[] result = Arrays.copyOf((args), (args).length);
+    }
+
+    void testAssignment(String[] args) {
+        String[] other;
+        // :: warning: (arrays.copyof.impure)
+        // :: error: (assignment.type.incompatible)
+        String[] result = Arrays.copyOf(other = args, (other = args).length);
+    }
+
+    void testPreIncrement(String[][] matrix, int i) {
+        // :: warning: (arrays.copyof.impure)
+        // :: error: (assignment.type.incompatible)
+        String[] result = Arrays.copyOf(matrix[++i], matrix[++i].length);
+    }
+
+    <T extends Object> void testTypeVar(T[] args, int i) {
+        T[] copyExact1 = Arrays.copyOf(args, args.length);
+        @Nullable T[] copyExact2 = Arrays.copyOf(args, args.length);
+
+        // :: warning: (arrays.copyof.size.mismatch)
+        // :: error: (assignment.type.incompatible)
+        T[] copyInexact1 = Arrays.copyOf(args, i);
+        @Nullable T[] copyInexact2 = Arrays.copyOf(args, i);
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,11 @@ Fixed `permit-nullness-assertion-exception.astub`'s missing `EnsuresNonNullIf`
 import, which caused two spurious warnings for every user passing
 `-Astubs=permit-nullness-assertion-exception.astub`.
 
+The Nullness Checker now checks if `Arrays.copyOf` is called with a
+side-effecting array expression, avoiding unsound behavior. It now also issues
+a warning message explaining why `copyOf` used a `@Nullable` return type,
+making errors with `copyOf` easier to fix.
+
 **Implementation details:**
 
 `SourceChecker.reportError` and `SourceChecker.reportWarning` now accept a null


### PR DESCRIPTION
... and improve error messages.

The Nullness Checker now checks if Arrays.copyOf is called with a side-effecting array expression, avoiding unsound behavior. It now also issues a warning message explaining why copyOf used a @Nullable return type, making errors with copyOf easier to fix.