### PR TITLE
Fix fake override order

### DIFF
--- a/checker/tests/stubparser-tainting/FOGenericReturnMid.java
+++ b/checker/tests/stubparser-tainting/FOGenericReturnMid.java
@@ -1,6 +1,7 @@
 // See https://github.com/eisop/checker-framework/issues/1862 .
-// Does not declare m() itself: FakeOverrideGenericReturn.astub fake-overrides it with a
-// return type that annotates a type ARGUMENT (not just the primary annotation on the
-// outermost type), to test that AnnotationFileElementTypes#refreshFakeOverride threads the
-// whole return-type structure, not only its primary annotation.
+// Does not declare m() or m2() itself: FakeOverrideGenericReturn.astub fake-overrides both
+// with generic return types, to test that AnnotationFileElementTypes#refreshFakeOverride
+// threads an explicit type-argument annotation through (m()) and resets an unannotated
+// type-argument position to the checker's default rather than inheriting it from the
+// overridden method (m2()).
 public class FOGenericReturnMid extends FOGenericReturnSuper {}

--- a/checker/tests/stubparser-tainting/FOGenericReturnMid.java
+++ b/checker/tests/stubparser-tainting/FOGenericReturnMid.java
@@ -1,0 +1,6 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+// Does not declare m() itself: FakeOverrideGenericReturn.astub fake-overrides it with a
+// return type that annotates a type ARGUMENT (not just the primary annotation on the
+// outermost type), to test that AnnotationFileElementTypes#refreshFakeOverride threads the
+// whole return-type structure, not only its primary annotation.
+public class FOGenericReturnMid extends FOGenericReturnSuper {}

--- a/checker/tests/stubparser-tainting/FOGenericReturnSuper.java
+++ b/checker/tests/stubparser-tainting/FOGenericReturnSuper.java
@@ -1,0 +1,11 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+// Real declaration of the overridden method. Unannotated, so its return type is fully
+// defaulted at both the primary and the type-argument position: @Tainted List<@Tainted
+// String>.
+import java.util.List;
+
+public class FOGenericReturnSuper {
+    public List<String> m() {
+        return null;
+    }
+}

--- a/checker/tests/stubparser-tainting/FOGenericReturnSuper.java
+++ b/checker/tests/stubparser-tainting/FOGenericReturnSuper.java
@@ -1,11 +1,21 @@
 // See https://github.com/eisop/checker-framework/issues/1862 .
-// Real declaration of the overridden method. Unannotated, so its return type is fully
-// defaulted at both the primary and the type-argument position: @Tainted List<@Tainted
-// String>.
+// Real declarations of the overridden methods.
+import org.checkerframework.checker.tainting.qual.Untainted;
+
 import java.util.List;
 
 public class FOGenericReturnSuper {
+    // Unannotated, so its return type is fully defaulted at both the primary and the
+    // type-argument position: @Tainted List<@Tainted String>.
     public List<String> m() {
+        return null;
+    }
+
+    // The type argument is explicitly @Untainted here. FOGenericReturnMid's presence-only fake
+    // override of this method (below) must NOT inherit @Untainted at that position: a
+    // presence-only fake override resets every position, including nested ones, to the
+    // checker's default, not to what the overridden method declares.
+    public List<@Untainted String> m2() {
         return null;
     }
 }

--- a/checker/tests/stubparser-tainting/FOGenericReturnUse.java
+++ b/checker/tests/stubparser-tainting/FOGenericReturnUse.java
@@ -1,9 +1,9 @@
 // See https://github.com/eisop/checker-framework/issues/1862 .
-// Regression test: FOGenericReturnMid.m()'s fake override return type is
-// List<@Untainted String>, not List<@Tainted String> (the checker's default, which is all
-// that the primary annotation alone would carry). If AnnotationFileElementTypes#
-// refreshFakeOverride only propagated the primary annotation and not the type argument,
-// assigning the result to List<@Tainted String> would incorrectly type-check.
+// Regression tests for AnnotationFileElementTypes#refreshFakeOverride's handling of a fake
+// override's generic return type, exercising both directions of the bug this used to have:
+// an explicit type-argument annotation must be threaded through (test()), and an
+// unannotated position must reset to the checker's default rather than leak an unrelated
+// annotation from the overridden method (test2()).
 import org.checkerframework.checker.tainting.qual.Tainted;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
