### PR TITLE
Test capture glb with a non-top type-parameter bound

### DIFF
--- a/framework/tests/nontopdefault/CaptureGlbWildcardBound.java
+++ b/framework/tests/nontopdefault/CaptureGlbWildcardBound.java
@@ -1,0 +1,41 @@
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDMiddle;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDTop;
+
+// Capture conversion of Foo<? extends Bar> where Foo<T extends @NTDTop Object> must give the
+// captured type variable an upper bound equal to the glb of the wildcard's extends bound and the
+// type parameter's bound -- not the type parameter's bound wholesale.  Here the wildcard's extends
+// bound (the type-use default @NTDMiddle, or an explicit qualifier) is more precise than the
+// @NTDTop parameter bound, so the glb is the wildcard's qualifier.
+//
+// This fills the coverage gap noted in framework/tests/h1h2checker/WildcardBounds.java ("We could
+// add an OuterS1 to also test with a non-top upper bound."): the existing wildcard-capture tests
+// use a top parameter bound, for which the glb trivially equals the wildcard's bound.  See also
+// cf-tasks/task-3-findings.md.
+@SuppressWarnings("inconsistent.constructor.type") // not the point of this test
+class CaptureGlbWildcardBound {
+    interface Bar {}
+
+    interface Foo<T extends @NTDTop Object> {
+        T get();
+    }
+
+    // Implicit wildcard extends bound: Bar defaults to the type-use default @NTDMiddle, which is
+    // below the @NTDTop parameter bound.  glb(@NTDMiddle Bar, @NTDTop Object) == @NTDMiddle Bar, so
+    // x.get() is @NTDMiddle.
+    void implicitBound(Foo<? extends Bar> x) {
+        @NTDMiddle Object m = x.get();
+    }
+
+    // Explicit @NTDMiddle wildcard extends bound: same glb, @NTDMiddle.
+    void explicitMiddleBound(Foo<? extends @NTDMiddle Bar> x) {
+        @NTDMiddle Object m = x.get();
+    }
+
+    // Discriminating control: an explicit @NTDTop wildcard extends bound equals the parameter
+    // bound, so the glb is @NTDTop, which is not assignable to @NTDMiddle.  This confirms the glb
+    // machinery actually varies with the wildcard's extends bound.
+    void explicitTopBound(Foo<? extends @NTDTop Bar> x) {
+        // :: error: (assignment.type.incompatible)
+        @NTDMiddle Object m = x.get();
+    }
+}

--- a/framework/tests/nontopdefault/CaptureGlbWildcardBound.java
+++ b/framework/tests/nontopdefault/CaptureGlbWildcardBound.java
@@ -1,21 +1,31 @@
 import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDMiddle;
 import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDTop;
 
-// Capture conversion of Foo<? extends Bar> where Foo<T extends @NTDTop Object> must give the
-// captured type variable an upper bound equal to the glb of the wildcard's extends bound and the
-// type parameter's bound -- not the type parameter's bound wholesale.  Here the wildcard's extends
-// bound (the type-use default @NTDMiddle, or an explicit qualifier) is more precise than the
-// @NTDTop parameter bound, so the glb is the wildcard's qualifier.
+// Capture conversion of Foo<? extends Bar> where Foo<T extends @Q Object> must give the captured
+// type variable an upper bound equal to the glb of the wildcard's extends bound and the
+// (substituted) type parameter bound -- not either bound wholesale.  This mirrors JSpecify's
+// spec-grounded capture rule (JLS 5.1.10 glb) with the qualifier lattice
+// @NTDBottom <: @NTDMiddle <: @NTDTop, whose non-top type-use default @NTDMiddle plays the role of
+// JSpecify's "unspecified".
 //
 // This fills the coverage gap noted in framework/tests/h1h2checker/WildcardBounds.java ("We could
 // add an OuterS1 to also test with a non-top upper bound."): the existing wildcard-capture tests
