### PR TITLE
Preserve a type-variable bound's primary qualifier during capture conversion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -137,6 +137,14 @@ Optional Checker's `prefer.map.and.orelse` warning for `if (VAR.isPresent())
 of the message's 3 arguments. `-Anomsgtext`, which every JUnit test uses, had
 masked the bug by skipping message formatting entirely.
 
+Fixed capture conversion dropping a primary qualifier from a type-parameter
+bound that is itself a type-variable use. For a parameter declared
+`<A, U extends @Q A>`, capturing a wildcard argument for `U` now applies `@Q`
+to the substituted bound `A theta` (per JLS 5.1.10) instead of discarding it,
+so the captured type variable's upper bound is no longer computed too low.
+Previously the missing qualifier could silently suppress an
+`assignment.type.incompatible` error.
+
 **Implementation details:**
 
 `SourceChecker.reportError` and `SourceChecker.reportWarning` now accept a null

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -6251,8 +6251,14 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             AnnotatedWildcardType wildcard,
             AnnotatedTypeVariable typeVariable,
             AnnotatedTypeVariable capturedTypeVar) {
+        // Per JLS 5.1.10, the captured type variable's upper bound is glb(B, S theta), where S is
+        // the type parameter's declared upper bound.  Use the copying substitution so that when S
+        // is itself a type-variable use carrying a primary annotation (as in the declaration
+        // `U extends @Q A`), that primary annotation is applied to the substitute rather than
+        // dropped.  The no-copy substitution returns the raw argument for A and loses @Q, which
+        // would corrupt the glb below.  The deep copy also avoids mutating the shared argument.
         AnnotatedTypeMirror typeVarUpperBound =
-                typeVarSubstitutor.substituteWithoutCopyingTypeArguments(
+                typeVarSubstitutor.substitute(
                         typeVarToAnnotatedTypeArg, typeVariable.getUpperBound());
         AnnotatedTypeMirror upperBound =
                 AnnotatedTypes.annotatedGLB(this, typeVarUpperBound, wildcard.getExtendsBound());

--- a/framework/tests/typedeclbounds/CaptureTypeVarBound.java
+++ b/framework/tests/typedeclbounds/CaptureTypeVarBound.java
@@ -1,0 +1,30 @@
+import org.checkerframework.framework.testchecker.typedeclbounds.quals.Bottom;
+import org.checkerframework.framework.testchecker.typedeclbounds.quals.S1;
+
+class CaptureTypeVarBound {
+
+    // BROKEN: the type-parameter bound is itself an (annotated) type variable, @S1 A.
+    interface HolderTV<A, U extends @S1 A> {
+        U get();
+    }
+
+    <T extends @Bottom Object> void broken(HolderTV<T, ? extends @S1 T> h) {
+        // Capture UB should be glb(@S1 T, @S1 T) = @S1 T; @S1 is NOT a subtype of @Bottom,
+        // so this assignment must be flagged.
+        // BUG: the @S1 on the bound `@S1 A` is dropped during the capture substitution,
+        // the capture UB collapses to @Bottom, and NO error is issued.
+        // :: error: (assignment.type.incompatible)
+        @Bottom Object x = h.get();
+    }
+
+    // WORKING contrast: the type-parameter bound is a class, @S1 Object.
+    interface HolderObj<U extends @S1 Object> {
+        U get();
+    }
+
+    void working(HolderObj<? extends @S1 Object> h) {
+        // Capture UB is correctly @S1; this assignment is correctly flagged today.
+        // :: error: (assignment.type.incompatible)
+        @Bottom Object x = h.get();
+    }
+}

--- a/framework/tests/typedeclbounds/CaptureTypeVarBound.java
+++ b/framework/tests/typedeclbounds/CaptureTypeVarBound.java
@@ -3,27 +3,25 @@ import org.checkerframework.framework.testchecker.typedeclbounds.quals.S1;
 
 class CaptureTypeVarBound {
 
-    // BROKEN: the type-parameter bound is itself an (annotated) type variable, @S1 A.
+    // The type-parameter bound is itself an (annotated) type variable, @S1 A.
     interface HolderTV<A, U extends @S1 A> {
         U get();
     }
 
-    <T extends @Bottom Object> void broken(HolderTV<T, ? extends @S1 T> h) {
-        // Capture UB should be glb(@S1 T, @S1 T) = @S1 T; @S1 is NOT a subtype of @Bottom,
-        // so this assignment must be flagged.
-        // BUG: the @S1 on the bound `@S1 A` is dropped during the capture substitution,
-        // the capture UB collapses to @Bottom, and NO error is issued.
+    <T extends @Bottom Object> void typeVariableBound(HolderTV<T, ? extends @S1 T> h) {
+        // Capture UB is glb(@S1 T, @S1 T) = @S1 T; @S1 is NOT a subtype of @Bottom, so this
+        // assignment must be flagged.
         // :: error: (assignment.type.incompatible)
         @Bottom Object x = h.get();
     }
 
-    // WORKING contrast: the type-parameter bound is a class, @S1 Object.
+    // Contrast: the type-parameter bound is a class, @S1 Object.
     interface HolderObj<U extends @S1 Object> {
         U get();
     }
 
-    void working(HolderObj<? extends @S1 Object> h) {
-        // Capture UB is correctly @S1; this assignment is correctly flagged today.
+    void classBound(HolderObj<? extends @S1 Object> h) {
+        // Capture UB is @S1; this assignment must be flagged.
         // :: error: (assignment.type.incompatible)
         @Bottom Object x = h.get();
     }


### PR DESCRIPTION
## Summary

Per JLS 5.1.10, capturing a wildcard argument for a type parameter
`<A, U extends @Q A>` computes the captured type variable's upper bound as
`glb(B, S θ)`, where `S` is `U`'s declared bound and `θ` is the capturing
substitution. `AnnotatedTypeFactory.annotateCapturedTypeVar` applied `θ` via
`TypeVariableSubstitutor.substituteWithoutCopyingTypeArguments`, whose
`copyArgument == false` branch returns the raw substituted argument without
applying the bound use's primary annotation. When `S` is itself an annotated
type-variable use (`@Q A`), `@Q` was silently dropped, so the subsequent glb
was computed on a stripped operand and collapsed to a qualifier strictly
below the correct one — the captured upper bound ended up too low, and a
downstream `assignment.type.incompatible` could go unreported (a false
negative). When `S` is a bound over a class instead (`U extends @Q Object`),
there's no type variable to substitute, so that shape was unaffected.

Fix: use the copying substitution (`substitute`) for this one bound instead.
Its `substituteTypeVariable` path already documents and implements applying
the use's primary annotation to a deep copy of the argument, which both
preserves `@Q` and avoids mutating a possibly-shared `AnnotatedTypeMirror`.
The fix is localized to capture conversion — the shared no-copy substitution
used by type inference and other call sites (7 call sites) is unchanged, to
keep the blast radius to the one place the defect was observed.

## Test plan

- [x] Added `framework/tests/typedeclbounds/CaptureTypeVarBound.java`,
      contrasting a type-variable-bound case (`HolderTV`, was broken) against
      a class-bound case (`HolderObj`, always worked); both now correctly
      report `assignment.type.incompatible`, and the previously-broken
      capture's upper bound is confirmed to retain `@S1` instead of
      collapsing to `@Bottom`.
- [x] `./gradlew :framework:test`: 50 suites, 304 tests, 0 failures, 0 errors
      (1 pre-existing, unrelated skip in `AnnotationBuilderTest`). No
      pre-existing test changed status.
- [x] CHANGELOG entry added.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>