### PR TITLE
Adapt field initializer LHS types to class bound viewpoint

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1996,6 +1996,21 @@ public abstract class GenericAnnotatedTypeFactory<
                                     + lhsTree.getKind());
                 }
         }
+
+        // A field declaration initializer assigns to an implicit this.field. Viewpoint-adapt the
+        // field's declared type to the enclosing class just as for an explicit member access.
+        if (viewpointAdapter != null && lhsTree instanceof VariableTree) {
+            VariableElement field = TreeUtils.elementFromDeclaration((VariableTree) lhsTree);
+            if (field.getKind().isField() && !ElementUtils.isStatic(field)) {
+                TypeElement enclosingType = ElementUtils.enclosingTypeElement(field);
+                assert enclosingType != null;
+                AnnotatedTypeMirror enclosingTypeMirror = getAnnotatedType(enclosingType);
+                AnnotatedTypeMirror adapted = res.shallowCopy(true);
+                viewpointAdapter.viewpointAdaptMember(enclosingTypeMirror, field, adapted);
+                res = adapted;
+            }
+        }
+
         useFlow = oldUseFlow;
         shouldCache = oldShouldCache;
         computingAnnotatedTypeMirrorOfLhs = oldComputingAnnotatedTypeMirrorOfLhs;

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1951,8 +1951,8 @@ public abstract class GenericAnnotatedTypeFactory<
         AnnotatedTypeMirror res;
         switch (lhsTree.getKind()) {
             case VARIABLE:
-                boolean isVarTree =
-                        TreeUtils.isVariableTreeDeclaredUsingVar((VariableTree) lhsTree);
+                VariableTree varTree = (VariableTree) lhsTree;
+                boolean isVarTree = TreeUtils.isVariableTreeDeclaredUsingVar(varTree);
                 if (isVarTree) {
                     // If this variable is declared using `var`, re-enable caching to avoid
                     // re-computing the initializer expression type.
@@ -1960,6 +1960,20 @@ public abstract class GenericAnnotatedTypeFactory<
                 }
                 res = getAnnotatedType(lhsTree);
                 // Value of shouldCache no longer used below, so no need to reset.
+
+                // A field declaration initializer assigns to an implicit this.field.
+                // Viewpoint-adapt the field's declared type to the enclosing class just as
+                // for an explicit member access.
+                if (viewpointAdapter != null) {
+                    VariableElement field = TreeUtils.elementFromDeclaration(varTree);
+                    if (field.getKind().isField() && !ElementUtils.isStatic(field)) {
+                        TypeElement enclosingType = (TypeElement) field.getEnclosingElement();
+                        AnnotatedTypeMirror adapted = res.shallowCopy();
+                        viewpointAdapter.viewpointAdaptMember(
+                                getAnnotatedType(enclosingType), field, adapted);
+                        res = adapted;
+                    }
+                }
                 break;
             case IDENTIFIER:
                 Element elt = TreeUtils.elementFromTree(lhsTree);
@@ -1995,19 +2009,6 @@ public abstract class GenericAnnotatedTypeFactory<
                                     + " Tree.Kind: "
                                     + lhsTree.getKind());
                 }
