### PR TITLE
Fix JDK 11 anonymous class bug and unify anonymous class handling

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -127,7 +127,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
 
         // Anon inner classes should not inherit the package annotation, since
         // they're so often used for closures to run async on background threads.
-        if (isAnonymousType(cls)) {
+        if (ElementUtils.isAnonymous(cls)) {
             // However, we need to look into Anonymous class effect inference
             if (uiAnonClasses.contains(cls)) {
                 return true;
@@ -160,11 +160,6 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         return false;
-    }
-
-    // TODO: is there a framework method for this?
-    private static boolean isAnonymousType(TypeElement elem) {
-        return elem.getSimpleName().length() == 0;
     }
 
     /**
@@ -246,7 +241,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         // Anonymous inner types should just get the effect of the parent by default, rather than
         // annotating every instance. Unless it's implementing a polymorphic supertype, in which
         // case we still want the developer to be explicit.
-        if (isAnonymousType(targetClassElt)) {
+        if (ElementUtils.isAnonymous(targetClassElt)) {
             boolean canInheritParentEffects = true; // Refine this for polymorphic parents
             DeclaredType directSuper = (DeclaredType) targetClassElt.getSuperclass();
             TypeElement superElt = (TypeElement) directSuper.asElement();
@@ -491,7 +486,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
                     //   "new @UI Runnable {...}"
                     // parses as @UI on an anon class decl extending Runnable
                     boolean isAnonInstantiation =
-                            isAnonymousType(declaringType)
+                            ElementUtils.isAnonymous(declaringType)
                                     && (fromElement(declaringType).hasAnnotation(UI.class)
                                             || uiAnonClasses.contains(declaringType));
                     if (!isAnonInstantiation && !overriddenType.hasAnnotation(UI.class)) {
@@ -587,7 +582,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
      *     instantiation of an UI-polymorphic superclass.
      */
     public void constrainAnonymousClassToUI(TypeElement classElt) {
-        assert TypesUtils.isAnonymous(classElt.asType());
+        assert ElementUtils.isAnonymous(classElt);
         uiAnonClasses.add(classElt);
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -33,7 +33,6 @@ import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
-import org.checkerframework.javacutil.TypesUtils;
 
 import java.util.ArrayDeque;
 import java.util.List;
@@ -311,7 +310,7 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
             // Note: All these checks should be fast in the common case, but happen for every method
             // call inside the anonymous class. Consider a cache here if profiling surfaces this as
             // taking too long.
-            if (TypesUtils.isAnonymous(callerReceiverType)
+            if (ElementUtils.isAnonymous(callerReceiverElt)
                     // Skip if already inferred @UI
                     && !effStack.peek().isUI()
                     // Ignore if explicitly annotated

--- a/checker/tests/nullness/AnonymousClassTypeAnnotation.java
+++ b/checker/tests/nullness/AnonymousClassTypeAnnotation.java
@@ -1,0 +1,9 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class AnonymousClassTypeAnnotation {
+    @SuppressWarnings("nullness.on.supertype")
+    void test() {
+        // :: error: (nullness.on.new.object)
+        new @Nullable Object() {};
+    }
+}

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -780,7 +780,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      * @param classTree the class to check
      */
     protected void warnInvalidPolymorphicQualifier(ClassTree classTree) {
-        if (TypesUtils.isAnonymous(TreeUtils.typeOf(classTree))) {
+        if (TreeUtils.isAnonymousClass(classTree)) {
             // Anonymous class can have polymorphic annotations, so don't check them.
             return;
         }
@@ -935,7 +935,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      * @param classTree class tree to check
      */
     protected void checkExtendsAndImplements(ClassTree classTree) {
-        if (TypesUtils.isAnonymous(TreeUtils.typeOf(classTree))) {
+        if (TreeUtils.isAnonymousClass(classTree)) {
             // Don't check extends clause on anonymous classes.
             return;
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -16,6 +16,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcard
 import org.checkerframework.framework.type.visitor.AnnotatedTypeVisitor;
 import org.checkerframework.framework.util.AnnotationFormatter;
 import org.checkerframework.framework.util.DefaultAnnotationFormatter;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 import org.plumelib.util.WeakIdentityHashMap;
@@ -244,12 +245,10 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
                 sb.append('.');
             }
             Element typeElt = type.getUnderlyingType().asElement();
-            String smpl = typeElt.getSimpleName().toString();
-            if (smpl.isEmpty()) {
-                // For anonymous classes smpl is empty - toString
-                // of the element is more useful.
-                smpl = typeElt.toString();
-            }
+            String smpl =
+                    ElementUtils.isAnonymous(typeElt)
+                            ? typeElt.toString()
+                            : typeElt.getSimpleName().toString();
             sb.append(
                     annoFormatter.formatAnnotationString(
                             type.getAnnotationsField(), currentPrintInvisibleSetting));

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TypeDeclarationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TypeDeclarationApplier.java
@@ -9,7 +9,7 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
-import org.checkerframework.javacutil.TypesUtils;
+import org.checkerframework.javacutil.ElementUtils;
 
 import java.util.List;
 
@@ -121,7 +121,7 @@ public class TypeDeclarationApplier extends TargetedElementAnnotationApplier {
     @Override
     protected void handleTargeted(List<TypeCompound> extendsAndImplementsAnnos)
             throws UnexpectedAnnotationLocationException {
-        if (TypesUtils.isAnonymous(typeSymbol.type)) {
+        if (ElementUtils.isAnonymous(typeSymbol)) {
             // If this is an anonymous class, then the annotations after "new" but before the class
             // name are stored as super class annotations. Treat them as annotations on the class.
             for (Attribute.TypeCompound anno : extendsAndImplementsAnnos) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -558,7 +558,7 @@ public class InferenceFactory {
             Element classEle =
                     ElementUtils.enclosingTypeElement(
                             TreeUtils.elementFromUse((NewClassTree) invocation));
-            if (classEle.getSimpleName().contentEquals("")) {
+            if (ElementUtils.isAnonymous(classEle)) {
                 classEle =
                         ((DeclaredType)
                                         TreeUtils.typeOf(

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -1,5 +1,8 @@
 package org.checkerframework.javacutil;
 
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
@@ -39,6 +42,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
+import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
@@ -864,6 +868,35 @@ public class ElementUtils {
      */
     public static boolean isTypeElement(Element element) {
         return typeElementKinds().contains(element.getKind());
+    }
+
+    /**
+     * Return true if the element is an anonymous class.
+     *
+     * @param element the element to test
+     * @return true if the element is an anonymous class
+     * @see #isAnonymousConstructor(Element)
+     * @see TreeUtils#isAnonymousClass(ClassTree)
+     * @see TypesUtils#isAnonymous(TypeMirror)
+     */
+    public static boolean isAnonymous(Element element) {
+        return element instanceof TypeElement
+                && ((TypeElement) element).getNestingKind() == NestingKind.ANONYMOUS;
+    }
+
+    /**
+     * Return true if the element is a constructor of an anonymous class.
+     *
+     * @param element the element to test
+     * @return true if the element is a constructor of an anonymous class
+     * @see #isAnonymous(Element)
+     * @see TreeUtils#isAnonymousConstructor(MethodTree)
+     * @see TreeUtils#isAnonymousConstructorWithExplicitEnclosingExpression(ExecutableElement,
+     *     NewClassTree)
+     */
+    public static boolean isAnonymousConstructor(Element element) {
+        return element.getKind() == ElementKind.CONSTRUCTOR
+                && isAnonymous(element.getEnclosingElement());
     }
 
     /**

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1782,6 +1782,17 @@ public final class TreeUtils {
     }
 
     /**
+     * Returns true if the given tree declares an anonymous class.
+     *
+     * @param classTree a class declaration
+     * @return whether {@code classTree} declares an anonymous class
+     */
+    public static boolean isAnonymousClass(ClassTree classTree) {
+        TypeElement typeElement = elementFromDeclaration(classTree);
+        return typeElement.getNestingKind() == NestingKind.ANONYMOUS;
+    }
+
+    /**
      * Returns true if the given {@link MethodTree} is an anonymous constructor (the constructor for
      * an anonymous class).
      *

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -108,7 +108,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
-import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -1805,10 +1804,11 @@ public final class TreeUtils {
      *
      * @param classTree a class declaration
      * @return whether {@code classTree} declares an anonymous class
+     * @see ElementUtils#isAnonymous(Element)
+     * @see TypesUtils#isAnonymous(TypeMirror)
      */
     public static boolean isAnonymousClass(ClassTree classTree) {
-        TypeElement typeElement = elementFromDeclaration(classTree);
-        return typeElement.getNestingKind() == NestingKind.ANONYMOUS;
+        return ElementUtils.isAnonymous(elementFromDeclaration(classTree));
     }
 
     /**
@@ -1817,14 +1817,12 @@ public final class TreeUtils {
      *
      * @param method a method tree that may be an anonymous constructor
      * @return true if the given path points to an anonymous constructor, false if it does not
+     * @see ElementUtils#isAnonymousConstructor(Element)
+     * @see #isAnonymousConstructorWithExplicitEnclosingExpression(ExecutableElement, NewClassTree)
      */
     public static boolean isAnonymousConstructor(MethodTree method) {
         Element e = elementFromTree(method);
-        if (e == null || e.getKind() != ElementKind.CONSTRUCTOR) {
-            return false;
-        }
-        TypeElement typeElement = (TypeElement) e.getEnclosingElement();
-        return typeElement.getNestingKind() == NestingKind.ANONYMOUS;
+        return e != null && ElementUtils.isAnonymousConstructor(e);
     }
 
     /**
@@ -1833,14 +1831,12 @@ public final class TreeUtils {
      * @param con an ExecutableElement of a constructor declaration
      * @param tree the NewClassTree of a constructor declaration
      * @return true if there is an extra enclosing expression
+     * @see ElementUtils#isAnonymousConstructor(Element)
+     * @see #isAnonymousConstructor(MethodTree)
      */
     public static boolean isAnonymousConstructorWithExplicitEnclosingExpression(
             ExecutableElement con, NewClassTree tree) {
-
-        return (tree.getEnclosingExpression() != null)
-                && con.getKind() == ElementKind.CONSTRUCTOR
-                && ((TypeElement) con.getEnclosingElement()).getNestingKind()
-                        == NestingKind.ANONYMOUS;
+        return tree.getEnclosingExpression() != null && ElementUtils.isAnonymousConstructor(con);
     }
 
     /**

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -1,5 +1,6 @@
 package org.checkerframework.javacutil;
 
+import com.sun.source.tree.ClassTree;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
@@ -32,7 +33,6 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
-import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.ArrayType;
@@ -469,11 +469,12 @@ public final class TypesUtils {
      *
      * @param type the type to check
      * @return whether the argument is an anonymous type
+     * @see ElementUtils#isAnonymous(Element)
+     * @see TreeUtils#isAnonymousClass(ClassTree)
      */
     public static boolean isAnonymous(TypeMirror type) {
         return (type instanceof DeclaredType)
-                && ((TypeElement) ((DeclaredType) type).asElement()).getNestingKind()
-                        == NestingKind.ANONYMOUS;
+                && ElementUtils.isAnonymous(((DeclaredType) type).asElement());
     }
 
     /**


### PR DESCRIPTION
Found in #1013.

This PR adds a Nullness Checker test that exposes a JDK 11-specific anonymous-class detection bug.

  For:

  ```java
  new @Nullable Object() {};
```

  JDK 11 incorrectly reports two additional declaration.inconsistent.with.extends.clause
  errors:

  - `@Nullable cannot extend @NonNull`
  - `@UnknownInitialization cannot extend @Initialized`

  The problem is that TypesUtils.isAnonymous(TreeUtils.typeOf(classTree)) does not recognize
  this annotated anonymous class on JDK 11. Newer JDKs do not produce these diagnostics.

  This test-only commit is expected to fail the JDK 11 CI job, confirming the regression
  before adding the framework fix.