### PR TITLE
Pin ruff version in GitHub Actions setup and fix ruff 0.16.0 lint findings

### DIFF
--- a/.claude/skills/cf-performance/gen-sized-program.py
+++ b/.claude/skills/cf-performance/gen-sized-program.py
@@ -68,8 +68,10 @@ def vararg(n: int) -> str:
             f"        List<String> xs{i} = Arrays.asList(s{i}, s{i}, s{i});",
             f"        List<String> ys{i} = Arrays.asList(s{i});",
             f'        String f{i} = String.format("%s %s", s{i}, s{i});',
-            f"        java.lang.reflect.Method mm{i} ="
-            f' Big.class.getMethod("m{i}", String.class);',
+            (
+                f"        java.lang.reflect.Method mm{i} ="
+                f' Big.class.getMethod("m{i}", String.class);'
+            ),
             "    }",
         ]
     lines.append("}")

--- a/.github/actions/setup-misc/action.yml
+++ b/.github/actions/setup-misc/action.yml
@@ -67,4 +67,11 @@ runs:
       shell: bash
       # PEP 668: Ubuntu 24.04's system Python is externally-managed.
       # `--break-system-packages` is the documented escape hatch for CI.
-      run: pip install --break-system-packages black flake8 html5validator
+      #
+      # ruff is pinned: the Makefile's `install-ruff` target (`if ! command -v
+      # ruff; then pipx install ruff; fi`) only installs its own (unpinned,
+      # always-latest) copy when ruff isn't already on PATH, so installing a
+      # fixed version here makes that fallback a no-op and keeps `make
+      # style-check` results reproducible across CI runs. Bump this pin
+      # deliberately, not as a side effect of an unrelated PR.
+      run: pip install --break-system-packages black flake8 html5validator ruff==0.16.0

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,6 +41,13 @@
       "depNameTemplate": "openjdk/jdk",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^jdk-{{{major}}}\\+(?<version>\\d+)$"
+    },
+    {
+      "description": "Update the pinned ruff version in the misc job's GitHub Actions setup",
+      "fileMatch": ["^\\.github/actions/setup-misc/action\\.yml$"],
+      "matchStrings": ["ruff==(?<currentValue>[\\d.]+)"],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "ruff"
     }
   ]
 }

