### PR TITLE
Nullness: Rename and document `NullnessNoInitStore`'s initialized-field value cache

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitStore.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitStore.java
@@ -33,6 +33,17 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
      * GenericAnnotatedTypeFactory, NullnessNoInitValue)} as cache to avoid performance issue in
      * #1438.
      *
+     * <p>This map is deliberately excluded from {@link #leastUpperBound}, {@link #equals}, and
+     * {@link #hashCode}: it caches a value that depends only on the field's declaration (not on the
+     * current store's path-sensitive state), so it is safe to keep, drop, or share the map without
+     * keeping it in sync with the rest of the store. In particular, dropping it (as the
+     * least-upper-bound store does, since it is freshly created rather than copied) is sound: the
+     * next call to {@link #newFieldValueAfterMethodCall} simply recomputes the answer via {@link
+     * InitializationAnnotatedTypeFactory#isInitialized} instead of reusing a cached one. Merging
+     * the maps of two stores at a control-flow-graph merge point, on the other hand, would be
+     * unsound in general: a field cached as initialized along one branch is not necessarily still
+     * initialized in the merged store. See #1818 for the analysis that led to this comment.
+     *
      * @see
      *     InitializationAnnotatedTypeFactory#isInitialized(org.checkerframework.framework.type.GenericAnnotatedTypeFactory,
      *     org.checkerframework.framework.flow.CFAbstractValue,
@@ -120,6 +131,9 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
         NullnessNoInitStore lub = super.leastUpperBound(other);
         lub.isPolyNullNonNull = isPolyNullNonNull && other.isPolyNullNonNull;
         lub.isPolyNullNull = isPolyNullNull && other.isPolyNullNull;
+        // lub.initializedFields is intentionally left unset (null) here rather than merged from
+        // this.initializedFields and other.initializedFields: see the javadoc of
+        // #initializedFields for why that is sound.
         return lub;
     }
 
@@ -198,7 +212,8 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
             return false;
         }
         NullnessNoInitStore other = (NullnessNoInitStore) o;
-        // TODO: what about initializedFields?
+        // initializedFields is deliberately not compared: it is a cache of information derivable
+        // from the rest of the store's state, not additional state itself. See its javadoc.
         return isPolyNullNonNull == other.isPolyNullNonNull
                 && isPolyNullNull == other.isPolyNullNull;
     }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitStore.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitStore.java
@@ -27,29 +27,19 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
     private boolean isPolyNullNull;
 
     /**
-     * Initialized fields and their values.
+     * Maps each field that is known to be initialized along the current flow path to the value it
+     * takes on after a non-pure method call, namely its declared type. Used by {@link
+     * #newFieldValueAfterMethodCall(FieldAccess, GenericAnnotatedTypeFactory, NullnessNoInitValue)}
+     * to avoid re-evaluating the expensive {@link
+     * InitializationAnnotatedTypeFactory#isInitialized(org.checkerframework.framework.type.GenericAnnotatedTypeFactory,
+     * org.checkerframework.framework.flow.CFAbstractValue,
+     * javax.lang.model.element.VariableElement)} check once a field is known to be initialized.
      *
-     * <p>This is used by {@link #newFieldValueAfterMethodCall(FieldAccess,
-     * GenericAnnotatedTypeFactory, NullnessNoInitValue)} as cache to avoid performance issue in
-     * #1438.
-     *
-     * <p>This map is deliberately excluded from {@link #leastUpperBound}, {@link #equals}, and
-     * {@link #hashCode}: it caches a value that depends only on the field's declaration (not on the
-     * current store's path-sensitive state), so it is safe to keep, drop, or share the map without
-     * keeping it in sync with the rest of the store. In particular, dropping it (as the
-     * least-upper-bound store does, since it is freshly created rather than copied) is sound: the
-     * next call to {@link #newFieldValueAfterMethodCall} simply recomputes the answer via {@link
-     * InitializationAnnotatedTypeFactory#isInitialized} instead of reusing a cached one. Merging
-     * the maps of two stores at a control-flow-graph merge point, on the other hand, would be
-     * unsound in general: a field cached as initialized along one branch is not necessarily still
-     * initialized in the merged store. See #1818 for the analysis that led to this comment.
-     *
-     * @see
-     *     InitializationAnnotatedTypeFactory#isInitialized(org.checkerframework.framework.type.GenericAnnotatedTypeFactory,
-     *     org.checkerframework.framework.flow.CFAbstractValue,
-     *     javax.lang.model.element.VariableElement)
+     * <p>This is a path-local memoization cache, not part of the store's abstract state, so it is
+     * deliberately excluded from {@link #leastUpperBound}, {@link #equals}, and {@link #hashCode}.
+     * See those methods for why the exclusion is sound.
      */
