### PR TITLE
CHANGELOG: backfill missing entries in the Closed issues list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -254,8 +254,9 @@ Other improvements and bug fixes:
 
 **Closed issues:**
 
-eisop#433, eisop#792, eisop#863, eisop#1015, eisop#1074, eisop#1315,
-eisop#1653, eisop#1801, eisop#1819.
+eisop#433, eisop#792, eisop#863, eisop#949, eisop#1015, eisop#1074,
+eisop#1244, eisop#1315, eisop#1653, eisop#1801, eisop#1818, eisop#1819,
+eisop#1861, eisop#1862, eisop#1863, eisop#1865.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -255,8 +255,9 @@ Other improvements and bug fixes:
 **Closed issues:**
 
 eisop#433, eisop#792, eisop#863, eisop#949, eisop#1015, eisop#1074,
-eisop#1244, eisop#1315, eisop#1653, eisop#1801, eisop#1818, eisop#1819,
-eisop#1861, eisop#1862, eisop#1863, eisop#1865.
+eisop#1244, eisop#1315, eisop#1592, eisop#1642, eisop#1653, eisop#1735,
+eisop#1801, eisop#1818, eisop#1819, eisop#1861, eisop#1862, eisop#1863,
+eisop#1865, eisop#1887.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)


### PR DESCRIPTION
The **Closed issues:** list under the current unreleased version
(3.49.5-eisop2) had drifted out of sync with what was actually closed
since the last release — presumably because adding an issue number
there was left as an afterthought rather than done as part of authoring
each PR's own changelog bullet. (See #1904, which adds a note requiring
this going forward.)

## Methodology (two passes)

**Pass 1 — merged PR bodies.** Audited every PR merged since the
3.49.5-eisop1 release (commit `04b78326d`) — 182 PRs — by fetching each
PR's body and searching for a GitHub auto-close keyword
(`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`,
`resolve`/`resolves`/`resolved`) directly preceding an issue reference in
this repository. Manually reviewed every match to exclude false
positives (several dependency-update PR bodies reference `#NNNN` issues
in *other* repositories — error-prone, `actions/cache`, `ruff` — which
are not this repository's issues).

**Pass 2 — the issue tracker directly.** Pass 1 only catches issues
closed *by* a PR's own auto-close keyword. It misses an issue closed
without one: a direct manual close, sometimes with an explanatory
comment or a cross-reference to the motivating PR instead of a
"Closes #N" in the PR body. Queried the GitHub issue search API directly
for every issue closed since the 3.49.5-eisop1 release date and
cross-checked the result against pass 1's list.

Verified every candidate issue number from both passes is real and
closed via the GitHub API before adding it.

## Eleven entries were missing

From pass 1 (closed by a PR's own auto-close keyword):

- eisop#949 — closed by #1890 (`@MonotonicNonNull` on static fields)
- eisop#1244 — closed by #1906 (`applyToSubpackages` crash)
- eisop#1818 — closed by #1903 (`NullnessNoInitStore` cache naming)
- eisop#1861 — closed by #1895 (stub-parser resolution gaps)
- eisop#1862 — closed by #1884 (fake-override snapshot order)
- eisop#1863 — closed by #1907 (`JavaStubifier` multi-directory)
- eisop#1865 — closed by #1889 (shared fake-override search)

From pass 2 (closed manually, no auto-close keyword):

- eisop#1592 — closed with an explanatory comment, no PR
- eisop#1642 — closed with an explanatory comment, no PR
- eisop#1735 — closed cross-referencing #1875, no auto-close keyword
- eisop#1887 — closed cross-referencing #1888, no auto-close keyword

The list now has all 20 issues closed since the last release.

Not included: #1564, closed by the still-open PR #1908 — it isn't
actually closed until that PR merges.