--- a/docs/developer/release/release_build.py
+++ b/docs/developer/release/release_build.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 """
 release_build.py
 
@@ -10,50 +9,52 @@ Copyright (c) 2015 University of Washington. All rights reserved.
 
 # See README-release-process.html for more information
 
-from release_vars import ANNO_FILE_UTILITIES
-from release_vars import ANNO_TOOLS
-from release_vars import BUILD_REPOS
-from release_vars import CF_VERSION
-from release_vars import CHECKER_FRAMEWORK
-from release_vars import CHECKER_FRAMEWORK_RELEASE
-from release_vars import CHECKLINK
-from release_vars import CHECKLINK_REPO
-from release_vars import DEV_SITE_DIR
-from release_vars import INTERM_REPOS
-from release_vars import INTERM_TO_BUILD_REPOS
-from release_vars import LIVE_SITE_URL
-from release_vars import LIVE_TO_INTERM_REPOS
-from release_vars import PLUME_BIB
-from release_vars import PLUME_BIB_REPO
-from release_vars import PLUME_SCRIPTS
-from release_vars import PLUME_SCRIPTS_REPO
-from release_vars import RELEASE_BUILD_COMPLETED_FLAG_FILE
-from release_vars import TOOLS
-
-from release_vars import execute
-
-from release_utils import check_repos
-from release_utils import check_tools
-from release_utils import clone_from_scratch_or_update
-from release_utils import commit_tag_and_push
-from release_utils import continue_or_exit
-from release_utils import create_empty_file
-from release_utils import current_distribution_by_website
-from release_utils import delete_if_exists
-from release_utils import delete_path_if_exists
-from release_utils import ensure_group_access
-from release_utils import increment_version
-from release_utils import os
-from release_utils import print_step
-from release_utils import prompt_to_continue
-from release_utils import prompt_w_default
-from release_utils import prompt_yes_no
-from release_utils import has_command_line_option
-from release_utils import set_umask
-
-from distutils.dir_util import copy_tree
 import datetime
 import sys
+from distutils.dir_util import copy_tree
+
+from release_utils import (
+    check_repos,
+    check_tools,
+    clone_from_scratch_or_update,
+    commit_tag_and_push,
+    continue_or_exit,
+    create_empty_file,
+    current_distribution_by_website,
+    delete_if_exists,
+    delete_path_if_exists,
+    ensure_group_access,
+    has_command_line_option,
+    increment_version,
+    os,
+    print_step,
+    prompt_to_continue,
+    prompt_w_default,
+    prompt_yes_no,
+    set_umask,
+)
+from release_vars import (
+    ANNO_FILE_UTILITIES,
+    ANNO_TOOLS,
+    BUILD_REPOS,
+    CF_VERSION,
+    CHECKER_FRAMEWORK,
+    CHECKER_FRAMEWORK_RELEASE,
+    CHECKLINK,
+    CHECKLINK_REPO,
+    DEV_SITE_DIR,
+    INTERM_REPOS,
+    INTERM_TO_BUILD_REPOS,
+    LIVE_SITE_URL,
+    LIVE_TO_INTERM_REPOS,
+    PLUME_BIB,
+    PLUME_BIB_REPO,
+    PLUME_SCRIPTS,
+    PLUME_SCRIPTS_REPO,
+    RELEASE_BUILD_COMPLETED_FLAG_FILE,
+    TOOLS,
+    execute,
+)
 
 # Turned on by the --debug command-line option.
 debug = False
@@ -151,7 +152,7 @@ def create_dev_website_release_version_dir(project_name, version):
         interm_dir = os.path.join(DEV_SITE_DIR, project_name, "releases", version)
     delete_path_if_exists(interm_dir)
 
-    execute("mkdir -p %s" % interm_dir, True, False)
+    execute(f"mkdir -p {interm_dir}", True, False)
     return interm_dir
 
 
@@ -199,7 +200,9 @@ def update_project_dev_website(project_name, release_version):
 
 def get_current_date():
     "Return today's date in a string format similar to: 02 May 2016"
-    return datetime.date.today().strftime("%d %b %Y")
+    # Use the releaser's local calendar date (not UTC): astimezone() makes the
+    # datetime timezone-aware without changing which local date it names.
+    return datetime.datetime.now().astimezone().date().strftime("%d %b %Y")
 
 
 def build_annotation_tools_release(version, afu_interm_dir):
@@ -210,20 +213,11 @@ def build_annotation_tools_release(version, afu_interm_dir):
     date = get_current_date()
 
     buildfile = os.path.join(ANNO_FILE_UTILITIES, "build.xml")
-    ant_cmd = (
-        'ant %s -buildfile %s -e update-versions -Drelease.ver="%s" -Drelease.date="%s"'
-        % (ant_debug, buildfile, version, date)
-    )
+    ant_cmd = f'ant {ant_debug} -buildfile {buildfile} -e update-versions -Drelease.ver="{version}" -Drelease.date="{date}"'
     execute(ant_cmd)
 
     # Deploy to intermediate site
-    gradle_cmd = (
-        "./gradlew releaseBuildWithoutTest -Pafu.version=%s -Pdeploy-dir=%s"
-        % (
-            version,
-            afu_interm_dir,
-        )
-    )
+    gradle_cmd = f"./gradlew releaseBuildWithoutTest -Pafu.version={version} -Pdeploy-dir={afu_interm_dir}"
     execute(gradle_cmd, True, False, ANNO_FILE_UTILITIES)
 
     update_project_dev_website("annotation-file-utilities", version)
@@ -246,24 +240,12 @@ def build_checker_framework_release(
     execute("./gradlew assemble -Prelease=true", True, False, ANNO_FILE_UTILITIES)
 
     # update versions
-    ant_props = (
-        '-Dchecker=%s -Dold.release.ver=%s -Drelease.ver=%s -Dafu.version=%s -Dafu.properties=%s -Dafu.release.date="%s"'
-        # python `black` styling can't decide where to break the line.
-        % (
-            checker_dir,
-            old_cf_version,
-            version,
-            version,
-            afu_build_properties,
-            afu_release_date,
-        )
-    )
+    ant_props = f'-Dchecker={checker_dir} -Dold.release.ver={old_cf_version} -Drelease.ver={version} -Dafu.version={version} -Dafu.properties={afu_build_properties} -Dafu.release.date="{afu_release_date}"'
     # IMPORTANT: The release.xml in the directory where the Checker Framework is
     # being built is used. Not the release.xml in the directory you ran
     # release_build.py from.
-    ant_cmd = "ant %s -f release.xml %s update-checker-framework-versions " % (
-        ant_debug,
-        ant_props,
+    ant_cmd = (
+        f"ant {ant_debug} -f release.xml {ant_props} update-checker-framework-versions "
     )
     execute(ant_cmd, True, False, CHECKER_FRAMEWORK_RELEASE)
     # Update version numbers in the manual and API documentation,
@@ -275,9 +257,7 @@ def build_checker_framework_release(
 
     # Check that updating versions didn't overlook anything.
     print("Here are occurrences of the old version number, " + old_cf_version + ":")
-    grep_cmd = (
-        "grep -n -r --exclude-dir=build --exclude-dir=.git -F %s" % old_cf_version
-    )
+    grep_cmd = f"grep -n -r --exclude-dir=build --exclude-dir=.git -F {old_cf_version}"
     execute(grep_cmd, False, False, CHECKER_FRAMEWORK)
     continue_or_exit(
         'If any occurrence is not acceptable, then stop the release, update target "update-checker-framework-versions" in file release.xml, and start over.'
@@ -299,36 +279,30 @@ def build_checker_framework_release(
     checker_tutorial_dir = os.path.join(CHECKER_FRAMEWORK, "docs", "tutorial")
     execute("make", True, False, checker_tutorial_dir)
 
-    cfZipName = "checker-framework-%s.zip" % version
+    cfZipName = f"checker-framework-{version}.zip"
 
     # Create checker-framework-X.Y.Z.zip and put it in checker_framework_interm_dir
-    ant_props = "-Dchecker=%s -Ddest.dir=%s -Dfile.name=%s -Dversion=%s" % (
-        checker_dir,
-        checker_framework_interm_dir,
-        cfZipName,
-        version,
-    )
+    ant_props = f"-Dchecker={checker_dir} -Ddest.dir={checker_framework_interm_dir} -Dfile.name={cfZipName} -Dversion={version}"
     # IMPORTANT: The release.xml in the directory where the Checker Framework
     # is being built is used. Not the release.xml in the directory you ran
     # release_build.py from.
-    ant_cmd = "ant %s -f release.xml %s zip-checker-framework " % (ant_debug, ant_props)
+    ant_cmd = f"ant {ant_debug} -f release.xml {ant_props} zip-checker-framework "
     execute(ant_cmd, True, False, CHECKER_FRAMEWORK_RELEASE)
 
-    ant_props = "-Dchecker=%s -Ddest.dir=%s -Dfile.name=%s -Dversion=%s" % (
+    ant_props = "-Dchecker={} -Ddest.dir={} -Dfile.name={} -Dversion={}".format(
         checker_dir,
         checker_framework_interm_dir,
         "mvn-examples.zip",
         version,
     )
     # IMPORTANT: The release.xml in the directory where the Checker Framework is being built is used. Not the release.xml in the directory you ran release_build.py from.
-    ant_cmd = "ant %s -f release.xml %s zip-maven-examples " % (ant_debug, ant_props)
+    ant_cmd = f"ant {ant_debug} -f release.xml {ant_props} zip-maven-examples "
     execute(ant_cmd, True, False, CHECKER_FRAMEWORK_RELEASE)
 
     # copy the remaining checker-framework website files to checker_framework_interm_dir
     ant_props = (
         # Adding a comment to maybe help black formatting
-        "-Dchecker=%s -Ddest.dir=%s -Dmanual.name=%s -Ddataflow.manual.name=%s -Dchecker.webpage=%s"
-        % (
+        "-Dchecker={} -Ddest.dir={} -Dmanual.name={} -Ddataflow.manual.name={} -Dchecker.webpage={}".format(
             checker_dir,
             checker_framework_interm_dir,
             "checker-framework-manual",
@@ -338,9 +312,8 @@ def build_checker_framework_release(
     )
 
     # IMPORTANT: The release.xml in the directory where the Checker Framework is being built is used. Not the release.xml in the directory you ran release_build.py from.
-    ant_cmd = "ant %s -f release.xml %s checker-framework-website-docs " % (
-        ant_debug,
-        ant_props,
+    ant_cmd = (
+        f"ant {ant_debug} -f release.xml {ant_props} checker-framework-website-docs "
     )
     execute(ant_cmd, True, False, CHECKER_FRAMEWORK_RELEASE)
 
@@ -351,8 +324,6 @@ def build_checker_framework_release(
     build_and_locally_deploy_maven(version)
 
     update_project_dev_website("checker-framework", version)
-
-    return
 
 
 def commit_to_interm_projects(cf_version):
@@ -438,11 +409,9 @@ def main(argv):
 
     if old_cf_version == cf_version:
         print(
-            (
-                "It is *strongly discouraged* to not update the release version numbers for the Checker Framework "
-                + "even if no changes were made to these in a month. This would break so much "
-                + "in the release scripts that they would become unusable. Update the version number in checker-framework/build.gradle\n"
-            )
+            "It is *strongly discouraged* to not update the release version numbers for the Checker Framework "
+            + "even if no changes were made to these in a month. This would break so much "
+            + "in the release scripts that they would become unusable. Update the version number in checker-framework/build.gradle\n"
         )
         prompt_to_continue()
 
@@ -479,7 +448,7 @@ def main(argv):
 
     # Not "cp -p" because that does not work across filesystems whereas rsync does
     CFLOGO = os.path.join(CHECKER_FRAMEWORK, "docs", "logo", "Logo", "CFLogo.png")
-    execute("rsync --times %s %s" % (CFLOGO, checker_framework_interm_dir))
+    execute(f"rsync --times {CFLOGO} {checker_framework_interm_dir}")
 
     # Each project has a set of files that are updated for release. Usually these updates include new
     # release date and version information. All changed files are committed and pushed to the intermediate

--- a/docs/developer/release/release_errors.py
+++ b/docs/developer/release/release_errors.py
@@ -1,0 +1,14 @@
+"""
+release_errors.py
+
+Defines the exception type shared by the release scripts. Kept in its own
+module, rather than in release_vars.py or release_utils.py, because
+release_utils.py already imports from release_vars.py (execute); either of
+those two importing this exception back from the other would be a circular
+import.
+"""
+
+
+class ReleaseError(Exception):
+    """Raised for any failure in the release scripts (release_vars.py,
+    release_utils.py, release_build.py, release_push.py, sanity_checks.py)."""

--- a/docs/developer/release/release_push.py
+++ b/docs/developer/release/release_push.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 """
 release_push.py
 
