### PR TITLE
nullness: Add regression test for JDK-8054309 super-wildcard collapse with bounded type param

### DIFF
--- a/checker/tests/nullness/generics/WildcardSuperBoundedTypeParam.java
+++ b/checker/tests/nullness/generics/WildcardSuperBoundedTypeParam.java
@@ -1,0 +1,30 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Regression/documentation test for the JDK-8054309 super-wildcard-collapse check ({@code
+ * type.invalid.super.wildcard} in {@code BaseTypeValidator}), for the case where the wildcard's
+ * extends bound comes not from an annotation written on the wildcard token itself (as in {@code
+ * WildcardAnnos.java}), but from the declared bound of the type parameter, propagated during
+ * capture conversion. This mirrors the shape of the jspecify conformance sample {@code
+ * SuperObjectUnspec} ({@code Lib<T extends @Nullable Object>}, {@code Lib<?
+ * super @NullnessUnspecified Object>}), reduced to the standard Nullness Checker's two-valued
+ * lattice (no {@code @NullnessUnspecified}-style middle qualifier).
+ */
+public class WildcardSuperBoundedTypeParam {
+    interface Lib<T extends @Nullable Object> {
+        void useT(T t);
+    }
+
+    // The super bound target (Object) is the same as the erasure of Lib's type parameter bound,
+    // so javac's capture conversion collapses this wildcard (JDK-8054309): no fresh captured type
+    // variable is created, and the Checker Framework uses only the super bound's annotation
+    // (@NonNull), ignoring the propagated extends bound (@Nullable, from T's declared bound).
+    // Since the two disagree, this must be reported.
+    // :: error: (type.invalid.super.wildcard)
+    void differing(Lib<? super @NonNull Object> lib) {}
+
+    // Here the explicit super bound annotation (@Nullable) agrees with the propagated extends
+    // bound (@Nullable, from T's declared bound), so no error is expected.
+    void agreeing(Lib<? super @Nullable Object> lib) {}
+}


### PR DESCRIPTION
Adds a regression test for the `type.invalid.super.wildcard` check
(JDK-8054309 super-wildcard collapse) covering a case not previously
exercised: the wildcard's extends bound propagated from the type
parameter's *declared* bound during capture conversion, rather than
written directly on the wildcard token (the existing `WildcardAnnos.java`
coverage).

`Lib<T extends @Nullable Object>` with a super bound whose erasure matches
the type parameter's own erasure (`Lib<? super Object>`) makes javac
collapse the wildcard's capture: the Checker Framework then uses only the
explicit super-bound annotation, discarding the propagated extends bound.
`differing` writes `@NonNull` on the super bound against the declared
`@Nullable` extends bound and expects the mismatch to be reported;
`agreeing` writes `@Nullable` on both and expects no error.

This mirrors the shape of the JSpecify conformance sample
`SuperObjectUnspec`, reduced to the Nullness Checker's two-valued lattice.

Verified: both cases produce the expected diagnostics against current
master; `NullnessTest` passes (23/23).
