### PR TITLE
Share the fake-override search between the text and binary stub loaders

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -117,7 +117,6 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
-import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -2260,34 +2259,26 @@ public class AnnotationFileParser {
      */
     private @Nullable ExecutableElement fakeOverriddenMethod(
             TypeElement typeElt, MethodDeclaration methodDecl) {
-        // Two passes: first look for a candidate whose every parameter matches exactly; only if
-        // none does, retry accepting any candidate parameter whose type is a type variable.  The
-        // lenient pass is needed because a type-variable parameter's javac type has no textual
-        // form that reliably matches the stub's spelling (see the comment in sameTypes).  But
-        // running only the lenient pass would let a stub parameter such as "String" match a
-        // type-variable parameter "T" -- and "<T> void f(T)" and "void f(String)" legally coexist
-        // as overloads (erasures f(Object) and f(String)), so a fake override "f(String)" could
-        // bind to whichever overload happens to be visited first.  The exact pass binds it to
-        // f(String).
-        ExecutableElement exactMatch =
-                fakeOverriddenMethod(typeElt, methodDecl, /* typevarLenient= */ false);
-        if (exactMatch != null) {
-            return exactMatch;
-        }
-        return fakeOverriddenMethod(typeElt, methodDecl, /* typevarLenient= */ true);
+        return FakeOverrideResolver.findFakeOverridden(
+                typeElt,
+                (candidate, typevarLenient) ->
+                        declaredMethodMatching(candidate, methodDecl, typevarLenient));
     }
 
     /**
-     * Implementation of {@link #fakeOverriddenMethod(TypeElement, MethodDeclaration)} for one
-     * matching mode.
+     * Returns the method that {@code typeElt} itself declares that matches {@code methodDecl} in
+     * the given mode, or null if it declares none. Inspects only {@code typeElt}'s own declared
+     * methods; {@link FakeOverrideResolver} walks the class hierarchy. This is the text parser's
+     * leaf comparison for {@link FakeOverrideResolver.FakeOverrideMatcher}.
      *
-     * @param typeElt the type in which the method appears
+     * @param typeElt the type whose own declared methods to search
      * @param methodDecl the method declaration that does not correspond to an element
      * @param typevarLenient if true, a candidate parameter whose type is a type variable matches
      *     any declared parameter type in the same position; see {@link #sameTypes}
-     * @return the methods that the given method declaration would override, or null if none
+     * @return the method {@code typeElt} declares that {@code methodDecl} would override, or null
+     *     if none does or the match is ambiguous
      */
-    private @Nullable ExecutableElement fakeOverriddenMethod(
+    private @Nullable ExecutableElement declaredMethodMatching(
             TypeElement typeElt, MethodDeclaration methodDecl, boolean typevarLenient) {
         ExecutableElement match = null;
         for (Element elt : typeElt.getEnclosedElements()) {
@@ -2319,29 +2310,7 @@ public class AnnotationFileParser {
                 match = candidate;
             }
         }
-        if (match != null) {
-            return match;
-        }
-
-        TypeElement superType = ElementUtils.getSuperClass(typeElt);
-        if (superType != null) {
-            ExecutableElement result = fakeOverriddenMethod(superType, methodDecl, typevarLenient);
-            if (result != null) {
-                return result;
-            }
-        }
-
-        for (TypeMirror interfaceTypeMirror : typeElt.getInterfaces()) {
-            TypeElement interfaceElement =
-                    (TypeElement) ((DeclaredType) interfaceTypeMirror).asElement();
-            ExecutableElement result =
-                    fakeOverriddenMethod(interfaceElement, methodDecl, typevarLenient);
-            if (result != null) {
-                return result;
-            }
-        }
-
-        return null;
+        return match;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/stub/BinaryStubReader.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/BinaryStubReader.java
@@ -27,7 +27,6 @@ import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -910,105 +909,31 @@ public class BinaryStubReader {
     }
 
     /**
-     * Searches the supertypes of {@code typeElt} (superclasses and interfaces, recursively) for a
-     * method with the given simple signature, mirroring {@code
-     * AnnotationFileParser.fakeOverriddenMethod}.
+     * Searches {@code typeElt} and its supertypes for a method with the given simple signature that
+     * a fake override declared on {@code typeElt} overrides or implements, or {@code null} if none
+     * matches. Delegates the hierarchy traversal to {@link FakeOverrideResolver}, the same search
+     * the text parser uses; only the per-class leaf comparison ({@link #declaredMethod}) is binary
+     * specific.
      *
-     * @param typeElt the class whose supertypes to search; its own declared methods have already
-     *     been checked by the caller
+     * <p>The caller has already established that {@code typeElt} does not declare {@code sig}
+     * exactly (that is what makes this a fake override rather than a real method), so the shared
+     * search's exact pass over {@code typeElt}'s own methods is a no-op here; its lenient pass over
+     * {@code typeElt}'s own methods still matters, because a type variable renamed between the stub
+     * and the JDK being compiled against means the class does declare the method under a different
+     * spelling (e.g. the stub declares {@code ConcurrentSkipListMap.KeySet<K,V>.ceiling(K)}, while
+     * JDK 8's {@code KeySet<E>} declares {@code ceiling(E)}).
+     *
+     * @param typeElt the class the fake override is declared on
      * @param sig the method's simple signature
      * @param elementTypes per-factory state, providing the per-class signature indexes
-     * @return the overridden method, or {@code null} if no supertype declares one
+     * @return the overridden method, or {@code null} if none matches
      */
     static @Nullable ExecutableElement findFakeOverriddenMethod(
             TypeElement typeElt, String sig, AnnotationFileElementTypes elementTypes) {
-        ExecutableElement exact =
-                findFakeOverriddenMethod(
-                        typeElt,
-                        sig,
-                        elementTypes,
-                        Collections.newSetFromMap(new IdentityHashMap<>()),
-                        /* typevarLenient= */ false);
-        if (exact != null) {
-            return exact;
-        }
-        // The lenient pass starts at typeElt's own methods, as the text parser's does
-        // (AnnotationFileParser.fakeOverriddenMethod scans getEnclosedElements() before recurring
-        // to supertypes, in both passes). The caller has already looked typeElt up exactly, and
-        // failed, but a type variable renamed between the stub and the JDK being compiled against
-        // means the class does declare the method under a different spelling: the stub declares
-        // ConcurrentSkipListMap.KeySet<K,V>.ceiling(K), while JDK 8's KeySet<E> declares
-        // ceiling(E). Without this, the two loaders key the entry by different overridden
-        // methods -- this class's own, or the one it inherits from NavigableSet.
-        ExecutableElement ownLenient =
-                declaredMethod(typeElt, sig, elementTypes, /* typevarLenient= */ true);
-        if (ownLenient != null) {
-            return ownLenient;
-        }
-        return findFakeOverriddenMethod(
+        return FakeOverrideResolver.findFakeOverridden(
                 typeElt,
-                sig,
-                elementTypes,
-                Collections.newSetFromMap(new IdentityHashMap<>()),
-                /* typevarLenient= */ true);
-    }
-
-    /**
-     * Worker for {@link #findFakeOverriddenMethod(TypeElement, String,
-     * AnnotationFileElementTypes)}.
-     *
-     * @param typeElt the class whose supertypes to search
-     * @param sig the method's simple signature
-     * @param elementTypes per-factory state, providing the per-class signature indexes
-     * @param visited interfaces already searched, to avoid re-traversing a shared ancestor
-     *     interface reachable through more than one path (diamond inheritance)
-     * @param typevarLenient whether a type-variable parameter of a candidate method matches any
-     *     type the signature spells in that position
-     * @return the overridden method, or {@code null} if no supertype declares one
-     */
-    private static @Nullable ExecutableElement findFakeOverriddenMethod(
-            TypeElement typeElt,
-            String sig,
-            AnnotationFileElementTypes elementTypes,
-            Set<TypeElement> visited,
-            boolean typevarLenient) {
-        TypeElement superClass = ElementUtils.getSuperClass(typeElt);
-        if (superClass != null) {
-            ExecutableElement found = declaredMethod(superClass, sig, elementTypes, typevarLenient);
-            if (found == null) {
-                found =
-                        findFakeOverriddenMethod(
-                                superClass, sig, elementTypes, visited, typevarLenient);
-            }
-            if (found != null) {
-                return found;
-            }
-        }
-        for (TypeMirror interfaceType : typeElt.getInterfaces()) {
-            if (interfaceType.getKind() != TypeKind.DECLARED) {
-                continue;
-            }
-            Element interfaceElt = ((javax.lang.model.type.DeclaredType) interfaceType).asElement();
-            if (!(interfaceElt instanceof TypeElement)
-                    || !visited.add((TypeElement) interfaceElt)) {
-                continue;
-            }
-            ExecutableElement found =
-                    declaredMethod((TypeElement) interfaceElt, sig, elementTypes, typevarLenient);
-            if (found == null) {
-                found =
-                        findFakeOverriddenMethod(
-                                (TypeElement) interfaceElt,
-                                sig,
-                                elementTypes,
-                                visited,
-                                typevarLenient);
-            }
-            if (found != null) {
-                return found;
-            }
-        }
-        return null;
+                (candidate, typevarLenient) ->
+                        declaredMethod(candidate, sig, elementTypes, typevarLenient));
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/stub/FakeOverrideResolver.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/FakeOverrideResolver.java
@@ -1,0 +1,163 @@
+package org.checkerframework.framework.stub;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.javacutil.ElementUtils;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * The shared "fake override" search that both stub-annotation loaders use to bind a stub-declared
+ * method that a class only inherits to the method it fake-overrides.
+ *
+ * <p>A <em>fake override</em> is a method a stub file (or the annotated JDK) declares on a class
+ * that does not itself declare that method, only inherits it; the declaration's annotations apply
+ * to the inherited method as seen through that subtype (see {@code
+ * AnnotationFileParser#processFakeOverride}). To store such a declaration, a loader must find the
+ * inherited method it targets. Both loaders search the same way, so the search lives here and each
+ * loader supplies only the leaf comparison -- "which method, if any, does <em>this one</em> class
+ * declare that this fake override matches" -- via a {@link FakeOverrideMatcher}, because the two
+ * loaders represent the fake-override declaration differently (the text parser matches against a
+ * parsed {@code .astub} {@code MethodDeclaration}; the binary reader matches against a compact
+ * signature string). Sharing the traversal is what keeps the two paths from drifting apart, as they
+ * once did: the binary path searched supertypes before the class's own methods and silently dropped
+ * 21 fake overrides in the annotated JDK (see commit db83617a4 and issue #1865).
+ *
+ * <p>The search is two passes over the class hierarchy. The first (exact) pass requires every
+ * parameter to match; only if it finds nothing does the second (lenient) pass run, in which a
+ * candidate parameter whose type is a type variable matches whatever the fake override spells in
+ * that position -- a type-variable parameter has no textual form that reliably matches a stub's
+ * spelling, and a type variable renamed between the stub and the JDK being compiled against (e.g.
+ * {@code KeySet<K,V>.ceiling(K)} in the stub versus {@code KeySet<E>.ceiling(E)} in JDK 8) means
+ * the class does declare the method, under another spelling. Running only the lenient pass would
+ * let a stub parameter such as {@code String} bind to a type-variable overload, so the exact pass
+ * is tried first. Within each pass, a class's own declared methods are searched before its
+ * superclass, and its superclass before its interfaces, as Java resolves overrides; the {@link
+ * FakeOverrideMatcher} decides an ambiguous match (two of one class's overloads matching) is no
+ * match, again as an override would be reported ambiguous.
+ */
+final class FakeOverrideResolver {
+
+    /** Do not instantiate. */
+    private FakeOverrideResolver() {
+        throw new AssertionError("Class FakeOverrideResolver cannot be instantiated.");
+    }
+
+    /**
+     * Decides, for one class at a time, which method (if any) that class itself declares matches
+     * the fake override being resolved. This is the only part of the search that differs between
+     * the text and binary loaders; {@link FakeOverrideResolver#findFakeOverridden} supplies the
+     * shared traversal over the class hierarchy that repeatedly calls it.
+     */
+    @FunctionalInterface
+    interface FakeOverrideMatcher {
+        /**
+         * Returns the method that {@code typeElt} itself declares that matches the fake override
+         * being resolved, or {@code null} if it declares none (including when the match is
+         * ambiguous, i.e. two of {@code typeElt}'s overloads match: annotating whichever javac
+         * enumerates first would be arbitrary, so this returns {@code null}). This inspects only
+         * {@code typeElt}'s own declared methods, never its supertypes'; the shared traversal walks
+         * the hierarchy.
+         *
+         * @param typeElt the class whose own declared methods to search
+         * @param typevarLenient if true, a candidate parameter whose type in {@code typeElt} is a
+         *     type variable matches whatever the fake override spells in that position; if false,
+         *     every parameter must match exactly
+         * @return the method {@code typeElt} declares that matches, or {@code null} if none does or
+         *     the match is ambiguous
+         */
+        @Nullable ExecutableElement matchDeclaredMethod(
+                TypeElement typeElt, boolean typevarLenient);
+    }
+
+    /**
+     * Returns the method that a fake override declared on {@code typeElt} overrides or implements,
+     * or {@code null} if none matches. As Java does, this prefers a method in a superclass to one
+     * in an interface, and a class's own method to an inherited one.
+     *
+     * <p>Runs the exact pass first over the whole hierarchy, then the lenient pass; see the class
+     * Javadoc for why. The {@code matcher} performs the per-class leaf comparison.
+     *
+     * @param typeElt the class the fake override is declared on
+     * @param matcher the loader-specific per-class leaf comparison
+     * @return the method the fake override overrides or implements, or {@code null} if none matches
+     */
+    static @Nullable ExecutableElement findFakeOverridden(
+            TypeElement typeElt, FakeOverrideMatcher matcher) {
+        ExecutableElement exact =
+                findFakeOverridden(typeElt, matcher, /* typevarLenient= */ false, newVisitedSet());
+        if (exact != null) {
+            return exact;
+        }
+        return findFakeOverridden(typeElt, matcher, /* typevarLenient= */ true, newVisitedSet());
+    }
+
+    /**
+     * Searches {@code typeElt} and its supertypes for a method matching the fake override in the
+     * given mode: {@code typeElt}'s own declared methods first, then (recursively) its superclass,
+     * then (recursively) its interfaces.
+     *
+     * @param typeElt the class to search, together with its supertypes
+     * @param matcher the loader-specific per-class leaf comparison
+     * @param typevarLenient whether a candidate type-variable parameter matches any spelled type;
+     *     see {@link FakeOverrideMatcher#matchDeclaredMethod}
+     * @param visited interfaces already searched in this pass, so a shared ancestor interface
+     *     reachable by more than one path (diamond inheritance) is searched only once
+     * @return the matching method, or {@code null} if none matches in this subtree
+     */
+    private static @Nullable ExecutableElement findFakeOverridden(
+            TypeElement typeElt,
+            FakeOverrideMatcher matcher,
+            boolean typevarLenient,
+            Set<TypeElement> visited) {
+        ExecutableElement own = matcher.matchDeclaredMethod(typeElt, typevarLenient);
+        if (own != null) {
+            return own;
+        }
+
+        TypeElement superClass = ElementUtils.getSuperClass(typeElt);
+        if (superClass != null) {
+            ExecutableElement result =
+                    findFakeOverridden(superClass, matcher, typevarLenient, visited);
+            if (result != null) {
+                return result;
+            }
+        }
+
+        for (TypeMirror interfaceType : typeElt.getInterfaces()) {
+            if (interfaceType.getKind() != TypeKind.DECLARED) {
+                continue;
+            }
+            Element interfaceElt = ((DeclaredType) interfaceType).asElement();
+            if (!(interfaceElt instanceof TypeElement)
+                    || !visited.add((TypeElement) interfaceElt)) {
+                continue;
+            }
+            ExecutableElement result =
+                    findFakeOverridden(
+                            (TypeElement) interfaceElt, matcher, typevarLenient, visited);
+            if (result != null) {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a fresh, identity-keyed set for tracking already-searched interfaces within one pass.
+     *
+     * @return a fresh mutable set of {@link TypeElement}, using identity comparison
+     */
+    private static Set<TypeElement> newVisitedSet() {
+        return Collections.newSetFromMap(new IdentityHashMap<>());
+    }
+}


### PR DESCRIPTION
Fixes eisop#1865.

The text `.astub` parser (`AnnotationFileParser.fakeOverriddenMethod`) and the binary-stub reader (`BinaryStubReader.findFakeOverriddenMethod`) each reimplemented the same "fake override" search — an exact-signature pass, then a type-variable-lenient pass, each walking a class's own declared methods, then its superclass, then its interfaces, refusing an ambiguous match. Because the traversal was duplicated rather than shared, it drifted: the binary path once searched supertypes before the class's own methods, silently dropping 21 fake overrides in the annotated JDK (`Properties`, `ConcurrentSkipListMap.KeySet`, `UnmodifiableHeaders`) — hand-fixed in db83617a4, but nothing prevented the two paths from drifting apart again.

## Fix

Extract the shared traversal into a new package-private `FakeOverrideResolver`, with a `FakeOverrideMatcher` functional interface for the one part that genuinely differs between the loaders — the per-class leaf comparison, "which method, if any, does this one class declare that this fake override matches." The text parser matches against a parsed `MethodDeclaration`; the binary reader against a compact signature string. Both loaders now call the identical shared walk, so this class of divergence is structurally impossible rather than something kept in sync by hand.

The unified walk is: for each pass (exact, then type-variable-lenient), search a class's own declared methods, then its superclass, then its interfaces, deduplicating interfaces reachable by more than one path.

## Behavior

The two loaders produce identical results on every tested input (the differential harness reports 0 mismatches; see below). While unifying, two text-path details are brought into line with the binary path — the direction of the unification this PR exists to enforce — and neither changes the result on any tested input:

- **Diamond-interface dedup.** The text parser's traversal was missing the binary path's dedup and could re-traverse an interface reachable by more than one path; the unified walk dedups for both. This cannot change which method is found — a redundant re-traversal that would have returned non-null already did — only redundant work.

- **Ambiguity handling.** When a class declares two overloads that both match a fake override ambiguously (a warned "write the parameter types fully-qualified" condition), the text parser previously abandoned the whole search from that class and applied no fake override at all. The binary path — and now both — instead treat that class as contributing no match and continue into its supertypes, the same "an ambiguous match is no match" rule the loaders already apply per class, now applied consistently across the hierarchy. This can only produce a different method when an ambiguous class also has a supertype that unambiguously declares the method, which does not arise in the tested corpus.

## Verification

`NullnessBinaryStubDiffTest` (the differential harness comparing text vs. binary stub application): 0 mismatches across all 1652 top-level classes plus the built-in stubs, same as before. All stubparser suites and `:checker:test` pass with 0 failures. No changelog entry — this is an internal refactor with no user-visible behavior change on any real stub.