@@ -11,47 +10,49 @@ Copyright (c) 2013-2016 University of Washington. All rights reserved.
 # See README-release-process.html for more information
 
 import os
+import sys
 from os.path import expanduser
 
-from release_vars import AFU_LIVE_RELEASES_DIR
-from release_vars import ANNO_FILE_UTILITIES
-from release_vars import CF_VERSION
-from release_vars import CHECKER_FRAMEWORK
-from release_vars import CHECKER_LIVE_RELEASES_DIR
-from release_vars import CHECKER_LIVE_API_DIR
-from release_vars import CHECKLINK
-from release_vars import DEV_SITE_DIR
-from release_vars import DEV_SITE_URL
-from release_vars import INTERM_ANNO_REPO
-from release_vars import INTERM_CHECKER_REPO
-from release_vars import LIVE_SITE_DIR
-from release_vars import LIVE_SITE_URL
-from release_vars import RELEASE_BUILD_COMPLETED_FLAG_FILE
-from release_vars import SANITY_DIR
-from release_vars import SCRIPTS_DIR
-from release_vars import TMP_DIR
-
-from release_vars import execute
-
-from release_utils import continue_or_exit
-from release_utils import current_distribution_by_website
-from release_utils import delete_if_exists
-from release_utils import delete_path
-from release_utils import delete_path_if_exists
-from release_utils import ensure_group_access
-from release_utils import get_announcement_email
-from release_utils import print_step
-from release_utils import prompt_to_continue
-from release_utils import prompt_yes_no
-from release_utils import push_changes_prompt_if_fail
-from release_utils import has_command_line_option
-from release_utils import read_first_line
-from release_utils import set_umask
-from release_utils import subprocess
-from release_utils import version_number_to_array
+from release_utils import (
+    continue_or_exit,
+    current_distribution_by_website,
+    delete_if_exists,
+    delete_path,
+    delete_path_if_exists,
+    ensure_group_access,
+    get_announcement_email,
+    has_command_line_option,
+    print_step,
+    prompt_to_continue,
+    prompt_yes_no,
+    push_changes_prompt_if_fail,
+    read_first_line,
+    set_umask,
+    subprocess,
+    version_number_to_array,
+)
+from release_vars import (
+    AFU_LIVE_RELEASES_DIR,
+    ANNO_FILE_UTILITIES,
+    CF_VERSION,
+    CHECKER_FRAMEWORK,
+    CHECKER_LIVE_API_DIR,
+    CHECKER_LIVE_RELEASES_DIR,
+    CHECKLINK,
+    DEV_SITE_DIR,
+    DEV_SITE_URL,
+    INTERM_ANNO_REPO,
+    INTERM_CHECKER_REPO,
+    LIVE_SITE_DIR,
+    LIVE_SITE_URL,
+    RELEASE_BUILD_COMPLETED_FLAG_FILE,
+    SANITY_DIR,
+    SCRIPTS_DIR,
+    TMP_DIR,
+    ReleaseError,
+    execute,
+)
 from sanity_checks import javac_sanity_check, maven_sanity_check
-
-import sys
 
 
 def check_release_version(previous_release, new_release):
@@ -60,7 +61,7 @@ def check_release_version(previous_release, new_release):
     if version_number_to_array(previous_release) >= version_number_to_array(
         new_release
     ):