-        }
-
-        // A field declaration initializer assigns to an implicit this.field. Viewpoint-adapt the
-        // field's declared type to the enclosing class just as for an explicit member access.
-        if (viewpointAdapter != null && lhsTree instanceof VariableTree) {
-            VariableElement field = TreeUtils.elementFromDeclaration((VariableTree) lhsTree);
-            if (field.getKind().isField() && !ElementUtils.isStatic(field)) {
-                TypeElement enclosingType = (TypeElement) field.getEnclosingElement();
-                AnnotatedTypeMirror adapted = res.shallowCopy();
-                viewpointAdapter.viewpointAdaptMember(
-                        getAnnotatedType(enclosingType), field, adapted);
-                res = adapted;
-            }
         }
 
         useFlow = oldUseFlow;

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2002,11 +2002,10 @@ public abstract class GenericAnnotatedTypeFactory<
         if (viewpointAdapter != null && lhsTree instanceof VariableTree) {
             VariableElement field = TreeUtils.elementFromDeclaration((VariableTree) lhsTree);
             if (field.getKind().isField() && !ElementUtils.isStatic(field)) {
-                TypeElement enclosingType = ElementUtils.enclosingTypeElement(field);
-                assert enclosingType != null;
-                AnnotatedTypeMirror enclosingTypeMirror = getAnnotatedType(enclosingType);
-                AnnotatedTypeMirror adapted = res.shallowCopy(true);
-                viewpointAdapter.viewpointAdaptMember(enclosingTypeMirror, field, adapted);
+                TypeElement enclosingType = (TypeElement) field.getEnclosingElement();
+                AnnotatedTypeMirror adapted = res.shallowCopy();
+                viewpointAdapter.viewpointAdaptMember(
+                        getAnnotatedType(enclosingType), field, adapted);
                 res = adapted;
             }
         }

--- a/framework/tests/viewpointtest/FieldDeclarationInitializers.java
+++ b/framework/tests/viewpointtest/FieldDeclarationInitializers.java
@@ -13,8 +13,23 @@ import viewpointtest.quals.ReceiverDependentQual;
     // :: error: (assignment.type.incompatible)
     @ReceiverDependentQual Object incompatible = new @B Object();
 
+    @ReceiverDependentQual GenericBox<@ReceiverDependentQual Object> genericCompatible = new @A GenericBox<@A Object>();
+
+    @ReceiverDependentQual GenericBox<@ReceiverDependentQual Object> genericOuterCompatible =
+            // :: error: (assignment.type.incompatible)
+            new @A GenericBox<@B Object>();
+
+    @ReceiverDependentQual GenericBox<@ReceiverDependentQual Object> genericArgumentCompatible =
+            // :: error: (assignment.type.incompatible)
+            new @B GenericBox<@A Object>();
+
+    // :: error: (assignment.type.incompatible)
+    @ReceiverDependentQual GenericBox<@ReceiverDependentQual Object> genericIncompatible = new @B GenericBox<@B Object>();
+
     @B Object fixed = new @B Object();
 
     // Static fields have no receiver viewpoint.
     static @B Object staticField = new @B Object();
+
+    static class GenericBox<T> {}
 }

--- a/framework/tests/viewpointtest/FieldDeclarationInitializers.java
+++ b/framework/tests/viewpointtest/FieldDeclarationInitializers.java
@@ -26,10 +26,38 @@ import viewpointtest.quals.ReceiverDependentQual;
     // :: error: (assignment.type.incompatible)
     @ReceiverDependentQual GenericBox<@ReceiverDependentQual Object> genericIncompatible = new @B GenericBox<@B Object>();
 
+    // Array field viewpoint adaptation
+    @ReceiverDependentQual Object @ReceiverDependentQual [] arrayCompatible = new @A Object @A [0];
+
+    @ReceiverDependentQual Object @ReceiverDependentQual [] arrayOuterIncompatible =
+            // :: error: (assignment.type.incompatible)
+            new @A Object @B [0];
+
+    @ReceiverDependentQual Object @ReceiverDependentQual [] arrayComponentIncompatible =
+            // :: error: (assignment.type.incompatible)
+            new @B Object @A [0];
+
     @B Object fixed = new @B Object();
 
     // Static fields have no receiver viewpoint.
     static @B Object staticField = new @B Object();
 
     static class GenericBox<T> {}
+
+    @B class Inner {
+        @ReceiverDependentQual Object innerCompatible = new @B Object();
+
+        // :: error: (assignment.type.incompatible)
+        @ReceiverDependentQual Object innerIncompatible = new @A Object();
+    }
+
+    void testAnonymous() {
+        Object anon =
+                new @A Object() {
+                    @ReceiverDependentQual Object anonCompatible = new @A Object();
+
+                    // :: error: (assignment.type.incompatible)
+                    @ReceiverDependentQual Object anonIncompatible = new @B Object();
+                };
+    }
 }

