### PR TITLE
Document unsound conservative default for field writes (#1358)

### DIFF
--- a/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUse.java
+++ b/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUse.java
@@ -26,6 +26,9 @@ public class AnnotatedForWithUse {
             // 1: OK, 2: OK, 3: Err
             @NonNull Object obj = u.o;
             // 1. Err, 2: Err, TODO want OK, 3:  OK, TODO want Err
+            // Case 3 (-AuseConservativeDefaultsForUncheckedCode=source) is unsound here:
+            // conservative defaults only protect field reads, not field writes.
+            // See https://github.com/eisop/checker-framework/issues/1358 .
             u.o = null;
             // 1: OK, 2: OK, 3: Err
             u.get().toString();

--- a/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUseConservativeDefault.out
+++ b/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUseConservativeDefault.out
@@ -1,14 +1,14 @@
 AnnotatedForWithUse.java:27:36: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
 found   : @Nullable Object
 required: @NonNull Object
-AnnotatedForWithUse.java:31:18: compiler.err.proc.messager: [dereference.of.nullable] dereference of possibly-null reference u.get()
-AnnotatedForWithUse.java:31:29: compiler.err.proc.messager: [method.invocation.invalid] call to toString() not allowed on the given receiver.
+AnnotatedForWithUse.java:34:18: compiler.err.proc.messager: [dereference.of.nullable] dereference of possibly-null reference u.get()
+AnnotatedForWithUse.java:34:29: compiler.err.proc.messager: [method.invocation.invalid] call to toString() not allowed on the given receiver.
 found   : @UnknownInitialization Object
 required: @Initialized Object
-AnnotatedForWithUse.java:33:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
+AnnotatedForWithUse.java:36:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
 found   : @UnknownKeyFor NullType
 required: @KeyForBottom Object
-AnnotatedForWithUse.java:33:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
+AnnotatedForWithUse.java:36:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
 found   : @Nullable NullType
 required: @NonNull Object
 5 errors

--- a/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUseNoFlag.out
+++ b/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUseNoFlag.out
@@ -2,10 +2,10 @@ AnnotatedForWithUse.java:14:16: compiler.err.proc.messager: [initialization.fiel
 AnnotatedForWithUse.java:17:20: compiler.err.proc.messager: [return.type.incompatible] incompatible types in return.
 type of expression: @Nullable NullType
 method return type: @NonNull Object
-AnnotatedForWithUse.java:29:19: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
+AnnotatedForWithUse.java:32:19: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
 found   : @Nullable NullType
 required: @NonNull Object
-AnnotatedForWithUse.java:33:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
+AnnotatedForWithUse.java:36:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
 found   : @Nullable NullType
 required: @NonNull Object
 4 errors

--- a/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUseOnlyAnnotatedFor.out
+++ b/checker/jtreg/nullness/onlyannotatedfor/AnnotatedForWithUseOnlyAnnotatedFor.out
@@ -1,7 +1,7 @@
-AnnotatedForWithUse.java:29:19: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
+AnnotatedForWithUse.java:32:19: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
 found   : @Nullable NullType
 required: @NonNull Object
-AnnotatedForWithUse.java:33:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
+AnnotatedForWithUse.java:36:19: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter of of Unannotated.set.
 found   : @Nullable NullType
 required: @NonNull Object
 2 errors

--- a/checker/tests/nulless-conservative-defaults/annotatedfornullness/FieldWriteUnsound.java
+++ b/checker/tests/nulless-conservative-defaults/annotatedfornullness/FieldWriteUnsound.java
@@ -1,0 +1,33 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
+// Regression test for https://github.com/eisop/checker-framework/issues/1358 :
+// -AuseConservativeDefaultsForUncheckedCode is sound for field reads (an unannotated field is
+// defaulted to the top qualifier, @Nullable, so reading it into a @NonNull local correctly
+// errors) but unsound for field writes (the same read-oriented default is reused as the
+// required type of the assignment, so writing null into the field is currently, incorrectly,
+// accepted). See QualifierDefaults.STANDARD_UNCHECKED_DEFAULTS_TOP for the root cause.
+public class FieldWriteUnsound {
+    class Unannotated {
+        // No explicit nullness qualifier: conservative defaults apply to this field.
+        Object field = new Object();
+    }
+
+    @AnnotatedFor("nullness")
+    class AnnotatedUse {
+        void use(Unannotated u) {
+            // Sound: field reads are conservative, so this correctly errors.
+            // ::error: (assignment.type.incompatible)
+            @NonNull Object read = u.field;
+
+            // TODO(#1358): unsound. Field writes under conservative defaults should also
+            // require @NonNull, but this is currently accepted (no error) because
+            // QualifierDefaults does not distinguish field-read defaults from field-write
+            // defaults. Once fixed, this line should be annotated with:
+            //     // ::error: (assignment.type.incompatible)
+            // No error is expected below until then; the assignment below documents the
+            // currently-unsound behavior, it is not a desired outcome.
+            u.field = null;
+        }
+    }
+}

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -187,11 +187,13 @@ public class QualifierDefaults {
     // and field writes.  (When a field is written to, its type should be bottom.)
     // This is the root cause of https://github.com/eisop/checker-framework/issues/1358 : because
     // TypeUseLocation.FIELD does not distinguish reads from writes, a field write under
-    // conservative defaults is unsoundly checked against the same (read-oriented) top default as
-    // a field read, instead of requiring the bottom qualifier.  Fixing this needs a way for
-    // QualifierDefaults to apply a different default when
-    // GenericAnnotatedTypeFactory#isComputingAnnotatedTypeMirrorOfLhs() is true; see the issue for
-    // discussion.
+    // conservative defaults is unsoundly checked against the same (read-oriented) top default as a
+    // field read, instead of requiring the bottom qualifier.
+    // GenericAnnotatedTypeFactory#isComputingAnnotatedTypeMirrorOfLhs() is reachable while
+    // defaulting a field write (getAnnotatedTypeLhs disables caching, so defaults are reapplied),
+    // but a sound fix needs a separate write-variant of the unchecked FIELD default rather than
+    // flipping any top FIELD default to bottom: an explicit @DefaultQualifier(locations=FIELD) must
+    // still apply to writes. See the issue for discussion.
     public static final List<TypeUseLocation> STANDARD_UNCHECKED_DEFAULTS_TOP =
             Collections.unmodifiableList(
                     Arrays.asList(

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -185,6 +185,13 @@ public class QualifierDefaults {
     // Fields are defaulted to top so that warnings are issued at field reads, which we believe are
     // more common than field writes. Future work is to specify different defaults for field reads
     // and field writes.  (When a field is written to, its type should be bottom.)
+    // This is the root cause of https://github.com/eisop/checker-framework/issues/1358 : because
+    // TypeUseLocation.FIELD does not distinguish reads from writes, a field write under
+    // conservative defaults is unsoundly checked against the same (read-oriented) top default as
+    // a field read, instead of requiring the bottom qualifier.  Fixing this needs a way for
+    // QualifierDefaults to apply a different default when
+    // GenericAnnotatedTypeFactory#isComputingAnnotatedTypeMirrorOfLhs() is true; see the issue for
+    // discussion.
     public static final List<TypeUseLocation> STANDARD_UNCHECKED_DEFAULTS_TOP =
             Collections.unmodifiableList(
                     Arrays.asList(


### PR DESCRIPTION
Under conservative (unchecked-code) defaults, `TypeUseLocation.FIELD` defaults
to the top qualifier regardless of whether the field is being read or
written. That is correct for reads (an unannotated field from unchecked code
could hold anything) but unsound for writes: a write should be checked
against the bottom qualifier, since the checker cannot verify what value an
unchecked caller stores there. This is the root cause of #1358.

Documents the root cause on `QualifierDefaults.STANDARD_UNCHECKED_DEFAULTS_TOP`
and adds `checker/tests/nulless-conservative-defaults/annotatedfornullness/FieldWriteUnsound.java`,
a regression test that pins down the current (unsound) behavior.

A sound fix is not included here. `GenericAnnotatedTypeFactory
.isComputingAnnotatedTypeMirrorOfLhs()` is reachable at the point
`QualifierDefaults` applies the FIELD default for a write (confirmed by
tracing `getAnnotatedTypeLhs`, which disables caching and forces defaults to
be reapplied), but simply flipping the unchecked FIELD default from top to
bottom whenever that flag is true is not sound in general: it cannot
distinguish the conservative/unchecked FIELD default from an explicit user
`@DefaultQualifier(locations = TypeUseLocation.FIELD)`, which must still
apply to writes. Verified concretely: applying that flip broke
`checker/tests/nullness/Issue1307.java`, which relies on an explicit
`@DefaultQualifier(value = Nullable.class, locations = TypeUseLocation.FIELD)`
being honored on a field write. A sound fix needs a separate write-variant
of the *unchecked* FIELD default, which is a larger change than this PR's
scope, and issue #1358 itself records an open, unresolved design question
(a proposed `@RWNull` qualifier) that should settle first.

Also updates `checker/tests/nullness/onlyannotatedfor/AnnotatedForWithUse*.{java,out}`.

Verified: `AnnotatedForNullnessTest` (3/3) and `NullnessTest` (23/23) pass;
`:framework:spotlessCheck` clean.