-        raise Exception(
+        raise ReleaseError(
             "Previous release version ("
             + previous_release
             + ") should be less than "
@@ -82,15 +83,12 @@ def copy_release_dir(path_to_dev_releases, path_to_live_releases, release_versio
         delete_path(dest_location)
 
     if os.path.exists(dest_location):
-        raise Exception("Destination location exists: " + dest_location)
+        raise ReleaseError("Destination location exists: " + dest_location)
 
     # The / at the end of the source location is necessary so that
     # rsync copies the files in the source directory to the destination directory
     # rather than a subdirectory of the destination directory.
-    cmd = "rsync --no-group --omit-dir-times --recursive --links --quiet %s/ %s" % (
-        source_location,
-        dest_location,
-    )
+    cmd = f"rsync --no-group --omit-dir-times --recursive --links --quiet {source_location}/ {dest_location}"
     execute(cmd)
 
     return dest_location
@@ -103,7 +101,7 @@ def promote_release(path_to_releases, release_version):
     from_dir = os.path.join(path_to_releases, release_version)
     to_dir = os.path.join(path_to_releases, "..")
     # Trailing slash is crucial.
-    cmd = "rsync -aJ --no-group --omit-dir-times %s/ %s" % (from_dir, to_dir)
+    cmd = f"rsync -aJ --no-group --omit-dir-times {from_dir}/ {to_dir}"
     execute(cmd)
 
 
@@ -111,7 +109,9 @@ def copy_htaccess():
     "Copy the .htaccess file from the dev site to the live site."
     LIVE_HTACCESS = os.path.join(LIVE_SITE_DIR, ".htaccess")
     execute(
-        "rsync --times %s %s" % (os.path.join(DEV_SITE_DIR, ".htaccess"), LIVE_HTACCESS)
+        "rsync --times {} {}".format(
+            os.path.join(DEV_SITE_DIR, ".htaccess"), LIVE_HTACCESS
+        )
     )
     ensure_group_access(LIVE_HTACCESS)
 
@@ -149,8 +149,7 @@ def stage_maven_artifacts_in_maven_central(new_cf_version):
         "/projects/swlab1/checker-framework/hosting-info/release-private.password"
     )
     execute(
-        "./gradlew publish -Prelease=true --no-parallel -Psigning.gnupg.keyName=checker-framework-dev@googlegroups.com -Psigning.gnupg.passphrase=%s"
-        % gnupgPassphrase,
+        f"./gradlew publish -Prelease=true --no-parallel -Psigning.gnupg.keyName=checker-framework-dev@googlegroups.com -Psigning.gnupg.passphrase={gnupgPassphrase}",
         working_dir=CHECKER_FRAMEWORK,
     )
 
@@ -172,30 +171,22 @@ def run_link_checker(site, output, additional_param=""):
         cmd = ["sh", check_links_script, additional_param, site]
     env = {"CHECKLINK": CHECKLINK}
 
-    out_file = open(output, "w+")
-
     print(
-        (
-            "Executing: "
-            + " ".join("%s=%r" % (key2, val2) for (key2, val2) in list(env.items()))
-            + " "
-            + " ".join(cmd)
-        )
+        "Executing: "
+        + " ".join(f"{key2}={val2!r}" for (key2, val2) in list(env.items()))
+        + " "
+        + " ".join(cmd)
     )
-    process = subprocess.Popen(cmd, env=env, stdout=out_file, stderr=out_file)
-    process.communicate()
-    process.wait()
-    out_file.close()
+    with open(output, "w+") as out_file:
+        process = subprocess.Popen(cmd, env=env, stdout=out_file, stderr=out_file)
+        process.communicate()
+        process.wait()
 
     if process.returncode != 0:
-        msg = "Non-zero return code (%s; see output in %s) while executing %s" % (
-            process.returncode,
-            output,
-            cmd,
-        )
+        msg = f"Non-zero return code ({process.returncode}; see output in {output}) while executing {cmd}"
         print(msg + "\n")
         if not prompt_yes_no("Continue despite link checker results?", True):
-            raise Exception(msg)
+            raise ReleaseError(msg)
 
     return output
 
@@ -239,20 +230,21 @@ def check_all_links(
         print("\t" + afuCheck + "\n")
     if not is_checkerCheck_empty:
         print("\t" + checkerCheck + "\n")
-    if errors_reported:
-        if not prompt_yes_no("Continue despite link checker results?", True):
-            release_option = ""
-            if not test_mode:
-                release_option = " release"
-            raise Exception(
-                "The link checker reported errors.  Please fix them by committing changes to the mainline\n"
-                + "repository and pushing them to GitHub, then updating the development and live sites by\n"
-                + "running\n"
-                + "  python3 release_build.py all\n"
-                + "  python3 release_push"
-                + release_option
-                + "\n"
-            )
+    if errors_reported and not prompt_yes_no(
+        "Continue despite link checker results?", True
+    ):
+        release_option = ""
+        if not test_mode:
+            release_option = " release"
+        raise ReleaseError(
+            "The link checker reported errors.  Please fix them by committing changes to the mainline\n"
+            + "repository and pushing them to GitHub, then updating the development and live sites by\n"
+            + "running\n"
+            + "  python3 release_build.py all\n"
+            + "  python3 release_push"
+            + release_option
+            + "\n"
+        )
 
 
 def push_interm_to_release_repos():
@@ -268,23 +260,21 @@ def validate_args(argv):
     criteria issued in print_usage."""
     if len(argv) > 3:
         print_usage()
-        raise Exception("Invalid arguments. " + ",".join(argv))
+        raise ReleaseError("Invalid arguments. " + ",".join(argv))
     for i in range(1, len(argv)):
         if argv[i] != "release":
             print_usage()
-            raise Exception("Invalid arguments. " + ",".join(argv))
+            raise ReleaseError("Invalid arguments. " + ",".join(argv))
 
 
 def print_usage():
     """Print instructions on how to use this script, and in particular how to
     set test or release mode."""
     print(
-        (
-            "Usage: python3 release_build.py [release]\n"
-            + 'If the "release" argument is '
-            + "NOT specified then the script will execute all steps that checking and prompting "
-            + "steps but will NOT actually perform a release.  This is for testing the script."
-        )
+        "Usage: python3 release_build.py [release]\n"
+        + 'If the "release" argument is '
+        + "NOT specified then the script will execute all steps that checking and prompting "
+        + "steps but will NOT actually perform a release.  This is for testing the script."
     )
 
 
@@ -306,7 +296,7 @@ def main(argv):
 
     m2_settings = expanduser("~") + "/.m2/settings.xml"
     if not os.path.exists(m2_settings):
-        raise Exception("File does not exist: " + m2_settings)
+        raise ReleaseError("File does not exist: " + m2_settings)
 
     if test_mode:
         msg = (
@@ -346,8 +336,7 @@ def main(argv):
     check_release_version(current_cf_version, new_cf_version)
 
     print(
-        "Checker Framework and AFU:  current-version=%s    new-version=%s"
-        % (current_cf_version, new_cf_version)
+        f"Checker Framework and AFU:  current-version={current_cf_version}    new-version={new_cf_version}"
     )
 
     # Runs the link the checker on all websites at:

--- a/docs/developer/release/release_push.py
+++ b/docs/developer/release/release_push.py
@@ -13,6 +13,7 @@ import os
 import sys
 from os.path import expanduser
 
+from release_errors import ReleaseError
 from release_utils import (
     continue_or_exit,
     current_distribution_by_website,
@@ -49,7 +50,6 @@ from release_vars import (
     SANITY_DIR,
     SCRIPTS_DIR,
     TMP_DIR,
-    ReleaseError,
     execute,
 )
 from sanity_checks import javac_sanity_check, maven_sanity_check

--- a/docs/developer/release/release_utils.py
+++ b/docs/developer/release/release_utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 """
 releaseutils.py
 
@@ -10,15 +9,16 @@ Created by Jonathan Burke 11/21/2012
 Copyright (c) 2012 University of Washington
 """
 
-import urllib.request
-import urllib.error
-import urllib.parse
-import re
-import subprocess
 import os
 import os.path
+import re
 import shutil
-from release_vars import execute
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from release_vars import ReleaseError, execute
 
 # =========================================================================================
 # Parse Args Utils # TODO: Perhaps use argparse module
@@ -41,23 +41,20 @@ def execute_write_to_file(
     command_args, output_file_path, halt_if_fail=True, working_dir=None
 ):
     """Execute the given command, capturing the output to the given file."""
-    print("Executing: %s" % (command_args))
+    print(f"Executing: {command_args}")
     import shlex
 
     args = shlex.split(command_args) if isinstance(command_args, str) else command_args
 
-    output_file = open(output_file_path, "w+")
-    process = subprocess.Popen(
-        args, stdout=output_file, stderr=output_file, cwd=working_dir
-    )
-    process.communicate()
-    process.wait()
-    output_file.close()
+    with open(output_file_path, "w+") as output_file:
+        process = subprocess.Popen(
+            args, stdout=output_file, stderr=output_file, cwd=working_dir
+        )
+        process.communicate()
+        process.wait()
 
     if process.returncode != 0 and halt_if_fail:
-        raise Exception(
-            "Error %s while executing %s" % (process.returncode, command_args)
-        )
+        raise ReleaseError(f"Error {process.returncode} while executing {command_args}")
 
 
 def check_command(command):
@@ -65,8 +62,8 @@ def check_command(command):
     is installed and on the PATH."""
     p = execute(["which", command], False)
     if p:
-        raise AssertionError("command not found: %s" % command)
-    print("")
+        raise AssertionError(f"command not found: {command}")
+    print()
 
 
 def prompt_yes_no(msg, default=False):
@@ -78,9 +75,7 @@ def prompt_yes_no(msg, default=False):
 
     result = prompt_w_default(msg, default_str, "^(Yes|yes|No|no)$")
 
-    if result == "yes" or result == "Yes":
-        return True
-    return False
+    return bool(result == "yes" or result == "Yes")
 
 
 def prompt_yn(msg):
@@ -105,7 +100,7 @@ def prompt_w_default(msg, default, valid_regex=None):
     If default is None, requires an answer."""
     answer = None
     while answer is None:
-        answer = input(msg + " (%s): " % default)
+        answer = input(msg + f" ({default}): ")
 
         if answer is None or answer == "":
             answer = default
@@ -129,14 +124,12 @@ def check_tools(tools):
     print("\nChecking to make sure the following programs are installed:")
     print(", ".join(tools))
     print(
-        (
-            "Note: If you are NOT working in the Release Docker image then you "
-            + "likely need to change the variables that are set in release.py\n"
-            + 'Search for "Set environment variables".'
-        )
+        "Note: If you are NOT working in the Release Docker image then you "
+        + "likely need to change the variables that are set in release.py\n"
+        + 'Search for "Set environment variables".'
     )
     list(map(check_command, tools))
-    print("")
+    print()
 
 
 def continue_or_exit(msg):
@@ -145,7 +138,7 @@ def continue_or_exit(msg):
         msg + " Continue ('no' will exit the script)?", "yes", "^(Yes|yes|No|no)$"
     )
     if continue_script == "no" or continue_script == "No":
-        raise Exception("User elected NOT to continue at prompt: " + msg)
+        raise ReleaseError("User elected NOT to continue at prompt: " + msg)
 
 
 # =========================================================================================
@@ -193,7 +186,7 @@ def current_distribution_by_website(site):
     Reads the checker framework version from the checker framework website and
     returns the version of the current release.
     """
-    print("Looking up checker-framework-version from %s\n" % site)
+    print(f"Looking up checker-framework-version from {site}\n")
     ver_re = re.compile(
         r"<!-- checker-framework-zip-version -->checker-framework-(.*)\.zip"
     )
@@ -210,9 +203,7 @@ def git_bare_repo_exists_at_path(
     repo_root,
 ):  # Bare git repos have no .git directory but they have a refs directory
     "Returns whether a bare git repository exists at the given filesystem path."
-    if os.path.isdir(repo_root + "/refs"):
-        return True
-    return False
+    return bool(os.path.isdir(repo_root + "/refs"))
 
 
 def git_repo_exists_at_path(repo_root):
@@ -227,9 +218,9 @@ def push_changes_prompt_if_fail(repo_root):
     if they would like to try again. Loop until pushing changes succeeds or the
     user answers opts to not try again."""
     while True:
-        cmd = "(cd %s && git push --tags)" % repo_root
+        cmd = f"(cd {repo_root} && git push --tags)"
         result = os.system(cmd)
-        cmd = "(cd %s && git push origin master)" % repo_root
+        cmd = f"(cd {repo_root} && git push origin master)"
         result = os.system(cmd)
         if result == 0:
             break
@@ -271,8 +262,8 @@ def commit_tag_and_push(version, path, tag_prefix):
     push these changes."""
     # Do nothing (instead of erring) if there is nothing to commit.
     if execute("git diff-index --quiet HEAD", False, False, working_dir=path) != 0:
-        execute('git commit -a -m "new release %s"' % (version), working_dir=path)
-    execute("git tag %s%s" % (tag_prefix, version), working_dir=path)
+        execute(f'git commit -a -m "new release {version}"', working_dir=path)
+    execute(f"git tag {tag_prefix}{version}", working_dir=path)
     push_changes(path)
 
 
@@ -309,7 +300,7 @@ def clone(src_repo, dst_repo, bareflag):
     flags = ""
     if bareflag:
         flags = "--bare"
-    execute("git clone --quiet %s %s %s" % (flags, src_repo, dst_repo))
+    execute(f"git clone --quiet {flags} {src_repo} {dst_repo}")
 
 
 def is_repo_cleaned_and_updated(repo):
@@ -342,27 +333,21 @@ def is_repo_cleaned_and_updated(repo):
 def check_repos(repos, fail_on_error, is_intermediate_repo_list):
     """Fail if the repository is not clean and up to date."""
     for repo in repos:
-        if git_repo_exists_at_path(repo):
-            if not is_repo_cleaned_and_updated(repo):
-                if is_intermediate_repo_list:
-                    print(
-                        (
-                            "\nWARNING: Intermediate repository "
-                            + repo
-                            + " is not up to date with respect to the live repository.\n"
-                            + "A separate warning will not be issued for a build repository that is cloned off of the intermediate repository."
-                        )
-                    )
-                if fail_on_error:
-                    raise Exception("repo %s is not cleaned and updated!" % repo)
-                else:
-                    if not prompt_yn(
-                        "%s is not clean and up to date! Continue (answering 'n' will exit the script)?"
-                        % repo
-                    ):
-                        raise Exception(
-                            "%s is not clean and up to date! Halting!" % repo
-                        )
+        if git_repo_exists_at_path(repo) and not is_repo_cleaned_and_updated(repo):
+            if is_intermediate_repo_list:
+                print(
+                    "\nWARNING: Intermediate repository "
+                    + repo
+                    + " is not up to date with respect to the live repository.\n"
+                    + "A separate warning will not be issued for a build repository that is cloned off of the intermediate repository."
+                )
+            if fail_on_error:
+                raise ReleaseError(f"repo {repo} is not cleaned and updated!")
+            else:
+                if not prompt_yn(
+                    f"{repo} is not clean and up to date! Continue (answering 'n' will exit the script)?"
+                ):
+                    raise ReleaseError(f"{repo} is not clean and up to date! Halting!")
 
 
 def get_tag_line(lines, revision, tag_prefixes):
@@ -397,12 +382,12 @@ def get_commit_for_tag(revision, repo_file_path, tag_prefixes):
 
     commit = lines[0]
     if commit is None:
-        msg = "Could not find revision %s in repo %s using tags %s " % (
+        msg = "Could not find revision {} in repo {} using tags {} ".format(
             revision,
             repo_file_path,
             ",".join(tag_prefixes),
         )
-        raise Exception(msg)
+        raise ReleaseError(msg)
 
     return commit
 
@@ -415,7 +400,7 @@ def wget_file(source_url, destination_dir):
     """Download a file from the source URL to the given destination directory.
     Useful since download_binary does not seem to work on source files."""
     print("DEST DIR: " + destination_dir)
-    execute("wget %s" % source_url, True, False, destination_dir)
+    execute(f"wget {source_url}", True, False, destination_dir)
 
 
 def download_binary(source_url, destination):
@@ -425,31 +410,28 @@ def download_binary(source_url, destination):
     content_length = http_response.headers["content-length"]
 
     if content_length is None:
-        raise Exception("No content-length when downloading: " + source_url)
+        raise ReleaseError("No content-length when downloading: " + source_url)
 
-    dest_file = open(destination, "wb")
-    dest_file.write(http_response.read())
-    dest_file.close()
+    with open(destination, "wb") as dest_file:
+        dest_file.write(http_response.read())
 
 
 def read_first_line(file_path):
     "Return the first line in the given file. Assumes the file exists."
-    infile = open(file_path, "r")
-    first_line = infile.readline()
-    infile.close()
-    return first_line
+    with open(file_path, "r") as infile:
+        return infile.readline()
 
 
 def ensure_group_access(path):
     "Give group access to all files and directories under the specified path"
     # Errs for any file not owned by this user.
     # But, the point is to set group writeability of any *new* files.
-    execute("chmod -f -R g+rw %s" % path, halt_if_fail=False)
+    execute(f"chmod -f -R g+rw {path}", halt_if_fail=False)
 
 
 def ensure_user_access(path):
     "Give the user access to all files and directories under the specified path"
-    execute("chmod -f -R u+rwx %s" % path, halt_if_fail=True)
+    execute(f"chmod -f -R u+rwx {path}", halt_if_fail=True)
 
 
 def set_umask():
@@ -485,18 +467,17 @@ def are_in_file(file_path, strs_to_find):
     """Returns true if every string in the given strs_to_find array is found in
     at least one line in the given file. In particular, returns true if
     strs_to_find is empty. Note that the strs_to_find parameter is mutated."""
-    infile = open(file_path)
+    with open(file_path) as infile:
+        for line in infile:
+            if len(strs_to_find) == 0:
+                return True
 
-    for line in infile:
-        if len(strs_to_find) == 0:
-            return True
-
-        index = 0
-        while index < len(strs_to_find):
-            if strs_to_find[index] in line:
-                del strs_to_find[index]
-            else:
-                index = index + 1
+            index = 0
+            while index < len(strs_to_find):
+                if strs_to_find[index] in line:
+                    del strs_to_find[index]
+                else:
+                    index = index + 1
 
     return len(strs_to_find) == 0
 
@@ -509,22 +490,18 @@ def insert_before_line(to_insert, file_path, line):
     with open(file_path) as infile:
         content = infile.readlines()
 
-    output = open(file_path, "w")
-    for i in range(0, mid_line):
-        output.write(content[i])
+    with open(file_path, "w") as output:
+        output.writelines(content[i] for i in range(mid_line))
 
-    output.write(to_insert)
+        output.write(to_insert)
 
-    for i in range(mid_line, len(content)):
-        output.write(content[i])
-
-    output.close()
+        output.writelines(content[i] for i in range(mid_line, len(content)))
 
 
 def create_empty_file(file_path):
     "Creates an empty file with the given filename."
-    dest_file = open(file_path, "wb")
-    dest_file.close()
+    with open(file_path, "wb"):
+        pass
 
 
 # =========================================================================================
@@ -537,7 +514,7 @@ def print_step(step):
     print(step)
 
     dashStr = ""
-    for dummy in range(0, len(step)):
+    for dummy in range(len(step)):
         dashStr += "-"
     print(dashStr)
 
@@ -545,9 +522,9 @@ def print_step(step):
 def get_announcement_email(version):
     """Return the template for the e-mail announcing a new release of the
     Checker Framework."""
-    return """
+    return f"""
 To:  checker-framework-discuss@googlegroups.com
-Subject: Release %s of the Checker Framework
+Subject: Release {version} of the Checker Framework
 
 We have released a new version of the Checker Framework.
 The Checker Framework lets you create and/or run pluggable type checkers, in order to detect and prevent bugs in your code.
@@ -555,13 +532,10 @@ The Checker Framework lets you create and/or run pluggable type checkers, in ord
 You can find documentation and download links at:
 http://eisop.github.io/
 
-Changes for Checker Framework version %s:
+Changes for Checker Framework version {version}:
 
 <<Insert latest Checker Framework changelog entry from https://github.com/eisop/checker-framework/blob/master/docs/CHANGELOG.md, preserving its formatting.>>
-""" % (
-        version,
-        version,
-    )
+"""
 
 
 # =========================================================================================

--- a/docs/developer/release/release_utils.py
+++ b/docs/developer/release/release_utils.py
@@ -18,7 +18,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from release_vars import ReleaseError, execute
+from release_errors import ReleaseError
+from release_vars import execute
 
 # =========================================================================================
 # Parse Args Utils # TODO: Perhaps use argparse module

--- a/docs/developer/release/release_vars.py
+++ b/docs/developer/release/release_vars.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 """
 release_vars.py
 
@@ -14,8 +13,13 @@ Copyright (c) 2014 University of Washington. All rights reserved.
 
 import os
 import pwd
-import subprocess
 import shlex
+import subprocess
+
+
+class ReleaseError(Exception):
+    """Raised for any failure in the release scripts (release_vars.py,
+    release_utils.py, release_build.py, release_push.py, sanity_checks.py)."""
 
 
 # ---------------------------------------------------------------------------------
@@ -42,9 +46,9 @@ def execute(command_args, halt_if_fail=True, capture_output=False, working_dir=N
     """
 
     if working_dir is not None:
-        print("Executing in %s: %s" % (working_dir, command_args))
+        print(f"Executing in {working_dir}: {command_args}")
     else:
-        print("Executing: %s" % (command_args))
+        print(f"Executing: {command_args}")
     args = shlex.split(command_args) if isinstance(command_args, str) else command_args
 
     if capture_output:
@@ -56,8 +60,8 @@ def execute(command_args, halt_if_fail=True, capture_output=False, working_dir=N
     else:
         result = subprocess.call(args, cwd=working_dir)
         if halt_if_fail and result:
-            raise Exception(
-                "Error %s while executing %s in %s" % (result, args, working_dir)
+            raise ReleaseError(
+                f"Error {result} while executing {args} in {working_dir}"
             )
         return result
 

--- a/docs/developer/release/release_vars.py
+++ b/docs/developer/release/release_vars.py
@@ -16,11 +16,7 @@ import pwd
 import shlex
 import subprocess
 
-
-class ReleaseError(Exception):
-    """Raised for any failure in the release scripts (release_vars.py,
-    release_utils.py, release_build.py, release_push.py, sanity_checks.py)."""
-
+from release_errors import ReleaseError
 
 # ---------------------------------------------------------------------------------
 # The only methods that should go here are methods that help define global release

--- a/docs/developer/release/sanity_checks.py
+++ b/docs/developer/release/sanity_checks.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 """
 releaseutils.py
 
@@ -12,21 +11,24 @@ Copyright (c) 2012 University of Washington
 
 import zipfile
 
-from release_vars import CHECKER_FRAMEWORK
-from release_vars import CHECKER_FRAMEWORK_RELEASE
-from release_vars import SANITY_DIR
-
-from release_vars import execute
-
-from release_utils import are_in_file
-from release_utils import delete
-from release_utils import delete_path
-from release_utils import download_binary
-from release_utils import ensure_user_access
-from release_utils import execute_write_to_file
-from release_utils import insert_before_line
-from release_utils import os
-from release_utils import wget_file
+from release_utils import (
+    are_in_file,
+    delete,
+    delete_path,
+    download_binary,
+    ensure_user_access,
+    execute_write_to_file,
+    insert_before_line,
+    os,
+    wget_file,
+)
+from release_vars import (
+    CHECKER_FRAMEWORK,
+    CHECKER_FRAMEWORK_RELEASE,
+    SANITY_DIR,
+    ReleaseError,
+    execute,
+)
 
 
 def javac_sanity_check(checker_framework_website, release_version):
@@ -51,12 +53,10 @@ def javac_sanity_check(checker_framework_website, release_version):
     execute("mkdir -p " + javac_sanity_dir)
 
     javac_sanity_zip = os.path.join(
-        javac_sanity_dir, "checker-framework-%s.zip" % release_version
+        javac_sanity_dir, f"checker-framework-{release_version}.zip"
     )
 
-    print(
-        "Attempting to download %s to %s" % (new_checkers_release_zip, javac_sanity_zip)
-    )
+    print(f"Attempting to download {new_checkers_release_zip} to {javac_sanity_zip}")
     download_binary(new_checkers_release_zip, javac_sanity_zip)
 
     nullness_example_url = "https://raw.githubusercontent.com/eisop/checker-framework/master/docs/examples/NullnessExampleWithWarnings.java"
@@ -135,10 +135,7 @@ def maven_sanity_check(sub_sanity_dir_name, repo_url, release_version):
     output_log = os.path.join(maven_example_dir, "output.log")
 
     ant_release_script = os.path.join(CHECKER_FRAMEWORK_RELEASE, "release.xml")
-    get_example_dir_cmd = (
-        "ant -f %s update-and-copy-maven-example -Dchecker=%s -Dversion=%s -Ddest.dir=%s"
-        % (ant_release_script, checker_dir, release_version, maven_sanity_dir)
-    )
+    get_example_dir_cmd = f"ant -f {ant_release_script} update-and-copy-maven-example -Dchecker={checker_dir} -Dversion={release_version} -Ddest.dir={maven_sanity_dir}"
 
     execute(get_example_dir_cmd)
     path_to_artifacts = os.path.join(
@@ -146,12 +143,10 @@ def maven_sanity_check(sub_sanity_dir_name, repo_url, release_version):
     )
     if repo_url != "":
         print(
-            (
-                "This script will now delete your Maven Checker Framework artifacts.\n"
-                + "See README-release-process.html#Maven-Plugin dependencies.  These artifacts "
-                + "will need to be re-downloaded the next time you need them.  This will be "
-                + "done automatically by Maven next time you use the plugin."
-            )
+            "This script will now delete your Maven Checker Framework artifacts.\n"
+            + "See README-release-process.html#Maven-Plugin dependencies.  These artifacts "
+            + "will need to be re-downloaded the next time you need them.  This will be "
+            + "done automatically by Maven next time you use the plugin."
         )
 
         if os.path.isdir(path_to_artifacts):
@@ -174,7 +169,7 @@ def check_results(title, output_log, expected_errors):
     found_errors = are_in_file(output_log, expected_errors)
 
     if not found_errors:
-        raise Exception(
+        raise ReleaseError(
             title
             + " did not work!\n"
             + "File: "
@@ -184,32 +179,29 @@ def check_results(title, output_log, expected_errors):
             + ", ".join(expected_errors)
         )
     else:
-        print("%s check: passed!\n" % title)
+        print(f"{title} check: passed!\n")
 
 
 def add_repo_information(pom, repo_url):
     """Adds development maven repo to pom file so that the artifacts used are
     the development artifacts"""
-    to_insert = """
+    to_insert = f"""
         <repositories>
               <repository>
                   <id>checker-framework-repo</id>
-                  <url>%s</url>
+                  <url>{repo_url}</url>
               </repository>
         </repositories>
 
         <pluginRepositories>
               <pluginRepository>
                     <id>checker-framework-repo</id>
-                    <url>%s</url>
+                    <url>{repo_url}</url>
               </pluginRepository>
         </pluginRepositories>
-        """ % (
-        repo_url,
-        repo_url,
-    )
+        """
 
-    result_str = execute('grep -nm 1 "<build>" %s' % pom, True, True).decode()
+    result_str = execute(f'grep -nm 1 "<build>" {pom}', True, True).decode()
     line_no_str = result_str.split(":")[0]
     line_no = int(line_no_str)
     print(" LINE_NO: " + line_no_str)

--- a/docs/developer/release/sanity_checks.py
+++ b/docs/developer/release/sanity_checks.py
@@ -11,6 +11,7 @@ Copyright (c) 2012 University of Washington
 
 import zipfile
 
+from release_errors import ReleaseError
 from release_utils import (
     are_in_file,
     delete,
@@ -26,7 +27,6 @@ from release_vars import (
     CHECKER_FRAMEWORK,
     CHECKER_FRAMEWORK_RELEASE,
     SANITY_DIR,
-    ReleaseError,
     execute,
 )
 


### PR DESCRIPTION
The "misc" CI job's Python lint step (`make style-check` -> `ruff check`/`ruff format --check` over `docs/developer/release/*.py` and `.claude/skills/cf-performance/*.py`) was failing on every open PR, including PRs whose diff never touches Python -- root-caused in #1885's discussion: ruff 0.16.0 landed with new/stricter default findings against these files, and the failure appeared on an unmodified master commit that had passed CI a day earlier -- same commit, no code change, just a newer ruff.

**Where ruff actually comes from for this job:** the `misc` job (`.github/workflows/ci.yml`, `remainder` job) runs directly on the `ubuntu-24.04` GitHub-hosted runner, not inside any of the repo's Docker images -- an earlier version of this PR pinned ruff in those Dockerfiles, which turned out to have no effect on CI at all. The real install is the repo-root `Makefile`'s `install-ruff` target:

```makefile
install-ruff:
	@if ! command -v ruff ; then pipx install ruff ; fi
```

which only runs `pipx install ruff` (unpinned) when ruff isn't already on PATH.

Two commits:

1. **Pin ruff to 0.16.0** by adding it to the existing "Install Python tools" step in `.github/actions/setup-misc/action.yml` (alongside black/flake8/html5validator, which stay unpinned by choice -- out of scope here). Installing it there means `command -v ruff` finds this pinned copy first, so the Makefile's own fallback install becomes a no-op for CI, while `make style-check` run locally by a developer (no CI setup step involved) keeps its existing get-latest-ruff behavior unchanged.
2. **Fix the 98 findings** ruff 0.16.0 reports against the 7 real files in scope (the 8th file the Makefile's file-glob picks up, `checker/bin-devel/.html-tools/dummy.py`, is gitignored and CI-generated, not part of the source tree). Mechanical fixes were tool-applied (`ruff check --fix`, then `--fix --unsafe-fixes` after reviewing the diff) and verified semantics-preserving -- no dynamic width/precision specifiers in any `%`-to-f-string conversion, import consolidation checked name-for-name against an AST dump of the originals. Findings ruff can't auto-fix were handled by hand:
   - **TRY002** (15 sites): added a shared `ReleaseError(Exception)` to `release_vars.py` and raise that instead of bare `Exception`. None of these scripts catch exceptions themselves (release automation fails loudly by design), so this is a pure rename.
   - **SIM115** (7 sites): converted to `with open(...) as f:`, closing at the same point the original explicit `.close()` did.
   - **SIM102** (2 sites): merged a nested `if` into its parent with `and`.
   - **DTZ011** (1 site): `release_build.py`'s `get_current_date()` used `datetime.date.today()`. ruff's suggested fix (`datetime.now(tz=utc).date()`) would silently change behavior -- UTC instead of the releaser's local calendar day, which is what a human-run release script should stamp. Used `datetime.now().astimezone().date()` instead: timezone-aware (satisfies the rule), same local date as before.

**Verification:** `ruff check` and `ruff format --check` (ruff 0.16.0) both pass on all 8 files the Makefile lints. `python3 -m py_compile` on every touched file. Ran `gen-sized-program.py` directly (the only touched script with no release-environment side effects at import time) to confirm its reformatted line still emits correct Java. The `release_*.py`/`sanity_checks.py` scripts have module-level side effects (read `pwd`/`os.environ`, shell out to git/gradle) and can't be safely executed outside a real release environment -- verification there is static analysis plus manual review of every diff hunk. Full CI run confirms `misc on JDK 21`/`misc on JDK 26` now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHhVqLoJukm4kKsE7UfY4

---

**Update:** two follow-up commits address review feedback:
3. Moved `ReleaseError` out of `release_vars.py` into a new `release_errors.py`. It didn't fit either `release_vars.py`'s or `release_utils.py`'s stated scope well, and `release_utils.py` isn't a drop-in alternative -- it already imports from `release_vars.py`, so importing `ReleaseError` back the other way would be a circular import (verified with a standalone repro).
4. Added a Renovate custom `regexManager` (matching the existing `USE_BAZEL_VERSION`/`JDK_EA_BUILD` pattern in `.github/renovate.json`) so the `ruff==0.16.0` pin gets automatic update PRs going forward -- Dependabot's `github-actions` ecosystem doesn't cover version strings inside `run:` steps, so it wouldn't have picked this up.
