### PR TITLE
Document spotless comment gotcha, test-style choice, and speculative hooks

### DIFF
--- a/.claude/skills/cf-patch-style/SKILL.md
+++ b/.claude/skills/cf-patch-style/SKILL.md
@@ -187,6 +187,15 @@ green but still fail CI:
   `spotlessJavaCheck` (a pre-commit hook then blocks the commit). Re-run
   `./gradlew spotlessApply` after **any** edit, including comment-only ones,
   not just code edits.
+- **`spotlessApply` on `//` comments is non-idempotent: it splits over-long
+  ones but never rejoins short ones.** google-java-format wraps a `//` line
+  comment that exceeds the column limit onto a second line, but it leaves an
+  already-short comment alone — so a hand-wrapped or incrementally-edited `//`
+  comment can keep a bad mid-sentence break indefinitely and `spotlessCheck`
+  will still pass (verified: two short `//` lines survived both
+  `spotlessApply` and `spotlessCheck` untouched). Collapse a `//` comment to a
+  single line yourself and let spotless re-wrap it; never hand-wrap `//`
+  comments.
 - **`shell-style-check` / `python-style-check` cover shell and Python, which
   Spotless does NOT.** `shell-style-check` runs **three** tools on every
   bash/`*.sh` script — `shfmt -i 2 -ci -bn -sr` (format), `shellcheck -x`

--- a/.claude/skills/cf-patch-style/SKILL.md
+++ b/.claude/skills/cf-patch-style/SKILL.md
@@ -256,6 +256,28 @@ commit while the working tree still shows your edit, so "it's already
 fixed" reads true from the tree but false from `HEAD`. One `git show HEAD:`
 check before claiming a change landed avoids a wrong status report.
 
+## `gh pr edit --body-file` fails on this repo — use the REST API to update a body
+
+This repo still has Projects (classic) enabled, so `gh pr edit`'s GraphQL
+query hits the sunset error and refuses to update anything:
+
+```
+GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)
+```
+
+Verified (gh 2.54.0): `gh pr edit <n> --body-file body.md` fails this way,
+while `gh pr create --body-file body.md` succeeds (creation does not query
+`projectCards`). To **edit** an existing PR body, go around gh with the REST
+API, which works:
+
+```
+gh api -X PATCH repos/eisop/checker-framework/pulls/<n> -F body=@body.md
+```
+
+(`-F body=@file` reads the file as the field value; `-f body="..."` for an
+inline string.) Use `gh pr create` for creation as normal; only the edit path
+needs the workaround.
+
 ## What good output to a human reviewer looks like
 
 - A branch with N small commits, each compiling.

--- a/.claude/skills/cf-patch-style/SKILL.md
+++ b/.claude/skills/cf-patch-style/SKILL.md
@@ -256,28 +256,6 @@ commit while the working tree still shows your edit, so "it's already
 fixed" reads true from the tree but false from `HEAD`. One `git show HEAD:`
 check before claiming a change landed avoids a wrong status report.
 
-## `gh pr edit --body-file` fails on this repo — use the REST API to update a body
-
-This repo still has Projects (classic) enabled, so `gh pr edit`'s GraphQL
-query hits the sunset error and refuses to update anything:
-
-```
-GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)
-```
-
-Verified (gh 2.54.0): `gh pr edit <n> --body-file body.md` fails this way,
-while `gh pr create --body-file body.md` succeeds (creation does not query
-`projectCards`). To **edit** an existing PR body, go around gh with the REST
-API, which works:
-
-```
-gh api -X PATCH repos/eisop/checker-framework/pulls/<n> -F body=@body.md
-```
-
-(`-F body=@file` reads the file as the field value; `-f body="..."` for an
-inline string.) Use `gh pr create` for creation as normal; only the edit path
-needs the workaround.
-
 ## What good output to a human reviewer looks like
 
 - A branch with N small commits, each compiling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,9 @@ not by itself a reason to prefer it over jtreg.
   language ("dramatically", "blazingly").
 - **Changelog:** every user-visible or perf-relevant change gets one
   bullet in [`docs/CHANGELOG.md`](docs/CHANGELOG.md) under the next