--- a/framework/tests/viewpointtest/FieldDeclarationInitializers.java
+++ b/framework/tests/viewpointtest/FieldDeclarationInitializers.java
@@ -1,0 +1,20 @@
+import viewpointtest.quals.A;
+import viewpointtest.quals.B;
+import viewpointtest.quals.ReceiverDependentQual;
+
+@SuppressWarnings({
+    "inconsistent.constructor.type",
+    "super.invocation.invalid",
+    "cast.unsafe.constructor.invocation"
+})
+@A class FieldDeclarationInitializers {
+    @ReceiverDependentQual Object compatible = new @A Object();
+
+    // :: error: (assignment.type.incompatible)
+    @ReceiverDependentQual Object incompatible = new @B Object();
+
+    @B Object fixed = new @B Object();
+
+    // Static fields have no receiver viewpoint.
+    static @B Object staticField = new @B Object();
+}

--- a/framework/tests/viewpointtest/SubclassFieldInheritance.java
+++ b/framework/tests/viewpointtest/SubclassFieldInheritance.java
@@ -1,0 +1,116 @@
+import viewpointtest.quals.A;
+import viewpointtest.quals.B;
+import viewpointtest.quals.ReceiverDependentQual;
+
+@SuppressWarnings({
+    "inconsistent.constructor.type",
+    "super.invocation.invalid",
+    "cast.unsafe.constructor.invocation"
+})
+public class SubclassFieldInheritance {
+
+    static class GenericBox<T> {}
+
+    @ReceiverDependentQual static class SuperClass {
+        @ReceiverDependentQual Object inheritedField;
+
+        @ReceiverDependentQual GenericBox<@ReceiverDependentQual Object> inheritedGenericField;
+
+        @ReceiverDependentQual Object @ReceiverDependentQual [] inheritedArrayField;
+
+        @A Object fixedAField;
+
+        @ReceiverDependentQual Object getField() {
+            return inheritedField;
+        }
+
+        void setField(@ReceiverDependentQual Object o) {
+            this.inheritedField = o;
+        }
+    }
+
+    @A static class SubA extends @A SuperClass {
+        @ReceiverDependentQual Object subFieldInit = new @A Object();
+
+        // :: error: (assignment.type.incompatible)
+        @ReceiverDependentQual Object badSubFieldInit = new @B Object();
+    }
+
+    @B static class SubB extends @B SuperClass {
+        @ReceiverDependentQual Object subFieldInit = new @B Object();
+
+        // :: error: (assignment.type.incompatible)
+        @ReceiverDependentQual Object badSubFieldInit = new @A Object();
+    }
+
+    void testSubA(SubA a) {
+        @A Object aObj = a.inheritedField;
+        // :: error: (assignment.type.incompatible)
+        @B Object badBObj = a.inheritedField;
+
+        @A GenericBox<@A Object> aBox = a.inheritedGenericField;
+        // :: error: (assignment.type.incompatible)
+        @B GenericBox<@A Object> badBBox = a.inheritedGenericField;
+        // :: error: (assignment.type.incompatible)
+        @A GenericBox<@B Object> badABox = a.inheritedGenericField;
+
+        @A Object @A [] aArray = a.inheritedArrayField;
+        // :: error: (assignment.type.incompatible)
+        @B Object @A [] badBArray = a.inheritedArrayField;
+        // :: error: (assignment.type.incompatible)
+        @A Object @B [] badAArray = a.inheritedArrayField;
+
+        @A Object aFixed = a.fixedAField;
+        // :: error: (assignment.type.incompatible)
+        @B Object badBFixed = a.fixedAField;
+
+        @A Object aMethod = a.getField();
+        // :: error: (assignment.type.incompatible)
+        @B Object badBMethod = a.getField();
+
+        a.setField(new @A Object());
+        // :: error: (argument.type.incompatible)
+        a.setField(new @B Object());
+    }
+
+    void testSubB(SubB b) {
+        @B Object bObj = b.inheritedField;
+        // :: error: (assignment.type.incompatible)
+        @A Object badAObj = b.inheritedField;
+
+        @B GenericBox<@B Object> bBox = b.inheritedGenericField;
+        // :: error: (assignment.type.incompatible)
+        @A GenericBox<@B Object> badABox = b.inheritedGenericField;
+        // :: error: (assignment.type.incompatible)
+        @B GenericBox<@A Object> badBBox = b.inheritedGenericField;
+
+        @B Object @B [] bArray = b.inheritedArrayField;
+        // :: error: (assignment.type.incompatible)
+        @A Object @B [] badAArray = b.inheritedArrayField;
+        // :: error: (assignment.type.incompatible)
+        @B Object @A [] badBArray = b.inheritedArrayField;
+
+        // fixedAField remains @A Object even on @B receiver.
+        @A Object aFixed = b.fixedAField;
+        // :: error: (assignment.type.incompatible)
+        @B Object badBFixed = b.fixedAField;
+
+        @B Object bMethod = b.getField();
+        // :: error: (assignment.type.incompatible)
+        @A Object badAMethod = b.getField();
+
+        b.setField(new @B Object());
+        // :: error: (argument.type.incompatible)
+        b.setField(new @A Object());
+    }
+
+    void testSubclassSuperAssignment() {
+        @A SuperClass aSuper = new SubA();
+        @B SuperClass bSuper = new SubB();
+
+        // :: error: (assignment.type.incompatible)
+        @B SuperClass badBSuper = new SubA();
+        // :: error: (assignment.type.incompatible)
+        @A SuperClass badASuper = new SubB();
+    }
+}