@@ -12,8 +12,21 @@ import java.util.List;
 public class FOGenericReturnUse {
     void test() {
         FOGenericReturnMid mid = new FOGenericReturnMid();
+        // FOGenericReturnMid.m()'s fake override return type is List<@Untainted String>, not
+        // List<@Tainted String> (the checker's default, which is all that the primary
+        // annotation alone would carry).
         List<@Untainted String> ok = mid.m();
         // :: error: (assignment.type.incompatible)
         List<@Tainted String> bad = mid.m();
+    }
+
+    void test2() {
+        FOGenericReturnMid mid = new FOGenericReturnMid();
+        // FOGenericReturnMid.m2()'s fake override is entirely presence-only, so its return
+        // type's type argument must reset to the checker's default (@Tainted), not inherit
+        // @Untainted from FOGenericReturnSuper.m2(), the method it fake-overrides.
+        List<@Tainted String> ok2 = mid.m2();
+        // :: error: (assignment.type.incompatible)
+        List<@Untainted String> bad2 = mid.m2();
     }
 }

--- a/checker/tests/stubparser-tainting/FOGenericReturnUse.java
+++ b/checker/tests/stubparser-tainting/FOGenericReturnUse.java
@@ -1,0 +1,19 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+// Regression test: FOGenericReturnMid.m()'s fake override return type is
+// List<@Untainted String>, not List<@Tainted String> (the checker's default, which is all
+// that the primary annotation alone would carry). If AnnotationFileElementTypes#
+// refreshFakeOverride only propagated the primary annotation and not the type argument,
+// assigning the result to List<@Tainted String> would incorrectly type-check.
+import org.checkerframework.checker.tainting.qual.Tainted;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+import java.util.List;
+
+public class FOGenericReturnUse {
+    void test() {
+        FOGenericReturnMid mid = new FOGenericReturnMid();
+        List<@Untainted String> ok = mid.m();
+        // :: error: (assignment.type.incompatible)
+        List<@Tainted String> bad = mid.m();
+    }
+}

--- a/checker/tests/stubparser-tainting/FakeOverrideGenericReturn.astub
+++ b/checker/tests/stubparser-tainting/FakeOverrideGenericReturn.astub
@@ -1,12 +1,18 @@
 // See https://github.com/eisop/checker-framework/issues/1862 .
-// Presence-only on the primary annotation (List stays at the checker's default, @Tainted),
-// but the return type's type argument is explicitly @Untainted. Applying this fake override
-// must produce BOTH: the primary annotation (reset to the checker's default here, since this
-// declaration does not write one) and the type-argument annotation.
 import java.util.List;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 class FOGenericReturnMid {
-    // fake override:
+    // fake override: presence-only on the primary annotation (List stays at the checker's
+    // default, @Tainted), but the return type's type argument is explicitly @Untainted.
+    // Applying this fake override must produce BOTH: the primary annotation (reset to the
+    // checker's default here, since this declaration does not write one) and the
+    // type-argument annotation.
     List<@Untainted String> m();
+
+    // fake override: entirely presence-only (no annotation anywhere), even though
+    // FOGenericReturnSuper.m2() -- the method this fake-overrides -- explicitly declares its
+    // type argument @Untainted. Every position, including the type argument, must reset to
+    // the checker's default (@Tainted), not inherit m2()'s @Untainted.
+    List<String> m2();
 }

