### PR TITLE
Optional: Clarify else-branch check in `handleConditionalStatementIsPresentGet`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/optional/OptionalImplVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/OptionalImplVisitor.java
@@ -364,6 +364,15 @@ public class OptionalImplVisitor
      *
      * <p>Prefer: {@code x = VAR.map(METHOD).orElse(OTHER);}
      *
+     * <p>The two patterns handled directly by this method (as opposed to by {@link
+     * #handleAssignmentInConditional}) both replace the {@code if} statement by a single method
+     * call with no {@code else} behavior of its own ({@code ifPresent(METHOD)}, or a variable
+     * initializer using {@code map(METHOD).orElse(...)}). They therefore only apply when the {@code
+     * else} branch of {@code tree}, if any, is missing or empty: a non-empty {@code else} branch
+     * (other than the same-variable-assignment case handled by {@link
+     * #handleAssignmentInConditional}) has behavior that neither replacement can express, so no
+     * warning is issued for it.
+     *
      * @param tree an if statement that can perhaps be simplified
      */
     public void handleConditionalStatementIsPresentGet(IfTree tree) {
@@ -399,11 +408,16 @@ public class OptionalImplVisitor
             handleAssignmentInConditional(tree, thenStmt, elseStmt);
         }
 
-        if (elseStmt != null
-                && !(elseStmt instanceof BlockTree
-                        && ((BlockTree) elseStmt).getStatements().isEmpty())) {
-            // else block is missing or is an empty block: "{}"
-            // TODO: the logic here seems wrong.
+        boolean elseIsMissingOrEmpty =
+                elseStmt == null
+                        || (elseStmt instanceof BlockTree
+                                && ((BlockTree) elseStmt).getStatements().isEmpty());
+        if (!elseIsMissingOrEmpty) {
+            // There is a non-empty `else` branch. `handleAssignmentInConditional`, called above,
+            // already reported a warning if applicable (i.e., if both branches are assignments to
+            // the same variable). The remaining patterns handled below -- `VAR.ifPresent(METHOD)`
+            // and the declaration-initializer form of `VAR.map(METHOD).orElse(...)` -- have no way
+            // to express the `else` branch's behavior, so do not suggest them here.
             return;
         }
 

--- a/checker/tests/optional/Marks3b.java
+++ b/checker/tests/optional/Marks3b.java
@@ -15,9 +15,29 @@ public class Marks3b {
     Executor executor = new Executor();
 
     void bad(Optional<Task> oTask) {
+        // Missing `else`: the pattern applies.
         // :: warning: (prefer.ifpresent)
         if (oTask.isPresent()) {
             executor.runTask(oTask.get());
+        }
+    }
+
+    void badEmptyElse(Optional<Task> oTask) {
+        // Empty `else` block: equivalent to a missing `else`, so the pattern still applies.
+        // :: warning: (prefer.ifpresent)
+        if (oTask.isPresent()) {
+            executor.runTask(oTask.get());
+        } else {
+        }
+    }
+
+    void okNonEmptyElse(Optional<Task> oTask) {
+        // Non-empty `else` block: `ifPresent` cannot express the `else` branch's behavior, so no
+        // warning is issued.
+        if (oTask.isPresent()) {
+            executor.runTask(oTask.get());
+        } else {
+            System.out.println("no task");
         }
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -142,10 +142,14 @@ Other improvements and bug fixes:
   recover Java type variables inferred by javac.
 - Fixed a latent aliasing bug in `AnnotatedTypeCopier` for executable types.
 - Fixed an `IndexOutOfBoundsException` for lambdas in varargs.
+- Clarified `OptionalImplVisitor.handleConditionalStatementIsPresentGet`'s
+  `else`-branch check (rule #3, `prefer.ifpresent`/`prefer.map.and.orelse`)
+  and removed a stale TODO; the underlying logic already matched the
+  documented rule, but a misleading comment suggested otherwise.
 
 **Closed issues:**
 
-eisop#433, eisop#792, eisop#863, eisop#1015, eisop#1074, eisop#1801, eisop#1819.
+eisop#433, eisop#792, eisop#863, eisop#1015, eisop#1074, eisop#1315, eisop#1801, eisop#1819.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)


### PR DESCRIPTION
OptionalImplVisitor.handleConditionalStatementIsPresentGet (rule #3: prefer ifPresent/map+orElse over isPresent+get) guards its two single-expression replacement suggestions with a check on whether the `if`'s `else` branch is missing or empty. The condition was written as `elseStmt != null && !(elseStmt instanceof BlockTree && isEmpty)`, with a comment describing the opposite (continue) case sitting right above the `return`, plus a "TODO: the logic here seems wrong" note (eisop#1315).

Tracing every existing Optional Checker test (Marks3a/b/c and the JDK 11 variants) and comparing against the pre-refactor code (before commit 93ac771, "Remove null checks that are redundant with instanceof checks") shows the condition is a De Morgan-equivalent rewrite of the original `!(elseStmt == null || isEmpty)` and was never behaviorally wrong: a non-empty `else` correctly disables `ifPresent`/`map+orElse` suggestions, since neither replacement can express the `else` branch's behavior. Replace the condition with a positively-named `elseIsMissingOrEmpty` local so the guard reads naturally, move the explanation to describe the actual `return` case, remove the stale TODO, and document the missing/empty-`else` requirement in the method's Javadoc. Add Marks3b test cases for the empty-else and non-empty-else shapes (missing-else was already covered) to lock in the diagnostics.