--- a/framework/tests/viewpointtest/TestGetAnnotatedLhs.java
+++ b/framework/tests/viewpointtest/TestGetAnnotatedLhs.java
@@ -42,20 +42,3 @@ import viewpointtest.quals.Top;
         top.f = new @A Object();
     }
 }
-
-@SuppressWarnings({
-    "inconsistent.constructor.type",
-    "super.invocation.invalid",
-    "cast.unsafe.constructor.invocation"
-})
-@A class FieldDeclarationInitializers {
-    @ReceiverDependentQual Object compatible = new @A Object();
-
-    // :: error: (assignment.type.incompatible)
-    @ReceiverDependentQual Object incompatible = new @B Object();
-
-    @B Object fixed = new @B Object();
-
-    // Static fields have no receiver viewpoint and are not adapted through the enclosing class.
-    static @ReceiverDependentQual Object staticField = new @ReceiverDependentQual Object();
-}

--- a/framework/tests/viewpointtest/TestGetAnnotatedLhs.java
+++ b/framework/tests/viewpointtest/TestGetAnnotatedLhs.java
@@ -42,3 +42,20 @@ import viewpointtest.quals.Top;
         top.f = new @A Object();
     }
 }
+
+@SuppressWarnings({
+    "inconsistent.constructor.type",
+    "super.invocation.invalid",
+    "cast.unsafe.constructor.invocation"
+})
+@A class FieldDeclarationInitializers {
+    @ReceiverDependentQual Object compatible = new @A Object();
+
+    // :: error: (assignment.type.incompatible)
+    @ReceiverDependentQual Object incompatible = new @B Object();
+
+    @B Object fixed = new @B Object();
+
+    // Static fields have no receiver viewpoint and are not adapted through the enclosing class.
+    static @ReceiverDependentQual Object staticField = new @ReceiverDependentQual Object();
+}


### PR DESCRIPTION
Viewpoint-adapt instance-field initializer types to the enclosing class, just like explicit `this.field` accesses.