### PR TITLE
Extract overridable `checkCapturedWildcardBounds` from `visitParameterizedType`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,6 +94,9 @@ type-argument-inference work, averting hangs on deeply nested (e.g.,
 machine-generated) invocations. Defaults to 10000; raises a
 `type.argument.inference.budget` error if exceeded.
 
+`BaseTypeValidator.visitParameterizedType`'s captured-wildcard bound recheck
+is extracted into an overridable `checkCapturedWildcardBounds` method.
+
 Performance optimizations:
 - Capped Java type argument inference bound-incorporation work and optimized
   the fixpoint algorithm to short-circuit and re-scan fewer variables.

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -598,6 +598,35 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
             return null;
         }
 
+        checkCapturedWildcardBounds(type, capturedType, tree);
+        checkExplicitSuperBoundWildcards(type, capturedType, tree);
+
+        return null;
+    }
+
+    /**
+     * Rechecks, for every wildcard type argument whose capture is a captured type variable, that
+     * the upper bound of the captured type variable is a subtype of the extends bound of the
+     * wildcard, and issues the "type.argument.type.incompatible" error if it is not.
+     *
+     * <p>For most captured type variables, this will trivially hold, as capturing incorporated the
+     * extends bound of the wildcard into the upper bound of the type variable. This will fail if
+     * the bound and the wildcard have generic types and there is no appropriate glb, in which case
+     * the two bounds have contradictory requirements and no type can satisfy both.
+     *
+     * <p>Checkers with a nonstandard subtyping relationship (where this recheck can spuriously fail
+     * even though capture conversion itself succeeded) may override this method to do nothing.
+     *
+     * @param type the (possibly unconverted) parameterized type being validated
+     * @param capturedType {@code type} after capture conversion
+     * @param tree the tree for {@code type}
+     */
+    protected void checkCapturedWildcardBounds(
+            AnnotatedDeclaredType type,
+            AnnotatedDeclaredType capturedType,
+            ParameterizedTypeTree tree) {
+        TypeElement element = (TypeElement) type.getUnderlyingType().asElement();
+
         // Check that the extends bound of the captured type variable is a subtype of the
         // extends bound of the wildcard.
         int numTypeArgs = capturedType.getTypeArguments().size();
@@ -621,35 +650,69 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
             }
             AnnotatedTypeMirror captureTypeArg = capturedType.getTypeArguments().get(i);
             AnnotatedWildcardType wildcard = (AnnotatedWildcardType) type.getTypeArguments().get(i);
