### PR TITLE
JavaStubifier: document and pin multi-directory fake-override safety

### DIFF
--- a/framework/src/stubifier/java/org/checkerframework/framework/stubifier/JavaStubifier.java
+++ b/framework/src/stubifier/java/org/checkerframework/framework/stubifier/JavaStubifier.java
@@ -50,6 +50,14 @@ import java.util.Optional;
  * the stubifier's own build classpath) aborts the run with a message naming the annotation and the
  * source file being processed; see {@link #SKIP_UNLOADABLE_ANNOTATIONS_FLAG} for the opt-in flag
  * that trades that safety for being able to finish the run anyway.
+ *
+ * <p>Each directory is processed by its own {@link BinaryStubWriter} into its own output file (see
+ * {@link #process}). An interface and its implementer being in different directories does not
+ * weaken fake-override handling: a writer records every unannotated method it sees as a
+ * presence-only signature unconditionally ({@code BinaryStubWriter.addMethodRecord}), with no
+ * dependence on the interfaces that writer happened to see, and the fake-override match runs at
+ * read time over the real class hierarchy ({@code BinaryStubReader.applyFakeOverride}, {@code
+ * FakeOverrideResolver}).
  */
 public class JavaStubifier {
     /**

--- a/framework/src/test/java/org/checkerframework/framework/stubifier/BinaryStubWriterTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/stubifier/BinaryStubWriterTest.java
@@ -43,6 +43,26 @@ public class BinaryStubWriterTest {
         }
     }
 
+    /**
+     * Writes an already-populated writer to a temporary file and reads the result back.
+     *
+     * @param writer a writer that has already processed its compilation units
+     * @return the binary stub data the writer produced
+     * @throws IOException if the temporary file cannot be written or read
+     */
+    private static BinaryStubData writeAndRead(BinaryStubWriter writer) throws IOException {
+        File tmp = File.createTempFile("binarystubwritertest", ".bin.gz");
+        tmp.deleteOnExit();
+        try {
+            writer.writeTo(tmp);
+            try (InputStream in = Files.newInputStream(tmp.toPath())) {
+                return new BinaryStubData(in);
+            }
+        } finally {
+            tmp.delete();
+        }
+    }
+
     /** Source declaring one annotated and one unannotated method, field, and enum constant. */
     private static final String MIXED_MEMBERS =
             "import org.checkerframework.checker.nullness.qual.Nullable;\n"
@@ -134,6 +154,53 @@ public class BinaryStubWriterTest {
                 1,
                 cr.presenceOnlyMethodSigs.length);
         Assert.assertEquals("m()", data.stringPool[cr.presenceOnlyMethodSigs[0]]);
+    }
+
+    /**
+     * A multi-directory {@link JavaStubifier} run creates a fresh {@link BinaryStubWriter} per
+     * directory (see {@code JavaStubifier.process}), so an interface in one directory and its
+     * implementer in another are processed by different writers. This pins that the split does not
+     * change the implementer's binary output: whether an unannotated method is retained as a
+     * presence-only fake-override signature ({@code ClassRecord.presenceOnlyMethodSigs}) depends
+     * only on the implementer's own declaration, never on whether the interface it overrides was
+     * processed by the same writer. Both writers below record {@code describe()} identically.
+     *
+     * <p>The retention is unconditional (see {@code BinaryStubWriter.addMethodRecord}) precisely so
+     * that no cross-writer -- hence no cross-directory -- interface knowledge is needed: the
+     * fake-override match itself is a read-time search over the real class hierarchy ({@code
+     * BinaryStubReader.applyFakeOverride}, {@code FakeOverrideResolver}), which no writer-side
+     * state feeds. A future change that made omission depend on the interfaces a writer happens to
+     * have seen would be unsafe across directories and would fail this test.
+     */
+    @Test
+    public void implementerOutputDoesNotDependOnTheInterfaceBeingInTheSameWriter()
+            throws IOException {
+        String iface = "public interface Service { String describe(); }\n";
+        String impl =
+                "public class ServiceImpl implements Service {\n"
+                        + "  public String describe() { return null; }\n"
+                        + "}\n";
+
+        // "Directory B" processed alone: a writer that never saw the interface.
+        BinaryStubWriter writerImplOnly = new BinaryStubWriter(/* omitUnannotatedMembers= */ true);
+        writerImplOnly.process(StaticJavaParser.parse(impl));
+
+        // The interface and implementer in one directory, the single-writer case.
+        BinaryStubWriter writerBoth = new BinaryStubWriter(/* omitUnannotatedMembers= */ true);
+        writerBoth.process(StaticJavaParser.parse(iface));
+        writerBoth.process(StaticJavaParser.parse(impl));
+
+        for (BinaryStubData data :
+                new BinaryStubData[] {writeAndRead(writerImplOnly), writeAndRead(writerBoth)}) {
+            BinaryStubData.ClassRecord cr = data.classes.get("ServiceImpl");
+            Assert.assertNotNull("ServiceImpl must be recorded", cr);
+            Assert.assertEquals(
+                    "describe() must be retained as a presence-only fake-override signature,"
+                            + " independent of whether the interface was in the same writer",
+                    1,
+                    cr.presenceOnlyMethodSigs.length);
+            Assert.assertEquals("describe()", data.stringPool[cr.presenceOnlyMethodSigs[0]]);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #1863.

Issue #1863 asked whether a multi-directory `JavaStubifier` run is safe
for fake overrides, given that each directory is processed by its own
`BinaryStubWriter`: an interface in directory A and its implementer in
directory B are written by different writers into different output
files. The issue referenced a per-writer `interfaceMethodSigs` set that
decided, from interface knowledge, whether an unannotated member could
be omitted — which would indeed be unsound across directories.

That mechanism no longer exists. The writer keeps every unannotated
method's signature unconditionally as a presence-only entry
(`addMethodRecord` → `ClassRecord.presenceOnlyMethodSigs`), using only
per-method local information, with no dependence on the interfaces the
writer happened to see. The fake-override match runs at read time over
the real class hierarchy (`BinaryStubReader.applyFakeOverride`,
`FakeOverrideResolver`), which no writer-side state feeds. So the
per-directory split loses nothing.

Verified end-to-end: running `JavaStubifier` on two directories
(interface in one, implementer in the other) produces two files, each
containing only its own directory's class, and the implementer's file
retains its fake-override method as a presence-only signature despite
the interface being processed by a different writer entirely.

Adds a Javadoc note on `JavaStubifier` stating this, and a regression
test that pins it: an implementer's binary output is identical whether
or not the interface it overrides was processed by the same writer. A
future change that made omission depend on the interfaces a writer has
seen — reviving the unsound design the issue was concerned about —
would fail the test.

No CHANGELOG entry: this is documentation and a regression test only,
with no behavioral or perf change.

## Testing

`BinaryStubWriterTest` (26/26, including the new regression test) and
the real two-directory reproduction above.