-// use a top parameter bound, for which the glb trivially equals the wildcard's bound.  See also
-// cf-tasks/task-3-findings.md.
+// use a top parameter bound, for which the glb trivially equals the wildcard's bound.
+//
+// Round-2 note: an investigation of the JSpecify capture-glb records (cf-tasks2/task-1-findings.md)
+// confirmed with instrumentation that AnnotatedTypeFactory.applyCaptureConversion already computes
+// the correct qualifier glb in every observed case; the remaining reference-checker mismatches are
+// downstream (substituteTypeVariable and a capture-id formatting difference), not capture-side.
+// This test locks in the CF behavior that investigation verified correct.
 @SuppressWarnings("inconsistent.constructor.type") // not the point of this test
 class CaptureGlbWildcardBound {
     interface Bar {}
 
     interface Foo<T extends @NTDTop Object> {
+        T get();
+    }
+
+    interface FooMid<T extends @NTDMiddle Object> {
         T get();
     }
 
@@ -36,6 +46,19 @@ class CaptureGlbWildcardBound {
     // machinery actually varies with the wildcard's extends bound.
     void explicitTopBound(Foo<? extends @NTDTop Bar> x) {
         // :: error: (assignment.type.incompatible)
+        @NTDMiddle Object m = x.get();
+    }
+
+    // The parameter bound constrains a less-precise wildcard bound: with a @NTDMiddle parameter
+    // bound, a @NTDTop wildcard extends bound is pulled down by the glb to @NTDMiddle, so x.get()
+    // is @NTDMiddle (not the wildcard's @NTDTop).  A no-error assertion here holds only if the glb
+    // is taken from both sides.
+    void midParamTopWildcard(FooMid<? extends @NTDTop Bar> x) {
+        @NTDMiddle Object m = x.get();
+    }
+
+    // Both sides @NTDMiddle (the implicit default): glb is @NTDMiddle.
+    void midParamImplicit(FooMid<? extends Bar> x) {
         @NTDMiddle Object m = x.get();
     }
 }


### PR DESCRIPTION
Investigation of the report that capture conversion drops a wildcard's more-precise qualifier from the capture's upper bound (observed through the JSpecify reference checker). **Verdict: stock CF is correct — no framework change is warranted.** This PR adds the test coverage that proves it.

## Diagnosis

Instrumenting `annotateCapturedTypeVar` (`AnnotatedTypeFactory.java:6196`) and `TypeVariableSubstitutor` showed:

- `annotateCapturedTypeVar` does compute `annotatedGLB(typeVarUpperBound, wildcard.getExtendsBound())`, and the per-hierarchy glb returns the correct, more-precise side (`typeVarUB=@NTDTop Object`, `wildcardExtends=@NTDMiddle Bar` → `glbUB=@NTDMiddle Bar`).
- In the JSpecify repro itself the finished capture is fully correct (upper bound carries the nonnull qualifier). The wildcard's extends bound reaches capture undefaulted, so this is also not a downstream instance of the intersection-bound homogenization from #1875.
- The qualifier is dropped **after** capture, by the reference checker's `NullSpecAnnotatedTypeFactory.substituteTypeVariable` override: stock CF only overrides on the use's primary annotation (empty for a bare `T`), while the override additionally applies the bound's *effective* unspecified operator, clobbering the capture's precise qualifier. The sample failure pattern keys on the parameter's bound qualifier, consistent with substitution, not capture.

Follow-up therefore belongs in the reference checker (skip the effective-annotation clause when the argument is a captured type variable with a more precise bound), not in CF.

## This PR contains

`framework/tests/nontopdefault/CaptureGlbWildcardBound.java` — a passing regression test filling the gap explicitly noted in `h1h2checker/WildcardBounds.java` (wildcard capture against a **non-top** type-parameter bound, where the glb is not trivially the wildcard's bound). Includes a discriminating control: `? extends @NTDTop Bar` must *not* be assignable to `@NTDMiddle`, proving the glb varies with the wildcard's extends bound.

(The `cf-tasks/task-3-findings.md` referenced in the comments is the full diagnosis write-up in the local task workspace, not in this repo.)

Tests: `:framework:test` (including the new test) and `:checker:NullnessTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHhVqLoJukm4kKsE7UfY4
