### PR TITLE
AnnotatedTypeFactory: cache `isFromByteCode` per element

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -136,6 +136,9 @@ Performance optimizations:
   methods per class); `ValueQualifierHierarchy` uses cached `value()` elements.
   Wall clock on constant-heavy 1500-method classes improved ~18%.
 - `TreeUtils.sameTree()`: use a visitor instead of an expensive `toString()`.
+- `AnnotatedTypeFactory.isFromByteCode(Element)` now caches its result per
+  element, avoiding a repeated `Path.toUri()` call (URI construction and
+  parsing) on every conservative-defaults check.
 
 Other improvements and bug fixes:
 - `TreeUtils` has a new `inferredTypeArguments(ExpressionTree)` method to

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1701,15 +1701,65 @@ within a compile). This covers the dominant call site (`isFromByteCode`); the ha
 `InitializationFieldAccessTreeAnnotator` check) are outside `applyConservativeDefaults`'s hot loop
 and were not targeted.
 
-**Verification.** Re-traced `checknullness` after the fix: samples under `isElementFromSourceCodeImpl`
-dropped from 93/1735 (5.36%) to 33/1909 (1.73%); `sun.nio.fs.UnixUriUtils.match` fell out of the
-top-30 self-time leaves entirely. Wall-clock A/B (warm daemon, `./gradlew checknullness`, all ~10
-subprojects, `shadowJar` rebuilt each side, 3 reps/side after a discarded warm-up rep): master
-103–104 s (104, 103, 104), patched 92 s (101 cold, 92, 92) — **≈11% faster** on the full build. Ran
-`:framework:test :javacutil:test :dataflow:test` and `:checker:NullnessTest`,
-`:checker:NullnessSafeDefaultsBytecodeTest`, `:checker:NullnessSafeDefaultsSourceCodeTest`,
-`:checker:AnnotatedForNullnessTest` (all pass); `:checker:AinferTestCheckerJaifsGenerationTest`
-fails identically on unmodified master (pre-existing, unrelated).
+**Correctness follow-up (July 2026): the initial cache was missing a parsing guard.** The first
+version above cached unconditionally, unlike `cacheDeclAnnos` (its own stated model), which skips
+writing its cache while `isParsingAnnotationFile()` is true — a guard `AnnotatedTypeFactory.
+getAnnotatedType(Element)`'s `elementTypeCache` also has, and that `GenericAnnotatedTypeFactory
+.parsePhasePrimaryDefaultsCache`'s Javadoc states as an explicit codebase convention: "Standard
+factory caches are disabled during parsing to prevent caching partially loaded stub annotations."
+`isFromByteCode`'s result depends on `isFromStubFile(element)`, i.e. on whether `element` carries a
+`@FromStubFile` declaration annotation — attached only once the relevant annotation file has been
+(possibly lazily, reentrantly, e.g. via a fake override's `getAnnotatedType(overridden)` call
+during `AnnotationFileParser#processFakeOverride`) parsed. Caching an answer computed before that
+attachment would lock in a wrong value permanently, the same bug class fixed for `elementTypeCache`
+and for the fake-override snapshot in "Fake-override snapshot order-dependence" below/eisop#1862.
+Confirmed reachable, not just theoretical: instrumenting `isFromByteCode` and running
+`:checker:checkNullness` (dogfooding this repo's own source) showed 15–19 reentrant calls with
+`isParsingAnnotationFile()` true per compile, for `java.lang.Object`, `java.util.Collection`,
+`java.lang.Iterable`, and two JDK methods. A companion snapshot-vs-recompute comparison did not
+catch an actual value flip for those specific elements.
+
+An independent review (July 2026) reproduced the reachability (five distinct parse-time elements:
+`java.lang.Object`, `java.util.Collection`, `java.lang.Iterable`, `Collection.isEmpty()`, and a JDK
+`valuesToArray(T[])`) and pinned down *why* none of them can flip, which is structural rather than a
+matter of timing: all of them are supplied by the **annotated JDK**, and the annotated JDK is never
+`@FromStubFile`-marked — `AnnotationFileParser#markAsFromStubFile` returns early for
+`AnnotationFileType.JDK_STUB`, and `BinaryStubReader#applyClassRecord` is called with a `null`
+`fromStubFileAnno` for the JDK case. So `isFromStubFile` is permanently `false` for every element
+reachable via this dogfooding workload's reentrant calls, and the cached-during-parse answer equals
+the post-parse answer no matter when it is computed. A genuine flip therefore requires a
+*non-JDK-stub* bytecode element (from a built-in checker stub or a user `-Astubs` file, which
+`markAsFromStubFile` *does* mark) to be queried reentrantly before its own declaration is processed
+— reachable in principle via `processFakeOverride`'s `getAnnotatedType(overridden)` call when
+conservative defaults are enabled, but not produced by any workload exercised here (the required
+checker JUnit suites — including `NullnessSafeDefaultsBytecodeTest` — triggered no parse-time
+`isFromByteCode` call at all). The guard is thus reachable-but-unobserved for this call site: adopted
+on the exact match to the documented `cacheDeclAnnos`/`elementTypeCache` convention plus confirmed
+reachability, not on an observed misdiagnosis. Fixed by adding the same `!isParsingAnnotationFile()`
+guard `cacheDeclAnnos` uses, before the cache write only (the computation itself is unconditional, so
+the return value is unaffected either way).
+
+**Verification (updated, July 2026, after the parsing-guard fix).** Full-build JFR captures
+(`./checker/bin-devel/record-jfr.sh` + unqualified `./gradlew --no-daemon checknullness`, the
+skill-recommended all-~10-subprojects workload, not the `:checker:checkNullness` slice the original
+measurement above used) confirm the win survives the guard: `sun.nio.fs.UnixUriUtils.match` is
+1.93% self-time (34/1763 samples) with no cache at all, and does not appear in the top-30 leaves at
+all with the guarded cache (1903 samples). Wall-clock A/B (warm daemon, `./gradlew checknullness`,
+`assemble` rebuilt each side, 3 reps/side after a discarded warm-up rep, same host as the original
+measurement): no cache 109.9/110.3/116.1 s (avg 112.1 s); unconditional cache (pre-guard) 96.4/95.9/
+97.1 s (avg 96.5 s); guarded cache (this fix) 98.7/97.5/95.8 s (avg 97.3 s). The guard costs
+~0.8 s/~0.8% versus the unconditional version — noise, not a measurable regression — while the
+cache overall remains **~13% faster** than no caching at all, consistent with (slightly exceeding)
+the original ~11% claim. An independent re-run of just the guarded-vs-unconditional A/B (warm
+daemon, `./gradlew checknullness`, 3 reps/side after a discarded warm-up) reproduced the noise-level
+overhead on a differently-loaded host: unconditional 90.3/92.1/91.8 s (avg 91.4 s), guarded
+91.8/93.5/90.9 s (avg 92.1 s) — a ~0.7 s/~0.7% difference, again within run-to-run variance. Re-ran
+`:framework:test :javacutil:test :dataflow:test`,
+`:checker:NullnessTest`, `NullnessSafeDefaultsBytecodeTest`, `NullnessSafeDefaultsSourceCodeTest`,
+`AnnotatedForNullnessTest`, `StubparserNullnessTest`, `StubparserTaintingTest`,
+`NullnessBinaryStubDiffTest`, and `alltests` (`:checker:jtregTests`' `nullness/Issue1438{,b,c}`
+timeouts under full-suite parallel contention are the documented environmental flake — 94/94 pass
+run standalone) — all pass with the guard in place.
 
 ---
 

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1672,6 +1672,45 @@ triggered without deep nesting.
   two regression tests; `checker/tests/nullness/Java8InferenceWorklistStress.java` exercises the
   worklist's dependency tracking across interacting inference features under strict mode.
 
+### `AnnotatedTypeFactory.isFromByteCode` caching (July 2026)
+
+PR #1868 (three days prior, `Use ElementUtils.isElementFromSourceCode and deprecate
+isElementFromByteCode`) changed `isFromByteCode`'s implementation from a cheap
+`classfile.getKind()` comparison to `!ElementUtils.isElementFromSourceCode(element)`, which
+(via `isElementFromSourceCodeImpl`) calls `symbol.sourcefile.toUri().toString().startsWith("file:")`
+on every invocation — uncached. For a `Symbol.ClassSymbol` backed by a real on-disk source file,
+`Path.toUri()` is not a cheap getter: it builds a fresh `URI` (percent-encoding each path
+character via `sun.nio.fs.UnixUriUtils.match`/`toUri`, then re-parsing it with `URI$Parser.scan`).
+The old bytecode-only check never took this path; only the new source-code check does, and it is
+expensive precisely on the common case (a real, on-disk source file), not the rare one.
+
+**JFR evidence (full `checknullness`, warm-ish `--no-daemon`, ~1735 on-CPU `ExecutionSample`s on
+the `:checker:checkNullness` worker):** 93 samples (5.36%) fell under
+`isElementFromSourceCodeImpl`; 89.2% of those co-occurred with `QualifierDefaults`/`isFromByteCode`
+(i.e. `QualifierDefaults.applyConservativeDefaults` → `AnnotatedTypeFactory.isFromByteCode` →
+`ElementUtils.isElementFromSourceCode`). `sun.nio.fs.UnixUriUtils.match` alone was 2.6–2.7%
+self-time, 95%+ of it attributed to `isElementFromSourceCodeImpl` by nearest-CF-frame search — not
+mentioned anywhere previously in this file, i.e. a genuinely new (three-day-old) regression, not an
+already-mined leaf.
+
+**Fix.** Added `isFromByteCodeCache: IdentityHashMap<Element, Boolean>` to `AnnotatedTypeFactory`,
+matching the existing `cacheDeclAnnos`/`methodDeclaresPolyCache` per-factory-instance idiom (not
+cleared between compilation units, since the result — like those two caches' — does not change
+within a compile). This covers the dominant call site (`isFromByteCode`); the handful of direct
+`ElementUtils.isElementFromSourceCode` callers (WPI storage, an assertion in `BaseTypeVisitor`, one
+`InitializationFieldAccessTreeAnnotator` check) are outside `applyConservativeDefaults`'s hot loop
+and were not targeted.
+
+**Verification.** Re-traced `checknullness` after the fix: samples under `isElementFromSourceCodeImpl`
+dropped from 93/1735 (5.36%) to 33/1909 (1.73%); `sun.nio.fs.UnixUriUtils.match` fell out of the
+top-30 self-time leaves entirely. Wall-clock A/B (warm daemon, `./gradlew checknullness`, all ~10
+subprojects, `shadowJar` rebuilt each side, 3 reps/side after a discarded warm-up rep): master
+103–104 s (104, 103, 104), patched 92 s (101 cold, 92, 92) — **≈11% faster** on the full build. Ran
+`:framework:test :javacutil:test :dataflow:test` and `:checker:NullnessTest`,
+`:checker:NullnessSafeDefaultsBytecodeTest`, `:checker:NullnessSafeDefaultsSourceCodeTest`,
+`:checker:AnnotatedForNullnessTest` (all pass); `:checker:AinferTestCheckerJaifsGenerationTest`
+fails identically on unmodified master (pre-existing, unrelated).
+
 ---
 
 ## Tried and rejected

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -344,6 +344,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      */
     private final IdentityHashMap<Element, AnnotationMirrorSet> cacheDeclAnnos;
 
+    /** A cache for the result of {@link #isFromByteCode(Element)}, keyed by element. */
+    private final IdentityHashMap<Element, Boolean> isFromByteCodeCache;
+
     /**
      * A set containing declaration annotations that should be inherited. A declaration annotation
      * will be inherited if it is in this set, or if it has the
@@ -663,6 +666,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         this.currentFileAjavaTypes = null;
 
         this.cacheDeclAnnos = new IdentityHashMap<>();
+        this.isFromByteCodeCache = new IdentityHashMap<>();
         this.methodDeclaresPolyCache = new IdentityHashMap<>();
 
         // get the shared instance from the checker
@@ -1120,6 +1124,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             // elementCache.clear();
             // elementTypeCache.clear();
             // cacheDeclAnnos.clear();
+            // isFromByteCodeCache.clear();
             // methodDeclaresPolyCache.clear();
         }
 
@@ -4835,10 +4840,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @return true if the element is from bytecode and did not appear in a stub file
      */
     public boolean isFromByteCode(Element element) {
-        if (isFromStubFile(element)) {
-            return false;
+        Boolean cached = isFromByteCodeCache.get(element);
+        if (cached != null) {
+            return cached;
         }
-        return !ElementUtils.isElementFromSourceCode(element);
+        boolean result = !isFromStubFile(element) && !ElementUtils.isElementFromSourceCode(element);
+        isFromByteCodeCache.put(element, result);
+        return result;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -4845,7 +4845,17 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             return cached;
         }
         boolean result = !isFromStubFile(element) && !ElementUtils.isElementFromSourceCode(element);
-        isFromByteCodeCache.put(element, result);
+        // Do not cache a result computed while an annotation file is being parsed: isFromStubFile
+        // depends on the element's @FromStubFile declaration annotation, which cacheDeclAnnos
+        // (backing getDeclAnnotations) itself does not cache while parsing, for the same reason --
+        // a fake override or other reentrant lookup can query this element before its own
+        // declaring class's stub info has been fully attached. See getDeclAnnotations's identical
+        // guard and GenericAnnotatedTypeFactory#parsePhasePrimaryDefaultsCache's Javadoc ("Standard
+        // factory caches are disabled during parsing to prevent caching partially loaded stub
+        // annotations").
+        if (!isParsingAnnotationFile()) {
+            isFromByteCodeCache.put(element, result);
+        }
         return result;
     }
 


### PR DESCRIPTION
`AnnotatedTypeFactory.isFromByteCode(Element)` calls
`ElementUtils.isElementFromSourceCode`, which (via
`isElementFromSourceCodeImpl`) calls `symbol.sourcefile.toUri().toString()`
on every invocation. For a `Symbol.ClassSymbol` backed by a real on-disk
source file, `Path.toUri()` is not a cheap getter: it builds a fresh `URI`
(percent-encoding via `sun.nio.fs.UnixUriUtils`, then re-parsing it), and it
runs on the common case (a real source file), not the rare one.

JFR evidence on a full `checknullness` run (warm-ish, `--no-daemon`, ~1735
on-CPU samples on the `:checker:checkNullness` worker): 93 samples (5.36%)
fell under `isElementFromSourceCodeImpl`, 89.2% of those co-occurring with
`QualifierDefaults.applyConservativeDefaults` → `AnnotatedTypeFactory
.isFromByteCode`. `sun.nio.fs.UnixUriUtils.match` alone accounted for
2.6-2.7% self-time.

`isFromByteCode` now caches its result in a per-factory-instance
`IdentityHashMap<Element, Boolean>`, matching the existing
`cacheDeclAnnos`/`methodDeclaresPolyCache` idiom: the result depends only on
the element's declaration, not on path-sensitive state, so it does not need
to be cleared between compilation units.

The cache skips writing while `isParsingAnnotationFile()` is true, matching
the identical guard already used by `cacheDeclAnnos` and `elementTypeCache`.
`isFromByteCode`'s result depends on `isFromStubFile(element)`, which in turn
depends on the element's `@FromStubFile` declaration annotation -- attached
only once the relevant annotation file has been parsed, which can happen
reentrantly during a fake-override lookup. Caching an answer computed before
that attachment would lock in a wrong value permanently. See
`docs/developer/performance-notes.md` for the full analysis, including
confirmation that this is reachable (15-19 reentrant calls per compile when
dogfooding this repo's own source) and why none of the specific elements hit
by that workload can actually flip (they are all supplied by the annotated
JDK, which is never `@FromStubFile`-marked).

Verified: full `alltests` run clean (three `Issue1438*` jtreg timeouts
reproduced as a pre-existing parallel-contention flake, confirmed by an
uncontended standalone rerun of just those tests, which passed).
