### PR TITLE
Extract `ATF#get(Constructor/Method)ReceiverType` helpers

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2236,7 +2236,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         List<AnnotatedTypeMirror> typeargs = mType.typeArgs;
 
         List<AnnotatedTypeParameterBounds> paramBounds =
-                atypeFactory.methodTypeVariablesFromUse(tree, invokedMethod);
+                atypeFactory.methodTypeVariableBoundsFromUse(tree, invokedMethod);
 
         ExecutableElement method = invokedMethod.getElement();
         CharSequence methodName = ElementUtils.getSimpleDescription(method);

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2637,8 +2637,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         checkVarargs(constructorType, tree);
 
         List<AnnotatedTypeParameterBounds> paramBounds =
-                CollectionsPlume.mapList(
-                        AnnotatedTypeVariable::getBounds, constructorType.getTypeVariables());
+                atypeFactory.constructorTypeVariableBoundsFromUse(tree, constructorType);
 
         checkTypeArguments(
                 tree,

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2236,8 +2236,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         List<AnnotatedTypeMirror> typeargs = mType.typeArgs;
 
         List<AnnotatedTypeParameterBounds> paramBounds =
-                CollectionsPlume.mapList(
-                        AnnotatedTypeVariable::getBounds, invokedMethod.getTypeVariables());
+                atypeFactory.methodTypeVariablesFromUse(tree, invokedMethod);
 
         ExecutableElement method = invokedMethod.getElement();
         CharSequence methodName = ElementUtils.getSimpleDescription(method);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2445,12 +2445,76 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
+     * Returns the constructor type-variable bounds adapted to the viewpoint of a constructor
+     * invocation.
+     *
+     * @param tree a constructor invocation
+     * @param invokedConstructor the type of the invoked constructor
+     * @return the adapted constructor type parameter bounds
+     */
+    public List<AnnotatedTypeParameterBounds> constructorTypeVariableBoundsFromUse(
+            NewClassTree tree, AnnotatedExecutableType invokedConstructor) {
+        List<AnnotatedTypeParameterBounds> bounds =
+                CollectionsPlume.mapList(
+                        AnnotatedTypeVariable::getBounds, invokedConstructor.getTypeVariables());
+
+        if (viewpointAdapter != null) {
+            AnnotatedTypeMirror receiverType = getConstructorReceiverType(tree);
+            viewpointAdapter.viewpointAdaptTypeParameterBounds(receiverType, bounds);
+        }
+        return bounds;
+    }
+
+    /**
+     * Returns the receiver type used to viewpoint-adapt a constructor invocation.
+     *
+     * @param tree a constructor invocation tree
+     * @return the receiver type
+     * @see #getReceiverType(ExpressionTree)
+     * @see #getMethodReceiverType(MethodInvocationTree)
+     */
+    public AnnotatedDeclaredType getConstructorReceiverType(NewClassTree tree) {
+        // Get the annotations written on the new class tree.
+        AnnotatedDeclaredType type =
+                (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(tree), false);
+        if (!TreeUtils.isDiamondTree(tree)) {
+            if (tree.getClassBody() == null) {
+                type.setTypeArguments(getExplicitNewClassClassTypeArgs(tree));
+            }
+        } else {
+            type = getAnnotatedType(TypesUtils.getTypeElement(type.underlyingType));
+            // Add explicit annotations below.
+            type.clearAnnotations();
+        }
+
+        AnnotationMirrorSet explicitAnnos = getExplicitNewClassAnnos(tree);
+        type.addAnnotations(explicitAnnos);
+
+        // Get the enclosing type of the constructor, if one exists.
+        // this.new InnerClass()
+        AnnotatedDeclaredType enclosingType = (AnnotatedDeclaredType) getReceiverType(tree);
+        if (enclosingType != null && enclosingType.isFrozen()) {
+            // getReceiverType may return a shared frozen cache value; it is embedded in `type` and
+            // mutated by addComputedTypeAnnotations below, so copy it first.
+            enclosingType = enclosingType.deepCopy();
+        }
+        type.setEnclosingType(enclosingType);
+
+        // Add computed annotations to the type.
+        addComputedTypeAnnotations(tree, type);
+
+        return type;
+    }
+
+    /**
      * Returns the receiver type used to viewpoint-adapt a method invocation.
      *
      * @param tree a method invocation tree
      * @return the receiver type, or null if the invocation has no receiver
+     * @see #getReceiverType(ExpressionTree)
+     * @see #getConstructorReceiverType(NewClassTree)
      */
-    private @Nullable AnnotatedTypeMirror getMethodReceiverType(MethodInvocationTree tree) {
+    public @Nullable AnnotatedTypeMirror getMethodReceiverType(MethodInvocationTree tree) {
         ExecutableElement methodElt = TreeUtils.elementFromUse(tree);
         if (ElementUtils.isStatic(methodElt)) {
             return null;
@@ -2684,6 +2748,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *
      * @param expression the expression for which to determine the receiver type
      * @return the type of the receiver of expression
+     * @see #getMethodReceiverType(MethodInvocationTree)
+     * @see #getConstructorReceiverType(NewClassTree)
      */
     public final @Nullable AnnotatedTypeMirror getReceiverType(ExpressionTree expression) {
         AnnotatedTypeMirror receiverType;
@@ -3533,34 +3599,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      */
     protected ParameterizedExecutableType constructorFromUse(
             NewClassTree tree, boolean inferTypeArgs) {
-        // Get the annotations written on the new class tree.
-        AnnotatedDeclaredType type =
-                (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(tree), false);
-        if (!TreeUtils.isDiamondTree(tree)) {
-            if (tree.getClassBody() == null) {
-                type.setTypeArguments(getExplicitNewClassClassTypeArgs(tree));
-            }
-        } else {
-            type = getAnnotatedType(TypesUtils.getTypeElement(type.underlyingType));
-            // Add explicit annotations below.
-            type.clearAnnotations();
-        }
-
-        AnnotationMirrorSet explicitAnnos = getExplicitNewClassAnnos(tree);
-        type.addAnnotations(explicitAnnos);
-
-        // Get the enclosing type of the constructor, if one exists.
-        // this.new InnerClass()
-        AnnotatedDeclaredType enclosingType = (AnnotatedDeclaredType) getReceiverType(tree);
-        if (enclosingType != null && enclosingType.isFrozen()) {
-            // getReceiverType may return a shared frozen cache value; it is embedded in `type` and
-            // mutated by addComputedTypeAnnotations below, so copy it first.
-            enclosingType = enclosingType.deepCopy();
-        }
-        type.setEnclosingType(enclosingType);
-
-        // Add computed annotations to the type.
-        addComputedTypeAnnotations(tree, type);
+        AnnotatedDeclaredType type = getConstructorReceiverType(tree);
 
         ExecutableElement ctor = TreeUtils.elementFromUse(tree);
         AnnotatedExecutableType con = getAnnotatedType(ctor); // get unsubstituted type
@@ -3659,9 +3698,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             addDefaultAnnotations(returnType);
             con.setReturnType(returnType);
         }
-        if (enclosingType != null) {
+        if (type.getEnclosingType() != null) {
             // Reset the enclosing type because it can be substituted incorrectly.
-            ((AnnotatedDeclaredType) con.getReturnType()).setEnclosingType(enclosingType);
+            ((AnnotatedDeclaredType) con.getReturnType()).setEnclosingType(type.getEnclosingType());
         }
         if (type.isUnderlyingTypeRaw() || TypesUtils.isRaw(TreeUtils.typeOf(tree))) {
             ((AnnotatedDeclaredType) con.getReturnType()).setIsUnderlyingTypeRaw();

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2399,6 +2399,26 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
+     * Returns the method type parameter bounds adapted to the viewpoint of a method invocation.
+     *
+     * @param tree a method invocation
+     * @param invokedMethod the type of the invoked method
+     * @return the adapted method type parameter bounds
+     */
+    public List<AnnotatedTypeParameterBounds> methodTypeVariablesFromUse(
+            MethodInvocationTree tree, AnnotatedExecutableType invokedMethod) {
+        List<AnnotatedTypeParameterBounds> bounds =
+                CollectionsPlume.mapList(
+                        AnnotatedTypeVariable::getBounds, invokedMethod.getTypeVariables());
+
+        AnnotatedTypeMirror receiverType = getReceiverType(tree);
+        if (viewpointAdapter != null && receiverType != null) {
+            viewpointAdapter.viewpointAdaptTypeParameterBounds(receiverType, bounds);
+        }
+        return bounds;
+    }
+
+    /**
      * Creates and returns an AnnotatedNullType qualified with {@code annotations}.
      *
      * @param annotations the set of AnnotationMirrors to qualify the returned type with

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2399,23 +2399,49 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns the method type parameter bounds adapted to the viewpoint of a method invocation.
+     * Returns the method type-variable bounds adapted to the viewpoint of a method invocation.
      *
      * @param tree a method invocation
      * @param invokedMethod the type of the invoked method
      * @return the adapted method type parameter bounds
      */
-    public List<AnnotatedTypeParameterBounds> methodTypeVariablesFromUse(
+    public List<AnnotatedTypeParameterBounds> methodTypeVariableBoundsFromUse(
             MethodInvocationTree tree, AnnotatedExecutableType invokedMethod) {
         List<AnnotatedTypeParameterBounds> bounds =
                 CollectionsPlume.mapList(
                         AnnotatedTypeVariable::getBounds, invokedMethod.getTypeVariables());
 
-        AnnotatedTypeMirror receiverType = getReceiverType(tree);
+        AnnotatedTypeMirror receiverType = getMethodReceiverType(tree);
         if (viewpointAdapter != null && receiverType != null) {
             viewpointAdapter.viewpointAdaptTypeParameterBounds(receiverType, bounds);
         }
         return bounds;
+    }
+
+    /**
+     * Returns the receiver type used to viewpoint-adapt a method invocation.
+     *
+     * @param tree a method invocation tree
+     * @return the receiver type, or null if the invocation has no receiver
+     */
+    private @Nullable AnnotatedTypeMirror getMethodReceiverType(MethodInvocationTree tree) {
+        ExecutableElement methodElt = TreeUtils.elementFromUse(tree);
+        if (ElementUtils.isStatic(methodElt)) {
+            return null;
+        }
+
+        AnnotatedTypeMirror receiverType = getReceiverType(tree);
+        if (receiverType == null
+                && (TreeUtils.isSuperConstructorCall(tree)
+                        || TreeUtils.isThisConstructorCall(tree))) {
+            // super() and this() calls don't have a receiver, but they should be view-point adapted
+            // as if "this" is the receiver.
+            receiverType = getSelfType(tree);
+        }
+        if (receiverType != null && receiverType.getKind() == TypeKind.DECLARED) {
+            receiverType = applyCaptureConversion(receiverType);
+        }
+        return receiverType;
     }
 
     /**
@@ -2753,17 +2779,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     protected ParameterizedExecutableType methodFromUse(
             MethodInvocationTree tree, boolean inferTypeArgs) {
         ExecutableElement methodElt = TreeUtils.elementFromUse(tree);
-        AnnotatedTypeMirror receiverType = getReceiverType(tree);
-        if (receiverType == null
-                && (TreeUtils.isSuperConstructorCall(tree)
-                        || TreeUtils.isThisConstructorCall(tree))) {
-            // super() and this() calls don't have a receiver, but they should be view-point adapted
-            // as if "this" is the receiver.
-            receiverType = getSelfType(tree);
-        }
-        if (receiverType != null && receiverType.getKind() == TypeKind.DECLARED) {
-            receiverType = applyCaptureConversion(receiverType);
-        }
+        AnnotatedTypeMirror receiverType = getMethodReceiverType(tree);
 
         ParameterizedExecutableType result =
                 methodFromUse(tree, methodElt, receiverType, inferTypeArgs);

--- a/framework/tests/viewpointtest/ConstructorTypeVariableBounds.java
+++ b/framework/tests/viewpointtest/ConstructorTypeVariableBounds.java
@@ -1,0 +1,19 @@
+import viewpointtest.quals.*;
+
+public class ConstructorTypeVariableBounds {
+    static class MyClass {
+        <T extends @ReceiverDependentQual Object> MyClass(T t) {}
+    }
+
+    void test(@Top Object top, @A Object a, @B Object b, @Bottom Object bottom) {
+
+        // :: error: (type.argument.type.incompatible) :: error: (new.class.type.invalid)
+        new <@Top Object>@Top MyClass(top);
+
+        // :: warning: (cast.unsafe.constructor.invocation)
+        new <@A Object>@A MyClass(a);
+
+        // :: warning: (cast.unsafe.constructor.invocation)
+        new <@B Object>@B MyClass(b);
+    }
+}

--- a/framework/tests/viewpointtest/MethodTypeVariableBounds.java
+++ b/framework/tests/viewpointtest/MethodTypeVariableBounds.java
@@ -1,0 +1,72 @@
+import viewpointtest.quals.*;
+
+public class MethodTypeVariableBounds {
+    static class Methods {
+        <T extends @ReceiverDependentQual Object> void noArg() {}
+
+        <T extends @ReceiverDependentQual Object> void withArg(T t) {}
+    }
+
+    void topReceiver(
+            @Top Methods methods,
+            @Top Object top,
+            @A Object a,
+            @B Object b,
+            @Bottom Object bottom) {
+        // @Top viewpoint-adapts @ReceiverDependentQual to @Lost, so only @Bottom is within the
+        // adapted method type parameter bound.
+        // :: error: (type.argument.type.incompatible)
+        methods.noArg();
+
+        // :: error: (type.argument.type.incompatible)
+        methods.<@Top Object>withArg(top);
+
+        // :: error: (type.argument.type.incompatible)
+        methods.<@A Object>withArg(a);
+
+        // :: error: (type.argument.type.incompatible)
+        methods.<@B Object>withArg(b);
+
+        methods.<@Bottom Object>withArg(bottom);
+
+        // :: error: (type.arguments.not.inferred)
+        methods.withArg(top);
+
+        // :: error: (type.arguments.not.inferred)
+        methods.withArg(a);
+
+        // :: error: (type.arguments.not.inferred)
+        methods.withArg(b);
+
+        methods.withArg(bottom);
+    }
+
+    void aReceiver(
+            @A Methods methods, @Top Object top, @A Object a, @B Object b, @Bottom Object bottom) {
+        // @A viewpoint-adapts @ReceiverDependentQual to @A, so @A and @Bottom are within the
+        // adapted method type parameter bound.
+        // :: error: (type.argument.type.incompatible)
+        methods.noArg();
+
+        // :: error: (type.argument.type.incompatible)
+        methods.<@Top Object>withArg(top);
+
+        methods.<@A Object>withArg(a);
+
+        // :: error: (type.argument.type.incompatible)
+        methods.<@B Object>withArg(b);
+
+        methods.<@Bottom Object>withArg(bottom);
+
+        // :: error: (type.arguments.not.inferred)
+        methods.withArg(top);
+
+        // :: error: (type.arguments.not.inferred)
+        methods.withArg(a);
+
+        // :: error: (type.arguments.not.inferred)
+        methods.withArg(b);
+
+        methods.withArg(bottom);
+    }
+}


### PR DESCRIPTION
Done while reviewing an earlier version of #1850 with Antigravity.

@aosen-xiong Is it worth keeping the two new helpers `ATF#get(Constructor/Method)ReceiverType`?

The extra test case is also useful.