### PR TITLE
AnnotationFileParser: avoid pretty-printing a whole class body in a warning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -177,6 +177,13 @@ ignored, including any declaration annotations written on it, such as the
 `com.sun.tools.javac.api.ClientCodeWrapper.Trusted` and
 `java.lang.invoke.LambdaForm.Compiled` write on themselves.
 
+Fixed `AnnotationFileParser` to report a type-parameter-count mismatch on a
+class, interface, enum, or record declaration using just its name, instead of
+pretty-printing the declaration's entire body (every member) into the warning
+message. The full-body dump was both hard to read and expensive to construct
+for a large class; a method or constructor declaration, which has no body in
+an annotation file, is unaffected.
+
 Enabled the Gradle configuration cache, speeding up build times.
 
 Added the `-AinferenceWorkBudget=N` command-line option to bound Java

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -2014,6 +2014,21 @@ public class AnnotationFileParser {
                 AnnotationMirrorSet.singleton(fromStubFileAnno));
     }
 
+    /**
+     * Annotates each type variable in {@code typeArguments} with the annotations written on the
+     * corresponding {@code typeParameters} declaration in the annotation file, including its
+     * bound(s). If {@code typeParameters} and {@code typeArguments} have different sizes, issues a
+     * warning (mentioning {@code decl} and {@code elt} for context) and returns without annotating
+     * anything.
+     *
+     * @param decl the type or callable declaration, as read from the annotation file, that owns
+     *     {@code typeParameters}; used only for diagnostics
+     * @param elt the type or executable element corresponding to {@code decl}; used only for
+     *     diagnostics
+     * @param typeArguments the type variables to be annotated
+     * @param typeParameters the type parameter declarations read from the annotation file, or null
+     *     if {@code decl} has none
+     */
     private void annotateTypeParameters(
             BodyDeclaration<?> decl, // for debugging
             Object elt, // for debugging; TypeElement or ExecutableElement
@@ -2024,6 +2039,15 @@ public class AnnotationFileParser {
         }
 
         if (typeParameters.size() != typeArguments.size()) {
+            // For a type declaration, `decl.toString()` pretty-prints the entire body
+            // (every member, recursively), which is unbounded in size and can be very
+            // expensive for a large class; only its name is useful for debugging here.
+            // A method/constructor declaration in an annotation file has no body, so
+            // `decl.toString()` is already just its (cheap) signature.
+            String declString =
+                    decl instanceof TypeDeclaration
+                            ? ((TypeDeclaration<?>) decl).getNameAsString()
+                            : decl.toString().replace(LINE_SEPARATOR, " ");
             String msg =
                     String.format(
                             "annotateTypeParameters: mismatched sizes:"
@@ -2034,7 +2058,7 @@ public class AnnotationFileParser {
                             typeParameters,
                             typeArguments.size(),
                             typeArguments,
-                            decl.toString().replace(LINE_SEPARATOR, " "),
+                            declString,
                             elt.toString().replace(LINE_SEPARATOR, " "),
                             elt.getClass());
             if (!debugAnnotationFileParser) {


### PR DESCRIPTION
## Summary
- `annotateTypeParameters()`'s mismatched-type-parameter-count warning built its message with `decl.toString()`. For a class/interface/enum/record declaration this pretty-prints the entire body (every member, recursively) via javaparser, not just a signature.
- Found while stress-testing the Nullness Checker's stub-file loading on real Guava code with several large generated stub files (JDK classes, 2000+ signatures total): a few files with a class-level type-parameter mismatch showed real, visible CPU under javaparser's `DefaultPrettyPrinterVisitor` in a JFR trace, plus an unreadably huge warning message.
- Fix: print just the declaration's name for a type declaration. A method/constructor declaration has no body in an annotation file, so its `toString()` was already cheap and is untouched.

## Test plan
- [x] `./gradlew assemble` — succeeds
- [x] `./gradlew :framework:test :javacutil:test :dataflow:test` — pass
- [x] `./gradlew :checker:test --tests "*Stubparser*"` and `NullnessStubfileTest` — pass
- [x] `./gradlew :checker:NullnessTest` — pass (22/22)
- [x] `./gradlew requireJavadoc` — no new warnings (two pre-existing unrelated warnings in this file, on methods this PR doesn't touch)
- [ ] `./gradlew alltests` was **not** run (large blast-radius suite); given the change only affects the text of one diagnostic message in one code path, the focused suites above were judged sufficient. Happy to run it if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)