### PR TITLE
Add regression test for BinaryOperation hashCode/equals contract

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -148,10 +148,14 @@ Other improvements and bug fixes:
   recover Java type variables inferred by javac.
 - Fixed a latent aliasing bug in `AnnotatedTypeCopier` for executable types.
 - Fixed an `IndexOutOfBoundsException` for lambdas in varargs.
+- Fixed `BinaryOperation.hashCode()` to agree with `equals()` for commutative
+  operators (e.g. `a + b` and `b + a`), so such dataflow expressions no longer
+  violate the `hashCode`/`equals` contract when used as map or set keys.
 
 **Closed issues:**
 
-eisop#433, eisop#792, eisop#863, eisop#1015, eisop#1074, eisop#1801, eisop#1819.
+eisop#433, eisop#792, eisop#863, eisop#1015, eisop#1074, eisop#1653,
+eisop#1801, eisop#1819.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/framework/src/test/java/org/checkerframework/dataflow/expression/BinaryOperationTest.java
+++ b/framework/src/test/java/org/checkerframework/dataflow/expression/BinaryOperationTest.java
@@ -1,0 +1,102 @@
+package org.checkerframework.dataflow.expression;
+
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.main.JavaCompiler;
+import com.sun.tools.javac.main.Option;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Options;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Tests that {@link BinaryOperation#equals(Object)} and {@link BinaryOperation#hashCode()} stay
+ * consistent with each other (see the contract of {@link Object#hashCode()}), in particular for
+ * commutative operators, where {@code equals} considers {@code a OP b} and {@code b OP a} equal.
+ */
+public class BinaryOperationTest {
+
+    /** The {@code int} type, used as both the operand type and the result type below. */
+    private TypeMirror intType;
+
+    /** A {@code ValueLiteral} operand with value {@code 1}. */
+    private JavaExpression one;
+
+    /** A {@code ValueLiteral} operand with value {@code 2}, distinct from {@link #one}. */
+    private JavaExpression two;
+
+    /**
+     * Builds a minimal {@link ProcessingEnvironment} (following the same approach as {@code
+     * AnnotationBuilderTest}) so that a real {@link TypeMirror} is available for the operands and
+     * result type of the {@link BinaryOperation}s under test.
+     */
+    @Before
+    public void setUp() {
+        Context context = new Context();
+        // Set source and target to 8, as in AnnotationBuilderTest.
+        Options options = Options.instance(context);
+        options.put(Option.SOURCE, "8");
+        options.put(Option.TARGET, "8");
+
+        ProcessingEnvironment env = JavacProcessingEnvironment.instance(context);
+        JavaCompiler javac = JavaCompiler.instance(context);
+        // Even though source/target are set to 8, the modules in the JavaCompiler
+        // need to be initialized by setting the list of modules to nil.
+        javac.initModules(List.nil());
+        javac.enterDone();
+
+        intType = env.getTypeUtils().getPrimitiveType(TypeKind.INT);
+        one = new ValueLiteral(intType, 1);
+        two = new ValueLiteral(intType, 2);
+    }
+
+    /** Checks that {@code equals} considers {@code 1 + 2} and {@code 2 + 1} equal. */
+    @Test
+    public void commutativeEqualsIsOrderIndependent() {
+        BinaryOperation oneTwo = new BinaryOperation(intType, Tree.Kind.PLUS, one, two);
+        BinaryOperation twoOne = new BinaryOperation(intType, Tree.Kind.PLUS, two, one);
+        Assert.assertEquals(oneTwo, twoOne);
+    }
+
+    /**
+     * Checks that {@code hashCode} agrees with {@code equals}: since {@code 1 + 2} and {@code 2 +
+     * 1} are equal, they must hash identically. This is the contract violation reported in issue
+     * #1653.
+     */
+    @Test
+    public void commutativeHashCodeIsOrderIndependent() {
+        BinaryOperation oneTwo = new BinaryOperation(intType, Tree.Kind.PLUS, one, two);
+        BinaryOperation twoOne = new BinaryOperation(intType, Tree.Kind.PLUS, two, one);
+        Assert.assertEquals(
+                "equal commutative BinaryOperations must have equal hash codes",
+                oneTwo.hashCode(),
+                twoOne.hashCode());
+    }
+
+    /** Checks that {@code equals} distinguishes {@code 1 - 2} from {@code 2 - 1}. */
+    @Test
+    public void nonCommutativeEqualsIsOrderSensitive() {
+        BinaryOperation oneTwo = new BinaryOperation(intType, Tree.Kind.MINUS, one, two);
+        BinaryOperation twoOne = new BinaryOperation(intType, Tree.Kind.MINUS, two, one);
+        Assert.assertNotEquals(oneTwo, twoOne);
+    }
+
+    /**
+     * Checks that {@code hashCode} remains order-sensitive for a non-commutative operator, i.e.
+     * that the fix for commutative operators did not make {@code hashCode} order-independent in
+     * general.
+     */
+    @Test
+    public void nonCommutativeHashCodeIsOrderSensitive() {
+        BinaryOperation oneTwo = new BinaryOperation(intType, Tree.Kind.MINUS, one, two);
+        BinaryOperation twoOne = new BinaryOperation(intType, Tree.Kind.MINUS, two, one);
+        Assert.assertNotEquals(oneTwo.hashCode(), twoOne.hashCode());
+    }
+}


### PR DESCRIPTION
Fixes eisop#1653

Issue eisop#1653 reported that BinaryOperation.equals() treats commutative operations as equal under operand swap (e.g. `a + b` equals `b + a`), while hashCode() was order-dependent, violating the equals/hashCode contract and risking lost entries when these dataflow expressions are used as map or set keys.

The hashCode side of that contract was already fixed by PR #1765 ("Correctness and performance fixes", commit 7ff3e2148) and refined for allocation in PR #1812 (commit 101268852): hashCode() now combines the operand hashes order-independently (via addition) for commutative operationKinds, matching equals(), while remaining order-sensitive for non-commutative operators. Neither PR referenced eisop#1653, so the issue stayed open with no regression coverage.

Add BinaryOperationTest, asserting that equal commutative BinaryOperations (operands swapped) have equal hashCodes, and that non-commutative operations remain order-sensitive in both equals and hashCode. Add a changelog bullet and close out eisop#1653.