+            if (!TypesUtils.isCapturedTypeVariable(captureTypeArg.getUnderlyingType())) {
+                continue;
+            }
+            AnnotatedTypeVariable capturedTypeVar = (AnnotatedTypeVariable) captureTypeArg;
+            // Substitute the captured type variables with their wildcards. Without
+            // this, the isSubtype check crashes because wildcards aren't comparable
+            // with type variables.
+            AnnotatedTypeMirror captureTypeVarUB =
+                    atypeFactory
+                            .getTypeVarSubstitutor()
+                            .substituteWithoutCopyingTypeArguments(
+                                    typeVarToWildcard, capturedTypeVar.getUpperBound());
+            if (!atypeFactory
+                    .getTypeHierarchy()
+                    .isSubtype(captureTypeVarUB, wildcard.getExtendsBound())) {
+                // For most captured type variables, this will trivially hold, as capturing
+                // incorporated the extends bound of the wildcard into the upper bound of the
+                // type variable.
+                // This will fail if the bound and the wildcard have generic types and there is
+                // no appropriate GLB.
+                // This issues an error for types that cannot be satisfied, because the two
+                // bounds have contradictory requirements.
+                checker.reportError(
+                        tree.getTypeArguments().get(i),
+                        "type.argument.type.incompatible",
+                        element.getTypeParameters().get(i),
+                        element.getSimpleName(),
+                        wildcard.getExtendsBound(),
+                        capturedTypeVar.getUpperBound());
+            }
+        }
+    }
+
+    /**
+     * Checks, for every wildcard type argument whose capture is not itself a captured type
+     * variable, the special case described by JDK-8054309: if the super bound of the wildcard is
+     * the same as the upper bound of the type parameter, then javac uses the bound rather than
+     * creating a fresh type variable. (See https://bugs.openjdk.org/browse/JDK-8054309.) In this
+     * case, the Checker Framework uses the annotations on the super bound of the wildcard and
+     * ignores the annotations on the extends bound. For example, {@code Set<@1 ? super @2 Object>}
+     * will collapse into {@code Set<@2 Object>}. This method issues the
+     * "type.invalid.super.wildcard" error if the annotations on the extends bound are not the same
+     * as the annotations on the super bound.
+     *
+     * @param type the (possibly unconverted) parameterized type being validated
+     * @param capturedType {@code type} after capture conversion
+     * @param tree the tree for {@code type}
+     */
+    protected void checkExplicitSuperBoundWildcards(
+            AnnotatedDeclaredType type,
+            AnnotatedDeclaredType capturedType,
+            ParameterizedTypeTree tree) {
+        int numTypeArgs = capturedType.getTypeArguments().size();
+        for (int i = 0; i < numTypeArgs; i++) {
+            if (type.getTypeArguments().get(i).getKind() != TypeKind.WILDCARD) {
+                continue;
+            }
+            AnnotatedTypeMirror captureTypeArg = capturedType.getTypeArguments().get(i);
+            AnnotatedWildcardType wildcard = (AnnotatedWildcardType) type.getTypeArguments().get(i);
             if (TypesUtils.isCapturedTypeVariable(captureTypeArg.getUnderlyingType())) {
-                AnnotatedTypeVariable capturedTypeVar = (AnnotatedTypeVariable) captureTypeArg;
-                // Substitute the captured type variables with their wildcards. Without
-                // this, the isSubtype check crashes because wildcards aren't comparable
-                // with type variables.
-                AnnotatedTypeMirror captureTypeVarUB =
-                        atypeFactory
-                                .getTypeVarSubstitutor()
-                                .substituteWithoutCopyingTypeArguments(
-                                        typeVarToWildcard, capturedTypeVar.getUpperBound());
-                if (!atypeFactory
-                        .getTypeHierarchy()
-                        .isSubtype(captureTypeVarUB, wildcard.getExtendsBound())) {
-                    // For most captured type variables, this will trivially hold, as capturing
-                    // incorporated the extends bound of the wildcard into the upper bound of the
-                    // type variable.
-                    // This will fail if the bound and the wildcard have generic types and there is
-                    // no appropriate GLB.
-                    // This issues an error for types that cannot be satisfied, because the two
-                    // bounds have contradictory requirements.
-                    checker.reportError(
-                            tree.getTypeArguments().get(i),
-                            "type.argument.type.incompatible",
-                            element.getTypeParameters().get(i),
-                            element.getSimpleName(),
-                            wildcard.getExtendsBound(),
-                            capturedTypeVar.getUpperBound());
-                }
-            } else if (AnnotatedTypes.hasExplicitSuperBound(wildcard)) {
+                continue;
+            }
+            if (AnnotatedTypes.hasExplicitSuperBound(wildcard)) {
                 // If the super bound of the wildcard is the same as the upper bound of the
                 // type parameter, then javac uses the bound rather than creating a fresh
                 // type variable.
@@ -675,8 +738,6 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 }
             }
         }
-
-        return null;
     }
 
     @Override


### PR DESCRIPTION
`BaseTypeValidator.visitParameterizedType` rechecked, for every captured wildcard type argument, that the capture's upper bound is a subtype of the wildcard's extends bound. For a standard qualifier lattice this is a tautology by construction of capture conversion, but checkers with a nonstandard subtyping relationship (e.g. the JSpecify reference checker, where `unspecified <: unspecified` does not hold in strict mode) get spurious `type.argument.type.incompatible` errors from it and currently have to copy the entire ~60-line method just to skip this one loop.

This extracts the recheck (substitution-map construction plus the subtype-check loop) into a new protected `checkCapturedWildcardBounds` method that subclasses can override to do nothing. The JDK-8054309 super-wildcard-collapse check is independent of the recheck and moves into its own protected `checkExplicitSuperBoundWildcards` method, so it stays reachable when the recheck is overridden away.

Pure extract-method refactor; no default-emitted diagnostic changes. The only observable difference is a diagnostic-ordering edge case: if one parameterized type has one wildcard argument triggering the captured-bound recheck and another triggering the super-wildcard check, the two reports now come grouped per check instead of in argument-index order.

Tests: `./gradlew assemble`, `:framework:test`, and `:checker:test --tests "*Nullness*"` all pass on JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHhVqLoJukm4kKsE7UfY4
