### PR TITLE
Viewpoint-adapt overridden method signatures using class declaration bound

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -4674,6 +4674,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             overriddenMethodType = overriddenMethodType.getErased();
         }
 
+        // Viewpoint-adapt the overridden method type to the overriding class.
+        overriddenMethodType =
+                atypeFactory.postAsOverride(
+                        overriddenMethodType, overriderType, overriddenMethodType.getElement());
+
         OverrideChecker overrideChecker =
                 createOverrideChecker(
                         overriderTree,

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1270,8 +1270,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 AnnotatedDeclaredType overriddenType = pair.getKey();
                 ExecutableElement overriddenMethodElt = pair.getValue();
                 AnnotatedExecutableType overriddenMethodType =
-                        AnnotatedTypes.asMemberOf(
-                                types, atypeFactory, overriddenType, overriddenMethodElt);
+                        atypeFactory.overriddenMethodType(
+                                overriddenType, overriddenMethodElt, enclosingType);
                 if (!checkOverride(tree, enclosingType, overriddenMethodType, overriddenType)) {
                     // Stop at the first mismatch; this makes a difference only if
                     // -Awarns is passed, in which case multiple warnings might be raised on
@@ -4673,11 +4673,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 && !overriddenMethodType.getTypeVariables().isEmpty()) {
             overriddenMethodType = overriddenMethodType.getErased();
         }
-
-        // Viewpoint-adapt the overridden method type to the overriding class.
-        overriddenMethodType =
-                atypeFactory.postAsOverride(
-                        overriddenMethodType, overriderType, overriddenMethodType.getElement());
 
         OverrideChecker overrideChecker =
                 createOverrideChecker(

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1283,27 +1283,25 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Viewpoint-adapts an overridden method type to the class that declares the overriding method
-     * before performing an override check.
+     * Returns the type of an overridden method as it should be seen for an override check against
+     * the given overriding class. This computes the overridden method type via {@link
+     * AnnotatedTypes#asMemberOf} and then viewpoint-adapts it to the overriding class.
      *
-     * <p>This method does not modify {@code methodType}; it returns a copy containing the adapted
-     * type.
-     *
-     * @param methodType the type of the overridden method
+     * @param overriddenType the supertype that contains the overridden method
+     * @param overriddenMethodElt the element of the overridden method
      * @param overriderType the type of the class declaring the overriding method
-     * @param methodElt the element of the overridden method
-     * @return the viewpoint-adapted method type to use in the override check
+     * @return the overridden method type, with type variables substituted and viewpoint-adapted to
+     *     the overriding class
      */
-    public AnnotatedExecutableType postAsOverride(
-            AnnotatedExecutableType methodType,
-            AnnotatedDeclaredType overriderType,
-            ExecutableElement methodElt) {
-        if (viewpointAdapter == null) {
-            return methodType;
+    public AnnotatedExecutableType overriddenMethodType(
+            AnnotatedDeclaredType overriddenType,
+            ExecutableElement overriddenMethodElt,
+            AnnotatedDeclaredType overriderType) {
+        AnnotatedExecutableType result =
+                AnnotatedTypes.asMemberOf(types, this, overriddenType, overriddenMethodElt);
+        if (viewpointAdapter != null) {
+            viewpointAdapter.viewpointAdaptMethod(overriderType, overriddenMethodElt, result);
         }
-        // Adaptation mutates its argument, and methodType may be shared, so work on a copy.
-        AnnotatedExecutableType result = methodType.deepCopy();
-        viewpointAdapter.viewpointAdaptMethod(overriderType, methodElt, result);
         return result;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1278,6 +1278,31 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
+     * Viewpoint-adapts an overridden method type to the class that declares the overriding method
+     * before performing an override check.
+     *
+     * <p>This method does not modify {@code methodType}; it returns a copy containing the adapted
+     * type.
+     *
+     * @param methodType the type of the overridden method
+     * @param overriderType the type of the class declaring the overriding method
+     * @param methodElt the element of the overridden method
+     * @return the viewpoint-adapted method type to use in the override check
+     */
+    public AnnotatedExecutableType postAsOverride(
+            AnnotatedExecutableType methodType,
+            AnnotatedDeclaredType overriderType,
+            ExecutableElement methodElt) {
+        if (viewpointAdapter == null) {
+            return methodType;
+        }
+        // Adaptation mutates its argument, and methodType may be shared, so work on a copy.
+        AnnotatedExecutableType result = methodType.deepCopy();
+        viewpointAdapter.viewpointAdaptMethod(overriderType, methodElt, result);
+        return result;
+    }
+
+    /**
      * TypeVariableSubstitutor provides a method to replace type parameters with their arguments.
      */
     protected TypeVariableSubstitutor createTypeVariableSubstitutor() {

--- a/framework/tests/viewpointtest/IntersectionTypes.java
+++ b/framework/tests/viewpointtest/IntersectionTypes.java
@@ -9,13 +9,14 @@ public class IntersectionTypes {
 
     interface Bar {}
 
-    interface Accessor {
+    @ReceiverDependentQual interface Accessor {
         @ReceiverDependentQual Object get();
 
         void set(@ReceiverDependentQual Object o);
     }
 
-    class Baz implements Foo, Bar, Accessor {
+    @SuppressWarnings({"super.invocation.invalid", "inconsistent.constructor.type"})
+    @ReceiverDependentQual class Baz implements Foo, Bar, Accessor {
         @Override
         public @ReceiverDependentQual Object get() {
             return null;
@@ -27,6 +28,7 @@ public class IntersectionTypes {
 
     <T extends Foo & Bar> void call(T p) {}
 
+    @SuppressWarnings("type.invalid.annotations.on.use")
     <T extends Foo & Accessor> void callAccessor(T p) {}
 
     class ViewpointAdaptedIntersectionBound<T extends @ReceiverDependentQual Accessor & Foo> {
@@ -42,7 +44,6 @@ public class IntersectionTypes {
     }
 
     void foo(@A Object aObj, @B Object bObj) {
-        // :: warning: (cast.unsafe.constructor.invocation)
         Baz baz = new @A Baz();
         call(baz);
         callAccessor(baz);
@@ -56,6 +57,7 @@ public class IntersectionTypes {
         baz.set(bObj);
     }
 
+    @SuppressWarnings("type.invalid.annotations.on.use")
     void intersectionCasts(Object obj) {
         Foo fooAndBar = (Foo & Bar) obj;
         Accessor fooAndAccessor = (Foo & Accessor) obj;

--- a/framework/tests/viewpointtest/OverrideViewpointAdaptation.java
+++ b/framework/tests/viewpointtest/OverrideViewpointAdaptation.java
@@ -1,0 +1,151 @@
+// Test that an override check resolves method signatures for the receiver that the overriding
+// method declares. A @ReceiverDependentQual type in the supertype is a template that resolves to
+// the overriding method's receiver qualifier.
+
+import viewpointtest.quals.*;
+
+public class OverrideViewpointAdaptation {
+
+    // spotless:off
+    interface Accessor {
+        // Return type test methods
+        @ReceiverDependentQual Object getReturnExact(@ReceiverDependentQual Accessor this);
+
+        @ReceiverDependentQual Object getReturnNarrowedBottom(@ReceiverDependentQual Accessor this);
+
+        @ReceiverDependentQual Object getReturnWidenedTop(@ReceiverDependentQual Accessor this);
+
+        @ReceiverDependentQual Object getReturnOther(@ReceiverDependentQual Accessor this);
+
+        // Parameter type test methods
+        void setParamExact(@ReceiverDependentQual Accessor this, @ReceiverDependentQual Object o);
+
+        void setParamWidenedTop(
+                @ReceiverDependentQual Accessor this, @ReceiverDependentQual Object o);
+
+        void setParamNarrowedBottom(
+                @ReceiverDependentQual Accessor this, @ReceiverDependentQual Object o);
+
+        void setParamOther(@ReceiverDependentQual Accessor this, @ReceiverDependentQual Object o);
+    }
+
+    // =========================================================================
+    // 1. @A Interface Testing All Method Overrides
+    // =========================================================================
+
+    @A interface SubA extends Accessor {
+
+        // --- Return Type Checks ---
+
+        @Override
+        @A Object getReturnExact(@A SubA this);
+
+        @Override
+        @Bottom Object getReturnNarrowedBottom(@A SubA this);
+
+        @Override
+        // :: error: (override.return.invalid)
+        @Top Object getReturnWidenedTop(@A SubA this);
+
+        @Override
+        // :: error: (override.return.invalid)
+        @B Object getReturnOther(@A SubA this);
+
+        // --- Parameter Type Checks ---
+
+        @Override
+        void setParamExact(@A SubA this, @A Object o);
+
+        @Override
+        void setParamWidenedTop(@A SubA this, @Top Object o);
+
+        @Override
+        // :: error: (override.param.invalid)
+        void setParamNarrowedBottom(@A SubA this, @Bottom Object o);
+
+        @Override
+        // :: error: (override.param.invalid)
+        void setParamOther(@A SubA this, @B Object o);
+    }
+
+    // =========================================================================
+    // 2. @B Interface Testing Symmetrical Method Overrides
+    // =========================================================================
+
+    @B interface SubB extends Accessor {
+
+        // --- Return Type Checks ---
+
+        @Override
+        @B Object getReturnExact(@B SubB this);
+
+        @Override
+        @Bottom Object getReturnNarrowedBottom(@B SubB this);
+
+        @Override
+        // :: error: (override.return.invalid)
+        @Top Object getReturnWidenedTop(@B SubB this);
+
+        @Override
+        // :: error: (override.return.invalid)
+        @A Object getReturnOther(@B SubB this);
+
+        // --- Parameter Type Checks ---
+
+        @Override
+        void setParamExact(@B SubB this, @B Object o);
+
+        @Override
+        void setParamWidenedTop(@B SubB this, @Top Object o);
+
+        @Override
+        // :: error: (override.param.invalid)
+        void setParamNarrowedBottom(@B SubB this, @Bottom Object o);
+
+        @Override
+        // :: error: (override.param.invalid)
+        void setParamOther(@B SubB this, @A Object o);
+    }
+
+    // =========================================================================
+    // 3. Receiver-Dependent Interface Testing Symmetrical Method Overrides
+    // =========================================================================
+
+    @ReceiverDependentQual interface SubReceiverDependent extends Accessor {
+
+        // --- Return Type Checks ---
+
+        @Override
+        @ReceiverDependentQual Object getReturnExact(@ReceiverDependentQual SubReceiverDependent this);
+
+        @Override
+        @Bottom Object getReturnNarrowedBottom(@ReceiverDependentQual SubReceiverDependent this);
+
+        @Override
+        // :: error: (override.return.invalid)
+        @Top Object getReturnWidenedTop(@ReceiverDependentQual SubReceiverDependent this);
+
+        @Override
+        // :: error: (override.return.invalid)
+        @A Object getReturnOther(@ReceiverDependentQual SubReceiverDependent this);
+
+        // --- Parameter Type Checks ---
+
+        @Override
+        void setParamExact(
+                @ReceiverDependentQual SubReceiverDependent this, @ReceiverDependentQual Object o);
+
+        @Override
+        void setParamWidenedTop(@ReceiverDependentQual SubReceiverDependent this, @Top Object o);
+
+        @Override
+        void setParamNarrowedBottom(
+                // :: error: (override.param.invalid)
+                @ReceiverDependentQual SubReceiverDependent this, @Bottom Object o);
+
+        @Override
+        // :: error: (override.param.invalid)
+        void setParamOther(@ReceiverDependentQual SubReceiverDependent this, @A Object o);
+    }
+    // spotless:on
+}

--- a/framework/tests/viewpointtest/OverrideViewpointAdaptation.java
+++ b/framework/tests/viewpointtest/OverrideViewpointAdaptation.java
@@ -6,7 +6,6 @@ import viewpointtest.quals.*;
 
 public class OverrideViewpointAdaptation {
 
-    // spotless:off
     interface Accessor {
         // Return type test methods
         @ReceiverDependentQual Object getReturnExact(@ReceiverDependentQual Accessor this);
@@ -147,5 +146,4 @@ public class OverrideViewpointAdaptation {
         // :: error: (override.param.invalid)
         void setParamOther(@ReceiverDependentQual SubReceiverDependent this, @A Object o);
     }
-    // spotless:on
 }

--- a/framework/tests/viewpointtest/OverrideViewpointAdaptation.java
+++ b/framework/tests/viewpointtest/OverrideViewpointAdaptation.java
@@ -186,6 +186,7 @@ public class OverrideViewpointAdaptation {
     // 5. Class Inheritance (SuperClass -> SubClass)
     // =========================================================================
 
+    @SuppressWarnings({"super.invocation.invalid", "inconsistent.constructor.type"})
     static class SuperClass {
         @ReceiverDependentQual Object getReturnExact(@ReceiverDependentQual SuperClass this) {
             return null;
@@ -216,6 +217,7 @@ public class OverrideViewpointAdaptation {
                 @ReceiverDependentQual SuperClass this, @ReceiverDependentQual Object o) {}
     }
 
+    @SuppressWarnings({"super.invocation.invalid", "inconsistent.constructor.type"})
     @A static class SubClassA extends SuperClass {
 
         @Override
@@ -259,7 +261,7 @@ public class OverrideViewpointAdaptation {
     // 6. Transitive / Multi-Level Inheritance
     // =========================================================================
 
-    @ReceiverDependentQual interface MiddleRD extends Accessor {}
+    interface MiddleRD extends Accessor {}
 
     @A interface LeafA extends MiddleRD {
 


### PR DESCRIPTION
Part of #1071.

When checking method overrides in type systems that use viewpoint adaptation, this PR changes `postAsOverride` to viewpoint-adapt the superclass  method signature against `overriderType` (the class declaration bound) instead of `overriderReceiverType`.