### PR TITLE
Degrade gracefully when `@DefaultQualifier` lacks `applyToSubpackages`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
@@ -405,14 +405,24 @@ public class NullnessNoInitAnnotatedTypeFactory
                 MONOTONIC_NONNULL);
 
         if (checker.getUltimateParentChecker().getBooleanOption("jspecifyNullMarkedAlias", true)) {
-            AnnotationMirror nullMarkedDefaultQual =
+            AnnotationBuilder nullMarkedDefaultQualBuilder =
                     new AnnotationBuilder(processingEnv, DefaultQualifier.class)
                             .setValue("value", NonNull.class)
                             .setValue(
                                     "locations",
-                                    new TypeUseLocation[] {TypeUseLocation.UPPER_BOUND})
-                            .setValue("applyToSubpackages", false)
-                            .build();
+                                    new TypeUseLocation[] {TypeUseLocation.UPPER_BOUND});
+            // The applyToSubpackages element is an EISOP-specific addition to @DefaultQualifier;
+            // it is absent if the classpath resolves @DefaultQualifier from upstream typetools
+            // checker-qual instead of EISOP's fork. QualifierDefaults's constructor already warns
+            // about that mismatch once per checker run, so this site degrades silently: the built
+            // annotation simply carries no applyToSubpackages value, matching how any other
+            // @DefaultQualifier built or written without that element behaves.
+            if (TreeUtils.getMethodOrNull(
+                            DefaultQualifier.class, "applyToSubpackages", 0, processingEnv)
+                    != null) {
+                nullMarkedDefaultQualBuilder.setValue("applyToSubpackages", false);
+            }
+            AnnotationMirror nullMarkedDefaultQual = nullMarkedDefaultQualBuilder.build();
             addAliasedDeclAnnotation(
                     "org.jspecify.annotations.NullMarked",
                     DefaultQualifier.class.getCanonicalName(),

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -55,6 +55,7 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
 
 /**
  * Determines the default qualifiers on a type. Default qualifiers are specified via the {@link
@@ -91,8 +92,11 @@ public class QualifierDefaults {
     /** The locations() element/field of a @DefaultQualifier annotation. */
     protected final ExecutableElement defaultQualifierLocationsElement;
 
-    /** The applyToSubpackages() element/field of a @DefaultQualifier annotation. */
-    protected final ExecutableElement defaultQualifierApplyToSubpackagesElement;
+    /**
+     * The applyToSubpackages() element/field of a @DefaultQualifier annotation. Null if the version
+     * of {@code @DefaultQualifier} on the classpath predates this element.
+     */
+    protected final @Nullable ExecutableElement defaultQualifierApplyToSubpackagesElement;
 
     /** The value() element/field of a @DefaultQualifier.List annotation. */
     protected final ExecutableElement defaultQualifierListValueElement;
@@ -229,7 +233,18 @@ public class QualifierDefaults {
         this.defaultQualifierLocationsElement =
                 TreeUtils.getMethod(DefaultQualifier.class, "locations", 0, processingEnv);
         this.defaultQualifierApplyToSubpackagesElement =
-                TreeUtils.getMethod(DefaultQualifier.class, "applyToSubpackages", 0, processingEnv);
+                TreeUtils.getMethodOrNull(
+                        DefaultQualifier.class, "applyToSubpackages", 0, processingEnv);
+        if (this.defaultQualifierApplyToSubpackagesElement == null) {
+            atypeFactory
+                    .getChecker()
+                    .message(
+                            Diagnostic.Kind.NOTE,
+                            "The @DefaultQualifier annotation on the classpath does not define the"
+                                    + " applyToSubpackages element; package defaults will apply to"
+                                    + " subpackages. Use the EISOP checker-qual artifact to control this"
+                                    + " behavior.");
+        }
         this.defaultQualifierListValueElement =
                 TreeUtils.getMethod(DefaultQualifier.List.class, "value", 0, processingEnv);
     }
@@ -665,8 +680,12 @@ public class QualifierDefaults {
                             TypeUseLocation.class,
                             defaultQualifierValueDefault);
             boolean applyToSubpackages =
-                    AnnotationUtils.getElementValue(
-                            dq, defaultQualifierApplyToSubpackagesElement, Boolean.class, true);
+                    defaultQualifierApplyToSubpackagesElement == null
+                            || AnnotationUtils.getElementValue(
+                                    dq,
+                                    defaultQualifierApplyToSubpackagesElement,
+                                    Boolean.class,
+                                    true);
 
             DefaultSet ret = new DefaultSet();
             for (TypeUseLocation loc : locations) {

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1316,6 +1316,25 @@ public final class TreeUtils {
     }
 
     /**
+     * Returns the ExecutableElement for a method declaration. Returns null if there is no matching
+     * method. Errs if there is more than one matching method.
+     *
+     * @param type the class that contains the method
+     * @param methodName the name of the method
+     * @param params the number of formal parameters
+     * @param env the processing environment
+     * @return the ExecutableElement for the specified method, or null
+     */
+    public static @Nullable ExecutableElement getMethodOrNull(
+            Class<?> type, String methodName, int params, ProcessingEnvironment env) {
+        String typeName = type.getCanonicalName();
+        if (typeName == null) {
+            throw new BugInCF("TreeUtils.getMethodOrNull: class %s has no canonical name", type);
+        }
+        return getMethodOrNull(typeName, methodName, params, env);
+    }
+
+    /**
      * Returns the ExecutableElement for a method declaration. Errs if there is not exactly one
      * matching method. If more than one method takes the same number of formal parameters, then use
      * {@link #getMethod(String, String, ProcessingEnvironment, String...)}.


### PR DESCRIPTION
Closes #1244.

`applyToSubpackages` is an EISOP-specific addition to `@DefaultQualifier`,
not present in upstream typetools `checker-qual`. Two places assumed it
always exists and crashed with `BugInCF` if a project's classpath resolved
`@DefaultQualifier` from upstream `checker-qual` instead of EISOP's fork
(the combination reported in #1107, whose stack trace goes through
`QualifierDefaults`'s constructor):

- `QualifierDefaults`'s constructor used `TreeUtils.getMethod`, which
  throws when the element isn't found.
- `NullnessNoInitAnnotatedTypeFactory` builds a synthetic
  `@DefaultQualifier` to alias `org.jspecify.annotations.NullMarked`,
  unconditionally setting `applyToSubpackages` via `AnnotationBuilder`,
  which throws the same way when the element doesn't exist to set.

Adds `TreeUtils.getMethodOrNull(Class<?>, String, int,
ProcessingEnvironment)`, delegating to the existing `String`-keyed
overload of the same name. `QualifierDefaults` now uses it, keeps the
field nullable, issues one `NOTE` per checker instance explaining that
package defaults will apply to subpackages unconditionally, and treats an
absent element as `applyToSubpackages=true` when reading a written
`@DefaultQualifier` (matching what code written against upstream
`checker-qual` already assumes, since there is no way for it to opt out).
`NullnessNoInitAnnotatedTypeFactory` checks for the element before
setting it, silently omitting it if absent; `QualifierDefaults`'s own note
already explains the mismatch once per run, so this site does not
duplicate it.

## Testing

Verified by temporarily removing `applyToSubpackages` from
`checker-qual`'s `DefaultQualifier.java`, rebuilding, and confirming a
`@DefaultQualifier`-using compile now emits the note and produces the
correct type-checking result instead of crashing; restored `checker-qual`
and confirmed the normal case emits no spurious notes and behaves
identically. `:framework:test`, `:javacutil:test`, and `NullnessTest`
(23/23) pass; spotless clean.