-  release.
+  release. If the PR closes a GitHub issue, add its number (as `eisop#NNNN`,
+  in ascending numeric order) to that release's **Closed issues:** list in
+  the same PR — don't leave it for a later backfill.
 - **Branch naming for perf/correctness audits:**
   `review-<package>` or `perf-<package>` matches recent practice
   (e.g., `Review of common/basetype package (#1721)`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,17 @@ reproducing a CI failure locally usually means running the matching
 script with the same `useJdkVersion`. CI workflow is
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
+**Adding a test — jtreg vs. JUnit.** For a narrow single-scenario check
+(e.g. one lint flag's on/off behavior) the lightest option is a jtreg test
+with a `@compile/ref=<name>.out` directive — one self-contained `.java` file
+plus its expected-diagnostics `.out`, no runner class (see
+`checker/jtreg/lintoption/`). For anything needing multiple related inputs or
+a shared stub file, use the JUnit `CheckerFrameworkPerDirectoryTest` pattern:
+a small runner class pointing at a `checker/tests/<dir>/` directory (see the
+`Stubparser*Test` classes, which pass `-Astubs=`). Prefer jtreg for a
+one-file scenario; reach for the JUnit runner only when a whole directory of
+inputs earns it.
+
 ## Commit and PR conventions
 
 - **User review.** Always ask for a review *before* committing.
@@ -133,6 +144,14 @@ Read that skill before proposing any perf change. The short version:
   allocations" (it doesn't, in the relevant call site); proposing
   `getEffectiveAnnotations()` as a hotspot (it was 0.05% of samples).
   If the reasoning is shaky, label it as a hypothesis, not a finding.
+- **Don't add speculative extension points.** This framework is built on
+  overridable hooks (ATF/visitor/annotator methods), so a plausible-sounding
+  "future extension point" is an easy — and recurring — thing to add. Do not
+  introduce an overridable hook, `protected` seam, or extra parameter "for
+  future use" without a real current caller or override. Verify by grepping
+  for an actual consumer; if the only implementation is the default you just
+  wrote, inline it instead. (This is the design-decision analogue of "verify
+  before claiming": don't assume a use case, demonstrate one.)
 - **`git format-patch` output is preferred** for non-trivial work, with
   each patch standalone and committable.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,15 +64,21 @@ script with the same `useJdkVersion`. CI workflow is
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 **Adding a test — jtreg vs. JUnit.** For a narrow single-scenario check
-(e.g. one lint flag's on/off behavior) the lightest option is a jtreg test
-with a `@compile/ref=<name>.out` directive — one self-contained `.java` file
-plus its expected-diagnostics `.out`, no runner class (see
-`checker/jtreg/lintoption/`). For anything needing multiple related inputs or
-a shared stub file, use the JUnit `CheckerFrameworkPerDirectoryTest` pattern:
-a small runner class pointing at a `checker/tests/<dir>/` directory (see the
-`Stubparser*Test` classes, which pass `-Astubs=`). Prefer jtreg for a
-one-file scenario; reach for the JUnit runner only when a whole directory of
-inputs earns it.
+(e.g. one lint flag's on/off behavior, or a stub-file parser regression) the
+lightest option is a jtreg test: one self-contained `.java` file, or a
+`.java` plus its `.astub`, with the `@compile`/`@compile/ref=<name>.out`
+directive(s) inline — no runner class (see `checker/jtreg/lintoption/` for
+the plain case, and `checker/jtreg/stubs/` for stub-file scenarios,
+including multi-file ones: `framework/jtreg/StubParserEnum` for a single
+`.astub` plus `.java`, `checker/jtreg/stubs/fakeoverrides` for a test that
+also needs a small helper class, compiled first via its own `@compile`
+directive in the same file). Reach for the JUnit
+`CheckerFrameworkPerDirectoryTest` pattern — a small runner class pointing
+at a `checker/tests/<dir>/` directory — only when a test genuinely needs a
+whole directory of related inputs checked together (many source files as
+one compilation unit) or the inline `// :: error:`-style diagnostic-comment
+convention that pattern supports; needing a stub file alongside the test is
+not by itself a reason to prefer it over jtreg.
 
 ## Commit and PR conventions
 


### PR DESCRIPTION
Adds four verified, repo-specific working-notes to the AI-assistant instructions. Each was checked empirically against the current repo/toolchain, not transcribed.

- **cf-patch-style — spotless `//`-comment non-idempotency.** `spotlessApply` splits an over-long `//` comment but never rejoins an already-short one, so a hand-wrapped `//` comment keeps a bad break indefinitely and `spotlessCheck` still passes. Verified against google-java-format 1.35.0 (AOSP). Guidance: collapse `//` comments to one line and let spotless re-wrap; never hand-wrap.
- **CLAUDE.md — choosing a test style.** Brief orientation on jtreg `@compile`/`@compile/ref=<name>.out` (one file, single scenario, or a small stub-file scenario; `checker/jtreg/lintoption/`, `checker/jtreg/stubs/`) vs. the JUnit `CheckerFrameworkPerDirectoryTest` pattern (a whole directory of related inputs, or the inline `// :: error:` diagnostic-comment convention). The section previously listed test commands but gave no orientation on which style to use for a new test.
- **CLAUDE.md — don't add speculative extension points.** In an extension-point-heavy framework, adding an overridable hook or parameter "for future use" without a current consumer is a recurring mistake; grep for a real caller before adding one.
- **CLAUDE.md — closed-issue numbers belong in the PR's own CHANGELOG entry.** The `docs/CHANGELOG.md` **Closed issues:** list has drifted out of sync with what PRs actually closed, because adding the issue number there was left as a later afterthought instead of part of authoring the PR's changelog bullet. (#1910 backfills what had already drifted.)

Docs-only; no code or build changes.

---

An earlier revision of this PR also documented a `gh pr edit --body-file` failure on this repo, attributed to Projects (classic) still being enabled. That attribution was wrong: disabling the repo's `has_projects` setting did not fix the failure, but upgrading the local `gh` CLI from 2.54.0 to 2.97.0 did — it was an outdated client still querying a sunset GraphQL field, not a repo setting. That note and its workaround have been removed.