--- a/checker/tests/stubparser-tainting/FakeOverrideGenericReturn.astub
+++ b/checker/tests/stubparser-tainting/FakeOverrideGenericReturn.astub
@@ -1,0 +1,12 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+// Presence-only on the primary annotation (List stays at the checker's default, @Tainted),
+// but the return type's type argument is explicitly @Untainted. Applying this fake override
+// must produce BOTH: the primary annotation (reset to the checker's default here, since this
+// declaration does not write one) and the type-argument annotation.
+import java.util.List;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+class FOGenericReturnMid {
+    // fake override:
+    List<@Untainted String> m();
+}

--- a/checker/tests/stubparser-tainting/OrderFOMidParam.java
+++ b/checker/tests/stubparser-tainting/OrderFOMidParam.java
@@ -1,0 +1,4 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+// Does not declare m(int) itself: OrderFakeOverrideParam.astub fake-overrides it with a
+// presence-only (unannotated) declaration.
+public class OrderFOMidParam extends OrderFOSuperParam {}

--- a/checker/tests/stubparser-tainting/OrderFOSuperParam.java
+++ b/checker/tests/stubparser-tainting/OrderFOSuperParam.java
@@ -1,0 +1,11 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+// This class's own parameter is annotated only via OrderFakeOverrideParam.astub, not in this
+// source file. A fake override only ever touches a return type (see
+// AnnotationFileParser#processFakeOverride), never a parameter, so
+// OrderFOMidParam's presence-only fake override of m(int) below must inherit this
+// parameter's stub-provided type unchanged -- regardless of where this class's own
+// declaration sits within that stub file relative to the fake override.
+public class OrderFOSuperParam {
+
+    public void m(int p) {}
+}

--- a/checker/tests/stubparser-tainting/OrderFakeOverrideParam.astub
+++ b/checker/tests/stubparser-tainting/OrderFakeOverrideParam.astub
@@ -1,0 +1,19 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+//
+// OrderFOMidParam's presence-only fake override of m(int) is declared BEFORE
+// OrderFOSuperParam's own stub-provided annotation on m(int)'s parameter, in this same file.
+// A fake override only ever touches a return type, never a parameter (see
+// AnnotationFileParser#processFakeOverride), so applying it must reset OrderFOMidParam's
+// m(int) to a fresh getAnnotatedType(overridden) whose parameter type reflects
+// OrderFOSuperParam's @Untainted annotation below once the whole file has been applied --
+// regardless of the order the two classes are declared in.
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+class OrderFOMidParam {
+    // fake override:
+    void m(int p);
+}
+
+class OrderFOSuperParam {
+    void m(@Untainted int p);
+}

