### PR TITLE
Extract overridable reportTypeArgumentInferenceFailure from checkTypeArgumentInference

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,6 +94,12 @@ type-argument-inference work, averting hangs on deeply nested (e.g.,
 machine-generated) invocations. Defaults to 10000; raises a
 `type.argument.inference.budget` error if exceeded.
 
+`BaseTypeVisitor`'s type-argument-inference failure report is extracted into
+an overridable `reportTypeArgumentInferenceFailure` method, so a checker
+whose qualifier encoding makes this failure mode common and usually spurious
+can report a warning (or suppress the diagnostic) instead of the default
+hard error.
+
 Performance optimizations:
 - Capped Java type argument inference bound-incorporation work and optimized
   the fixpoint algorithm to short-circuit and re-scan fewer variables.

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2397,12 +2397,51 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     args == null ? "" : args.getErrorMsg());
             return false;
         }
+        reportTypeArgumentInferenceFailure(tree, methodType, args);
+        return false;
+    }
+
+    /**
+     * Reports that type argument inference failed because the annotation constraint system had no
+     * satisfying solution -- as opposed to {@link InferenceResult#inferenceBudgetExceeded()} or
+     * {@link InferenceResult#inferenceCrashed()}, which are reported separately by {@link
+     * #checkTypeArgumentInference} and never reach this method. This can happen even when javac's
+     * own (unannotated) type argument inference succeeds for the same invocation, for example when
+     * a type system's qualifier encoding makes some constraint sets unsatisfiable that are not
+     * actually errors.
+     *
+     * <p>Regardless of how this method reports the failure (or whether it reports anything at all),
+     * the caller treats type argument inference as failed for {@code tree}: it skips this
+     * invocation's structural checks (argument and type-argument-bound compatibility), exactly as
+     * it does for the budget-exceeded and crashed cases. This does not change the type computed for
+     * the invocation expression itself, which {@link
+     * org.checkerframework.framework.util.AnnotatedTypes#findTypeArguments} produces independently
+     * of this method, using the same best-effort type arguments that {@code inferenceResult}
+     * already carries.
+     *
+     * <p>The default implementation reports a hard error. A checker whose qualifier encoding makes
+     * this failure mode common and usually spurious (for example, one with a nonstandard qualifier
+     * order) may override this method to report a warning instead, via {@link
+     * org.checkerframework.framework.source.SourceChecker#reportWarning} with the same {@code
+     * "type.arguments.not.inferred"} message key, or to suppress the diagnostic entirely.
+     *
+     * @param tree a tree that requires type argument inference
+     * @param methodType the type of the method before type argument substitution
+     * @param inferenceResult the failed result of type argument inference; never null at this call
+     *     site, because {@link #checkTypeArgumentInference} already dereferences it (via {@link
+     *     InferenceResult#inferenceBudgetExceeded()} and {@link
+     *     InferenceResult#inferenceCrashed()}) before reaching this method, so a null value there
+     *     would already have thrown a {@link NullPointerException}
+     */
+    protected void reportTypeArgumentInferenceFailure(
+            ExpressionTree tree,
+            AnnotatedExecutableType methodType,
+            InferenceResult inferenceResult) {
         checker.reportError(
                 tree,
                 "type.arguments.not.inferred",
                 ElementUtils.getSimpleDescription(methodType.getElement()),
-                args == null ? "" : args.getErrorMsg());
-        return false;
+                inferenceResult.getErrorMsg());
     }
 
     /**

--- a/framework/tests/framework/TypeArgumentInferenceFailure.java
+++ b/framework/tests/framework/TypeArgumentInferenceFailure.java
@@ -1,0 +1,45 @@
+import org.checkerframework.framework.testchecker.util.Odd;
+
+/**
+ * Regression test for the default behavior of {@link
+ * org.checkerframework.common.basetype.BaseTypeVisitor#reportTypeArgumentInferenceFailure}: {@link
+ * Ordering2#sort} cannot be called on {@code e} without an explicit type argument because the
+ * Checker Framework's annotation-level type argument inference finds no satisfying instantiation,
+ * even though javac's own (unannotated) type argument inference succeeds for the same invocation.
+ * Adapted from the {@code Ordering2} case in {@code GenericTest9.java}. By default this remains a
+ * hard error.
+ */
+public class TypeArgumentInferenceFailure {
+
+    /** A generic entry type used only to build the failing-inference example below. */
+    interface MyEntry<S> {}
+
+    /**
+     * A generic type whose type parameter has an annotated upper bound. Instantiating {@code sort}
+     * against {@code MyEntry<V>} is what makes annotation-level inference fail.
+     *
+     * @param <T> the upper bound for the argument to {@link #sort}
+     */
+    interface Ordering2<T extends @Odd Object> {
+        /**
+         * Returns its argument unchanged.
+         *
+         * @param <U> the type of {@code iterable}, a subtype of {@code T}
+         * @param iterable the value to return
+         * @return {@code iterable}
+         */
+        <U extends T> U sort(U iterable);
+    }
+
+    /**
+     * Triggers the type-argument-inference failure described in the class Javadoc.
+     *
+     * @param <V> an unbounded type variable
+     * @param ord an {@code Ordering2} instantiated with a {@code MyEntry<?>} bound
+     * @param e the value passed to {@link Ordering2#sort}
+     */
+    <V> void test(Ordering2<@Odd MyEntry<?>> ord, MyEntry<V> e) {
+        // :: error: (type.arguments.not.inferred)
+        MyEntry<V> e1 = ord.sort(e);
+    }
+}


### PR DESCRIPTION
Reworked per maintainer feedback: no new checker option (suppression already works on errors, per-site or via `-AsuppressWarnings=key`, so an option's only delta was visibility). Instead, this follows the same overridable-hook pattern as #1874.

`BaseTypeVisitor.checkTypeArgumentInference`'s final report — the case where the annotation constraint system is unsatisfiable, as opposed to the budget-exceeded and crashed cases, which are untouched — is extracted into a new protected method:

```java
protected void reportTypeArgumentInferenceFailure(
        ExpressionTree tree, AnnotatedExecutableType methodType, InferenceResult inferenceResult)
```

The default implementation reports the same `type.arguments.not.inferred` error, byte-identically. A checker whose qualifier encoding makes this failure mode common and usually spurious (the JSpecify reference checker's "unspecified" operator in strict mode — 18 of its 87 outstanding samples-suite mismatches are exactly this key) can override it to report a warning with the same key, or suppress. Control flow is unchanged either way: the caller still skips the invocation's structural checks, and the invocation's type still comes independently from `AnnotatedTypes.findTypeArguments`, which already carries the constraint solver's best-effort instantiations on failure.

One incidental cleanup, verified: the old call site's `args == null ? "" : args.getErrorMsg()` ternary was dead — a null `args` would have thrown NPE at `args.inferenceBudgetExceeded()` two branches earlier — so the hook takes a non-null `InferenceResult` and the Javadoc documents why.

Includes a regression test input in the existing `framework/tests/framework` EvenOdd corpus (next to the `GenericTest9.java` it was adapted from) asserting the default error still fires — no separate test directory or JUnit runner — and a changelog bullet under implementation details. No override test: doing it minimally would have required promoting `EvenOddChecker`'s package-private auxiliary visitor class to its own file, which is more scaffolding than the hook warrants.

Tests: `:framework:test` (incl. the new test), `:checker:NullnessTest`, `assemble` all pass on JDK 21.

Follow-up (reference checker): override `reportTypeArgumentInferenceFailure` to `reportWarning` in strict mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHhVqLoJukm4kKsE7UfY4