-    protected Map<FieldAccess, NullnessNoInitValue> initializedFields;
+    private @Nullable Map<FieldAccess, NullnessNoInitValue> initializedFieldValueCache;
 
     /**
      * Create a NullnessStore.
@@ -75,8 +65,8 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
         super(s);
         isPolyNullNonNull = s.isPolyNullNonNull;
         isPolyNullNull = s.isPolyNullNull;
-        if (s.initializedFields != null) {
-            initializedFields = s.initializedFields;
+        if (s.initializedFieldValueCache != null) {
+            initializedFieldValueCache = s.initializedFieldValueCache;
         }
     }
 
@@ -86,24 +76,21 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
             GenericAnnotatedTypeFactory<NullnessNoInitValue, NullnessNoInitStore, ?, ?>
                     atypeFactory,
             NullnessNoInitValue value) {
-        // If the field is unassignable, it cannot change; thus we keep
-        // its current value.
-        // Unassignable fields must be handled before initialized fields
-        // because in the case of a field that is both unassignable and
-        // initialized, the initializedFields cache may contain an older,
-        // less refined value.
+        // If the field is unassignable, it cannot change, so keep its current value. Unassignable
+        // fields are handled before initialized ones because a field that is both unassignable and
+        // initialized may have a stale, less-refined value in the cache.
         if (!fieldAccess.isAssignableByOtherCode()) {
             return value;
         }
 
-        if (initializedFields == null) {
-            initializedFields = new HashMap<>(4);
+        if (initializedFieldValueCache == null) {
+            initializedFieldValueCache = new HashMap<>(4);
         }
 
-        // If the field is initialized, it can change, but cannot be uninitialized.
-        // We thus keep a new value based on its declared type.
-        if (initializedFields.containsKey(fieldAccess)) {
-            return initializedFields.get(fieldAccess);
+        // An initialized field can change but cannot become uninitialized, so after the call it
+        // takes on a value based on its declared type.
+        if (initializedFieldValueCache.containsKey(fieldAccess)) {
+            return initializedFieldValueCache.get(fieldAccess);
         } else if (InitializationAnnotatedTypeFactory.isInitialized(
                         atypeFactory, value, fieldAccess.getField())
                 && atypeFactory
@@ -114,7 +101,7 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
                     analysis.createAbstractValue(
                             atypeFactory.getAnnotatedType(fieldAccess.getField()).getAnnotations(),
                             value.getUnderlyingType());
-            initializedFields.put(fieldAccess, newValue);
+            initializedFieldValueCache.put(fieldAccess, newValue);
             return newValue;
         }
 
@@ -131,9 +118,10 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
         NullnessNoInitStore lub = super.leastUpperBound(other);
         lub.isPolyNullNonNull = isPolyNullNonNull && other.isPolyNullNonNull;
         lub.isPolyNullNull = isPolyNullNull && other.isPolyNullNull;
-        // lub.initializedFields is intentionally left unset (null) here rather than merged from
-        // this.initializedFields and other.initializedFields: see the javadoc of
-        // #initializedFields for why that is sound.
+        // initializedFieldValueCache is intentionally not merged into lub. It is a path-local memo,
+        // and a field known to be initialized along one branch need not be initialized in the
+        // merged store, so dropping it is required for soundness; lub starts as an empty store, so
+        // its cache is null and gets repopulated on demand.
         return lub;
     }
 
@@ -212,8 +200,10 @@ public class NullnessNoInitStore extends CFAbstractStore<NullnessNoInitValue, Nu
             return false;
         }
         NullnessNoInitStore other = (NullnessNoInitStore) o;
-        // initializedFields is deliberately not compared: it is a cache of information derivable
-        // from the rest of the store's state, not additional state itself. See its javadoc.
+        // initializedFieldValueCache is not compared: it is a path-local memo, not part of the
+        // store's abstract state. Two stores that are otherwise equal denote the same abstract
+        // value regardless of what either has cached, and each cache entry is recomputable from the
+        // field's declaration, so ignoring it here (and in hashCode) is sound.
         return isPolyNullNonNull == other.isPolyNullNonNull
                 && isPolyNullNull == other.isPolyNullNull;
     }

--- a/checker/tests/initialization/RawTypesInit.java
+++ b/checker/tests/initialization/RawTypesInit.java
@@ -237,11 +237,12 @@ public class RawTypesInit {
         RawAfterConstructorOK2() {}
     }
 
-    // This class documents a desired but unimplemented feature: performing initialization in a
-    // helper method (verified via @RequiresNonNull/@EnsuresNonNull), rather than directly in the
-    // constructor. Currently the checker conservatively keeps the receiver raw for the rest of
-    // the constructor once a helper method is called, so the calls to nonRawMethod() below are
-    // (imprecisely) rejected.
+    // This class documents a desired but unimplemented feature: treating the receiver as fully
+    // initialized part-way through a constructor or helper method once every field has been set, so
+    // that a non-raw instance method may be called. The checker instead keeps the receiver under
+    // initialization until the constructor returns, so every nonRawMethod() call below is
+    // (imprecisely) rejected, whether the fields are set directly (constructor_inits_ab) or through
+    // an @EnsuresNonNull helper method (init_b, init_ab).
     class InitInHelperMethod {
         Integer a;
         Integer b;

--- a/checker/tests/initialization/RawTypesInit.java
+++ b/checker/tests/initialization/RawTypesInit.java
@@ -237,8 +237,11 @@ public class RawTypesInit {
         RawAfterConstructorOK2() {}
     }
 
-    // TODO: reinstate.  This shows desired features, for initialization in
-    // a helper method rather than in the constructor.
+    // This class documents a desired but unimplemented feature: performing initialization in a
+    // helper method (verified via @RequiresNonNull/@EnsuresNonNull), rather than directly in the
+    // constructor. Currently the checker conservatively keeps the receiver raw for the rest of
+    // the constructor once a helper method is called, so the calls to nonRawMethod() below are
+    // (imprecisely) rejected.
     class InitInHelperMethod {
         Integer a;
         Integer b;


### PR DESCRIPTION
Closes #1818.

Issue #1818 raised three concerns about `NullnessNoInitStore.initializedFields`:
the confusing name it shares with `InitializationStore.initializedFields`,
whether removing it would save memory or redundant computation, and why it is
not used in `leastUpperBound`. This PR resolves all three.

## What the two `initializedFields` fields actually are

`NullnessNoInitStore` and `InitializationStore` are **siblings** (both extend
`CFAbstractStore` with different type parameters), not parent/child, so the two
fields are entirely independent and share a name only by coincidence:

- `InitializationStore.initializedFields` is a `Set<VariableElement>`: a genuine
  path-sensitive dataflow fact (which fields are definitely initialized here),
  correctly intersected in its `leastUpperBound`.
- `NullnessNoInitStore.initializedFields` is a `Map<FieldAccess,
  NullnessNoInitValue>`: a **memoization cache** for
  `newFieldValueAfterMethodCall`, not a set of initialized fields at all. It
  avoids re-running the expensive `InitializationAnnotatedTypeFactory.isInitialized`
  check for a field already known to be initialized along the current flow path.

## Rename (addresses the naming complaint)

Renamed `NullnessNoInitStore.initializedFields` to `initializedFieldValueCache`,
tightened it to `private` (no subclasses reference it) and `@Nullable`, and
rewrote its Javadoc to describe what it is. Replaced the `// TODO: what about
initializedFields?` in `equals` and the bare `leastUpperBound` with definitive
reasoning.

## Why it is (correctly) not in LUB / equals / hashCode

The cache is a **path-local memo**, not part of the store's abstract state:

- Dropping it at a control-flow merge is *required for soundness*: a field
  cached as initialized along one branch need not be initialized in the merged
  store. This happens automatically because the `lub` store is freshly created
  (`super.leastUpperBound` -> `CFAbstractStore.upperBound` -> `createEmptyStore`),
  so its cache starts null and is repopulated on demand.
- Excluding it from `equals`/`hashCode` is sound because two otherwise-equal
  stores denote the same abstract value regardless of what either has cached,
  and each entry is recomputable from the field's declaration.

## Why it was NOT removed or moved to the factory (the "reduce memory /
redundant computation" investigation)

I investigated moving the cache to a per-`Element` cache on the
`AnnotatedTypeFactory` (like `isFromByteCodeCache`, `cacheDeclAnnos`), which
would take it out of store state entirely. **This is unsound**, for two reasons
that compound:

1. The gate `isInitialized(atypeFactory, value, field)` depends on the field's
   *current abstract value* (`hasInvariantInStore`), so it is program-point
   dependent — a `@NonNull`-declared field is "initialized" only where the store
   already holds `@NonNull` for it. The cache remembers a positive gate result
   and skips re-checking it on a hit; that is only valid along a single forward
   path where "once initialized, stays initialized" holds.
2. `FieldAccess.equals` treats all `this`/`super` receivers as equal
   (`ThisReference.equals` returns true for any `ThisReference`), so `this.f`
   is the *same key* in every method and constructor of a class. A factory-wide
   cache would therefore conflate `this.f` across methods, and a lookup in a
   constructor before `f` is assigned would hit an entry cached from an
   unrelated method and wrongly treat `f` as initialized — suppressing real
   errors.

Removing the cache entirely is also not an improvement: on a hit it skips both
the `isInitialized` gate and the value construction, so dropping it would run
`isInitialized` on every non-pure method call and reintroduce the #1438
performance problem. The per-store cache is already cheap in memory — the map is
shared by reference across store copies and dropped (not copied) at merges.

Conclusion: the field must remain per-store state. The right fix for #1818 is
the rename + documentation here, not a structural move; there is no behavior or
performance change.

## RawTypesInit comment

The `RawTypesInit.InitInHelperMethod` comment #1818 flagged is unrelated to this
cache (it is about the receiver staying under-initialization for a constructor's
body, not field-value caching) and was already corrected on this branch to match
the actual, verified behavior.

## Testing

`:checker:spotlessCheck`, `NullnessTest` (23/23, which covers
`checker/tests/initialization/` including `RawTypesInit`),
`AnnotatedForNullnessTest`, and `StubparserNullnessTest` all pass.
Documentation/rename only; no behavior or performance change (no CHANGELOG entry
needed).