--- a/checker/tests/stubparser-tainting/OrderFakeOverrideParamUse.java
+++ b/checker/tests/stubparser-tainting/OrderFakeOverrideParamUse.java
@@ -1,0 +1,19 @@
+// See https://github.com/eisop/checker-framework/issues/1862 .
+// Regression test: a fake override's stored snapshot must not go stale just because the
+// overridden method's own stub-provided parameter annotation is declared later in the same
+// stub file (OrderFakeOverrideParam.astub). A fake override never touches parameter types
+// itself, so OrderFOMidParam.m(int) must require exactly what OrderFOSuperParam.m(int)
+// requires.
+import org.checkerframework.checker.tainting.qual.Tainted;
+
+public class OrderFakeOverrideParamUse {
+    void m(@Tainted int t) {
+        OrderFOSuperParam sup = new OrderFOSuperParam();
+        OrderFOMidParam mid = new OrderFOMidParam();
+
+        // :: error: (argument.type.incompatible)
+        sup.m(t);
+        // :: error: (argument.type.incompatible)
+        mid.m(t);
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,14 @@ to none at all, silently changing or dropping the annotations it provides:
   simple name, so the fake override was dropped; such a name is now matched as
   a suffix of the fully-qualified name.
 
+Fixed a bug where `AnnotatedTypeFactory.getAnnotatedType(Element)` could cache
+an incomplete type for an element visited reentrantly while an annotation file
+was still being parsed (e.g., via a fake override's `getAnnotatedType`
+lookup on the overridden method, when that method's own declaring class had
+not been processed yet), permanently poisoning that element's type for the
+rest of the compilation. The cache write is now skipped while parsing is in
+progress, matching the guard `fromElement` already had.
+
 Fixed a typo (`@SafeEFfect`) in the Guieffect Checker's `org-eclipse.astub` that
 made `CompareEditorInput.getMessage()` inherit the enclosing `@UIType`'s
 `@UIEffect` default rather than being `@SafeEffect`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,11 +76,14 @@ always after parsing has finished; the return type, which a fake override
 always determines from its own declaration, is unaffected. Both the text and
 binary stub paths shared this hazard and are both fixed by this change.
 
-Fixed a fake override's return type losing any explicit annotation on a type
-argument, array component type, or type-variable/wildcard bound (e.g. a
-declared return type `List<@Foo String>`) -- only the outermost (primary)
-annotation was applied to the refreshed return type; a nested annotation
-silently fell back to the checker's default at that position instead.
+Fixed a fake override's return type being applied incorrectly at any
+position other than the outermost (primary) one -- a type argument, array
+component type, or type-variable/wildcard bound. An explicit annotation
+there (e.g. a declared return type `List<@Foo String>`) was silently
+dropped, and an unannotated position there incorrectly inherited whatever
+annotation the overridden method itself declared, instead of resetting to
+the checker's default the way a fake override's primary annotation already
+correctly did.
 
 Fixed a typo (`@SafeEFfect`) in the Guieffect Checker's `org-eclipse.astub` that
 made `CompareEditorInput.getMessage()` inherit the enclosing `@UIType`'s

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,16 @@ not been processed yet), permanently poisoning that element's type for the
 rest of the compilation. The cache write is now skipped while parsing is in
 progress, matching the guard `fromElement` already had.
 
+Fixed a fake override's parameter types, receiver type, and declaration
+annotations going stale when the overridden method's own declaring class is
+processed later in the same stub file or JDK class group (e.g., a fake
+override in `TreeMap.NavigableSubMap` targeting a `java.util.Map` default
+method declared later). The stored snapshot is now refreshed against a
+complete `getAnnotatedType(overridden)` the first time it is used, which is
+always after parsing has finished; the return type, which a fake override
+always determines from its own declaration, is unaffected. Both the text and
+binary stub paths shared this hazard and are both fixed by this change.
+
 Fixed a typo (`@SafeEFfect`) in the Guieffect Checker's `org-eclipse.astub` that
 made `CompareEditorInput.getMessage()` inherit the enclosing `@UIType`'s
 `@UIEffect` default rather than being `@SafeEffect`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,12 @@ always after parsing has finished; the return type, which a fake override
 always determines from its own declaration, is unaffected. Both the text and
 binary stub paths shared this hazard and are both fixed by this change.
 
+Fixed a fake override's return type losing any explicit annotation on a type
+argument, array component type, or type-variable/wildcard bound (e.g. a
+declared return type `List<@Foo String>`) -- only the outermost (primary)
+annotation was applied to the refreshed return type; a nested annotation
+silently fell back to the checker's default at that position instead.
+
 Fixed a typo (`@SafeEFfect`) in the Guieffect Checker's `org-eclipse.astub` that
 made `CompareEditorInput.getMessage()` inherit the enclosing `@UIType`'s
 `@UIEffect` default rather than being `@SafeEffect`.

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -1304,7 +1304,7 @@ public class AnnotationFileElementTypes {
             TypeMirror fakeLocation = candidatePair.first;
             AnnotatedExecutableType candidate = (AnnotatedExecutableType) candidatePair.second;
             if (atypeFactory.types.isSameType(receiverTypeMirror, fakeLocation)) {
-                return candidate;
+                return refreshFakeOverride(method, candidate);
             } else if (atypeFactory.types.isSubtype(receiverTypeMirror, fakeLocation)) {
                 TypeElement fakeElement = TypesUtils.getTypeElement(fakeLocation);
                 switch (fakeElement.getKind()) {
@@ -1350,13 +1350,49 @@ public class AnnotationFileElementTypes {
         for (IPair<TypeMirror, AnnotatedTypeMirror> candidatePair : candidates) {
             TypeMirror candidateReceiverType = candidatePair.first;
             if (atypeFactory.types.isSameType(fakeReceiverType, candidateReceiverType)) {
-                return (AnnotatedExecutableType) candidatePair.second;
+                return refreshFakeOverride(method, (AnnotatedExecutableType) candidatePair.second);
             }
         }
 
         throw new BugInCF(
                 "No match for %s in %s %s %s",
                 fakeReceiverType, candidates, applicableClasses, applicableInterfaces);
+    }
+
+    /**
+     * Returns a fresh {@code getAnnotatedType(overridden)} with {@code storedCandidate}'s
+     * return-type annotations overlaid on top.
+     *
+     * <p>{@code storedCandidate} was computed once, during parsing (see {@code
+     * AnnotationFileParser#processFakeOverride}, {@code BinaryStubReader#applyFakeOverride}), by
+     * calling {@code getAnnotatedType(overridden)} and then unconditionally resetting the return
+     * type's annotations to exactly what the fake-override declaration itself writes there -- which
+     * is empty for a presence-only fake override; a fake override deliberately resets the return
+     * type to the checker's default at that subtype rather than inheriting {@code overridden}'s,
+     * even when it writes no explicit annotation (see the {@code NoExplicitAnnotations} test in
+     * {@code checker/tests/stubparser-nullness}). That base call can run before {@code
+     * overridden}'s own declaring class has been fully processed -- e.g., when the class is
+     * declared later in the same stub file, or is a not-yet-loaded binary JDK class -- in which
+     * case everything in {@code storedCandidate} other than the return type (parameter types,
+     * receiver type, declaration annotations) may be stale (see
+     * https://github.com/eisop/checker-framework/issues/1862). Recomputing the base type here is
+     * always safe: {@link #getFakeOverride}, this method's only caller, runs only once parsing has
+     * finished (see its {@code isParsing()} check), so {@code overridden}'s own type is guaranteed
+     * complete by now. The return type is deliberately re-applied from {@code storedCandidate}
+     * verbatim (clear-then-add, not merge) rather than left alone, to preserve that
+     * reset-to-default behavior exactly.
+     *
+     * @param overridden the overridden method the fake override targets
+     * @param storedCandidate the fake override's stored snapshot; only its return-type annotations
+     *     are trusted
+     * @return a fresh, non-stale fake override method type
+     */
+    private AnnotatedExecutableType refreshFakeOverride(
+            ExecutableElement overridden, AnnotatedExecutableType storedCandidate) {
+        AnnotatedExecutableType fresh = atypeFactory.getAnnotatedType(overridden);
+        fresh.getReturnType().clearAnnotations();
+        fresh.getReturnType().addAnnotations(storedCandidate.getReturnType().getAnnotations());
+        return fresh;
     }
 
     //

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -15,6 +15,7 @@ import org.checkerframework.framework.stub.AnnotationFileUtil.AnnotationFileType
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.AnnotatedTypeReplacer;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.BugInCF;
@@ -1379,8 +1380,17 @@ public class AnnotationFileElementTypes {
      * always safe: {@link #getFakeOverride}, this method's only caller, runs only once parsing has
      * finished (see its {@code isParsing()} check), so {@code overridden}'s own type is guaranteed
      * complete by now. The return type is deliberately re-applied from {@code storedCandidate}
-     * verbatim (clear-then-add, not merge) rather than left alone, to preserve that
-     * reset-to-default behavior exactly.
+     * verbatim (replace, not merge) rather than left alone, to preserve that reset-to-default
+     * behavior exactly -- structurally, at every position in the return type (including type
+     * arguments, array component types, and wildcard/type-variable bounds), not just the primary
+     * annotation, since {@code AnnotationFileParser#annotate} recurses into and resets every such
+     * position while parsing (this used to be a bug: only the primary annotation was propagated, so
+     * an explicit annotation on a fake override's return-type argument, e.g. {@code List<@Foo
+     * String>}, was silently dropped). {@link AnnotatedTypeReplacer} performs that structural
+     * replacement; using it here is equivalent to a structural clear-then-add because {@code
+     * storedCandidate}'s return type already carries a fully resolved (explicit-or-default)
+     * annotation at every position, so there is no position where "replace" and "clear-then-add"
+     * could disagree.
      *
      * @param overridden the overridden method the fake override targets
      * @param storedCandidate the fake override's stored snapshot; only its return-type annotations
@@ -1390,8 +1400,15 @@ public class AnnotationFileElementTypes {
     private AnnotatedExecutableType refreshFakeOverride(
             ExecutableElement overridden, AnnotatedExecutableType storedCandidate) {
         AnnotatedExecutableType fresh = atypeFactory.getAnnotatedType(overridden);
-        fresh.getReturnType().clearAnnotations();
-        fresh.getReturnType().addAnnotations(storedCandidate.getReturnType().getAnnotations());
+        // Use visit(from, to), not from.accept(replacer, to): AnnotatedTypeReplacer's annotation
+        // replacement happens in defaultAction, which DoubleAnnotatedTypeScanner#scan calls before
+        // dispatching; accept() dispatches directly to the type-kind-specific visit method and
+        // skips that call for kinds (primitive, null, no-type) that do not override it, silently
+        // leaving the top-level annotation unchanged. visit() (called on the AnnotatedTypeReplacer
+        // instance, not on the visited type) goes through scan() and is the pattern every other
+        // caller in this codebase uses (see AnnotatedTypeFactory#replaceAnnotations,
+        // DependentTypesHelper).
+        new AnnotatedTypeReplacer().visit(storedCandidate.getReturnType(), fresh.getReturnType());
         return fresh;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileElementTypes.java
@@ -15,7 +15,7 @@ import org.checkerframework.framework.stub.AnnotationFileUtil.AnnotationFileType
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
-import org.checkerframework.framework.type.AnnotatedTypeReplacer;
+import org.checkerframework.framework.type.visitor.DoubleAnnotatedTypeScanner;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.BugInCF;
@@ -1380,17 +1380,22 @@ public class AnnotationFileElementTypes {
      * always safe: {@link #getFakeOverride}, this method's only caller, runs only once parsing has
      * finished (see its {@code isParsing()} check), so {@code overridden}'s own type is guaranteed
      * complete by now. The return type is deliberately re-applied from {@code storedCandidate}
-     * verbatim (replace, not merge) rather than left alone, to preserve that reset-to-default
-     * behavior exactly -- structurally, at every position in the return type (including type
-     * arguments, array component types, and wildcard/type-variable bounds), not just the primary
-     * annotation, since {@code AnnotationFileParser#annotate} recurses into and resets every such
-     * position while parsing (this used to be a bug: only the primary annotation was propagated, so
-     * an explicit annotation on a fake override's return-type argument, e.g. {@code List<@Foo
-     * String>}, was silently dropped). {@link AnnotatedTypeReplacer} performs that structural
-     * replacement; using it here is equivalent to a structural clear-then-add because {@code
-     * storedCandidate}'s return type already carries a fully resolved (explicit-or-default)
-     * annotation at every position, so there is no position where "replace" and "clear-then-add"
-     * could disagree.
+     * verbatim (clear-then-add, not merge) rather than left alone, to preserve that
+     * reset-to-default behavior exactly -- structurally, at every position in the return type
+     * (including type arguments, array component types, and wildcard/type-variable bounds), not
+     * just the primary annotation (this used to be a bug: only the primary annotation was
+     * propagated, so an explicit annotation on a fake override's return-type argument, e.g. {@code
+     * List<@Foo String>}, was silently dropped). {@link #RETURN_TYPE_RESETTER} performs that
+     * structural clear-then-add. A plain structural <em>replace</em> (only overwriting a position
+     * where {@code storedCandidate} has an annotation, e.g. {@link
+     * org.checkerframework.framework.type.AnnotatedTypeReplacer}) is not equivalent here and must
+     * not be used: {@code storedCandidate}'s return type is <em>not</em> defaulted at parse time
+     * (see {@code AnnotationFileParser#annotate}'s {@code clearAnnotations} call and this method's
+     * own Javadoc above -- a presence-only fake override's stored return type is empty, not
+     * defaulted), so a position {@code storedCandidate} leaves bare must become bare on {@code
+     * fresh} too, relying on the checker's normal defaulting once the type is read, rather than
+     * keeping whatever {@code fresh} (i.e. {@code overridden}'s own declared type) already had
+     * there.
      *
      * @param overridden the overridden method the fake override targets
      * @param storedCandidate the fake override's stored snapshot; only its return-type annotations
@@ -1400,17 +1405,33 @@ public class AnnotationFileElementTypes {
     private AnnotatedExecutableType refreshFakeOverride(
             ExecutableElement overridden, AnnotatedExecutableType storedCandidate) {
         AnnotatedExecutableType fresh = atypeFactory.getAnnotatedType(overridden);
-        // Use visit(from, to), not from.accept(replacer, to): AnnotatedTypeReplacer's annotation
-        // replacement happens in defaultAction, which DoubleAnnotatedTypeScanner#scan calls before
-        // dispatching; accept() dispatches directly to the type-kind-specific visit method and
-        // skips that call for kinds (primitive, null, no-type) that do not override it, silently
-        // leaving the top-level annotation unchanged. visit() (called on the AnnotatedTypeReplacer
-        // instance, not on the visited type) goes through scan() and is the pattern every other
-        // caller in this codebase uses (see AnnotatedTypeFactory#replaceAnnotations,
-        // DependentTypesHelper).
-        new AnnotatedTypeReplacer().visit(storedCandidate.getReturnType(), fresh.getReturnType());
+        RETURN_TYPE_RESETTER.visit(storedCandidate.getReturnType(), fresh.getReturnType());
         return fresh;
     }
+
+    /**
+     * Structurally resets every annotation position in the second ({@code to}) argument passed to
+     * {@code visit(from, to)} to exactly what the first ({@code from}) argument has at the same
+     * position: clearing {@code to}'s annotations there, then adding {@code from}'s. Unlike {@link
+     * org.checkerframework.framework.type.AnnotatedTypeReplacer}, which leaves a position in {@code
+     * to} unchanged wherever {@code from} has no annotation there, this always clears first, so a
+     * position where {@code from} has nothing becomes bare on {@code to} too. Used by {@link
+     * #refreshFakeOverride} to reset a fake override's return type to exactly what the fake
+     * override declaration wrote, at every position, including positions the declaration left
+     * unannotated (which must become bare, not retain {@code to}'s own prior annotation, so that
+     * the checker's normal defaulting fills them in when the type is read).
+     */
+    private static final DoubleAnnotatedTypeScanner<Void> RETURN_TYPE_RESETTER =
+            new DoubleAnnotatedTypeScanner<Void>() {
+                @Override
+                protected Void defaultAction(AnnotatedTypeMirror from, AnnotatedTypeMirror to) {
+                    if (from != null && to != null) {
+                        to.clearAnnotations();
+                        to.addAnnotations(from.getAnnotations());
+                    }
+                    return null;
+                }
+            };
 
     //
     // End of public methods, private helper methods follow

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1601,7 +1601,15 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // or obtained from bytecode.
         AnnotatedTypeMirror type = fromElement(elt);
         addComputedTypeAnnotations(elt, type);
-        if (useCache) {
+        // Do not cache a result computed while an annotation file is being parsed: a fake
+        // override (AnnotationFileParser#processFakeOverride, BinaryStubReader#applyFakeOverride)
+        // reentrantly calls this method on the overridden method while that method's own
+        // declaring class may not have been processed yet, e.g. when it appears later in the same
+        // stub file. `elementTypeCache` is intentionally never cleared between compilation units
+        // (see the comment in setRoot), so caching such an incomplete result here would freeze it
+        // for the rest of the compilation. `fromElement`'s `elementCache` already applies this
+        // same guard, for the same reason; see `isParsingAnnotationFile`'s Javadoc.
+        if (useCache && !isParsingAnnotationFile()) {
             elementTypeCache.put(elt, frozenDeepCopy(type));
         }
         return type;


### PR DESCRIPTION
Fixes eisop#1862.

`AnnotationFileElementTypes.getFakeOverride` stores a `getAnnotatedType(overridden)` snapshot for each fake override at parse time. If the overridden method's own declaring class is processed later in the same stub file or JDK class group, that snapshot's parameter types, receiver type, and declaration annotations can go stale — both the text and binary stub paths share this hazard.

## What's here

**Commit 1** (`AnnotatedTypeFactory`): stop caching `getAnnotatedType(Element)` results computed while an annotation file is still being parsed, matching the guard `fromElement` already had.

**Commit 2** (`AnnotationFileElementTypes`): `getFakeOverride`'s fix — refresh the stored snapshot against a freshly computed `getAnnotatedType(overridden)` the first time it's used (always after parsing has finished), overlaying only the return type (which a fake override always determines from its own declaration, independent of any staleness in `overridden`).

**Commits 3–4** (this update, squashed into one story below): commit 2's overlay step only copied the *primary* (outermost) annotation of the stored return type, so an explicit annotation on a return type's type argument (e.g. `List<@Foo String>`) was silently dropped. Fixing that took two attempts:

- First attempt used `AnnotatedTypeReplacer` via `.accept()` — which turned out to call the annotation-replacement logic through the wrong entry point (`accept()` skips it for primitive/null/no-type kinds; the correct entry point, used elsewhere in this codebase, is `.visit()`). Building against the pre-existing `FakeOverrideReturn.java` fixture in the same test directory (primitive `int` returns) caught this immediately, before push.
- Second attempt fixed the entry point but kept `AnnotatedTypeReplacer`'s *replace* semantics: it leaves a position unchanged when the source has no annotation there. That's wrong here — a presence-only fake override's stored return type is genuinely unannotated at that position (not yet defaulted; see `AnnotationFileParser#annotate`'s `clearAnnotations` call), and must reset to the checker's default, not inherit whatever the overridden method itself declared. **This is what broke CI**: `StubparserNullnessTest`'s `NoExplicitAnnotations.java` fixture exists specifically to pin down this reset-to-default contract, and an unannotated fake override's return type started incorrectly inheriting the overridden method's `@Nullable` annotation.

The final fix replaces `AnnotatedTypeReplacer` with a small private structural scanner (`RETURN_TYPE_RESETTER`, a `DoubleAnnotatedTypeScanner`) that does an explicit clear-then-add at every position — matching the original top-level clear-then-add contract, but applied throughout the return type's structure instead of only at the top.

## Tests

`stubparser-tainting` fixture, two fake overrides:
- `m()`: return type `List<@Untainted String>`, unannotated at the primary — verifies an explicit type-argument annotation is threaded through.
- `m2()`: entirely presence-only, targeting a real method whose return type's type argument is explicitly annotated — verifies an unannotated nested position resets to the checker's default rather than inheriting the overridden method's annotation (this is the case that would have caught the CI failure).

Both cases were verified failing against each intermediate (broken) version of the fix and passing against the final version, without regressing the pre-existing `FakeOverrideReturn.java`/`NoExplicitAnnotations.java` fixtures that originally caught the two mistakes.

Full `:framework:test` and `:checker:test` (all checkers, not just the stub-related suites) pass with zero failures, including `NullnessBinaryStubDiffTest` (0 mismatches against the real annotated JDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHhVqLoJukm4kKsE7UfY4
