### PR TITLE
Consolidate `BaseTypeValidator` and `BaseTypeVisitor` methods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -227,6 +227,28 @@ whose qualifier encoding makes this failure mode common and usually spurious
 can report a warning (or suppress the diagnostic) instead of the default
 hard error.
 
+Target-location validation and bound-stripping logic has been consolidated into
+`BaseTypeValidator`:
+- Methods relocated from `BaseTypeVisitor` to `BaseTypeValidator`:
+  - `validateVariableTargetLocation(Tree, AnnotatedTypeMirror)`
+  - `validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)`
+  - `annotationsDisallowedAtLocation(AnnotatedTypeMirror, TypeUseLocation)`
+  - `createQualAllowedLocations(AnnotatedTypeFactory)`
+  - `shouldStripInvalidLocationQualifiers()`
+- Wrapper methods for `validateVariableTargetLocation` and `validateTargetLocation`
+  were removed from `BaseTypeVisitor` (it now calls `TypeValidator` methods directly).
+- Protected fields relocated from `BaseTypeVisitor` to `BaseTypeValidator`:
+  - `qualAllowedLocations`, `noQualHasTargetLocations`, `ignoreTargetLocations`
+- Renamed and extracted methods within `BaseTypeValidator` for consistency:
+  - `validateWildcardTargetLocations` (was `validateWildCardTargetLocation`)
+  - `annotationsDisallowedAtLocation(AnnotatedTypeMirror, Set<TypeUseLocation>)`
+    (was `annotationsDisallowedAtWildcardBound`)
+  - `validateTypeParameterTargetLocations` (extracted from `visitTypeVariable`)
+  - `stripInvalidLocationQualifiersFromWildcardBounds` (extracted from
+    `validateWildcardTargetLocations`)
+- `TypeValidator` interface now declares `validateVariableTargetLocation`
+  and `validateTargetLocation`.
+
 Performance optimizations:
 - Capped Java type argument inference bound-incorporation work and optimized
   the fixpoint algorithm to short-circuit and re-scan fewer variables.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -247,6 +247,10 @@ Target-location validation and bound-stripping logic has been consolidated into
     `validateWildcardTargetLocations`)
 - `TypeValidator` interface now declares `validateVariableTargetLocation`
   and `validateTargetLocation`.
+- As a result of this pass reordering, `type.invalid.annotations.on.location`
+  diagnostics now appear before `bound.type.incompatible` diagnostics for the
+  same tree.
+
 
 Performance optimizations:
 - Capped Java type argument inference bound-incorporation work and optimized

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -230,13 +230,12 @@ hard error.
 Target-location validation and bound-stripping logic has been consolidated into
 `BaseTypeValidator`:
 - Methods relocated from `BaseTypeVisitor` to `BaseTypeValidator`:
-  - `validateVariableTargetLocation(Tree, AnnotatedTypeMirror)`
-  - `validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)`
+  - `validateVariableTargetLocation(AnnotatedTypeMirror, Tree)`
+    (was `validateVariablesTargetLocation`)
+  - `validateTargetLocation(AnnotatedTypeMirror, Tree, TypeUseLocation)`
   - `annotationsDisallowedAtLocation(AnnotatedTypeMirror, TypeUseLocation)`
   - `createQualAllowedLocations(AnnotatedTypeFactory)`
   - `shouldStripInvalidLocationQualifiers()`
-- Wrapper methods for `validateVariableTargetLocation` and `validateTargetLocation`
-  were removed from `BaseTypeVisitor` (it now calls `TypeValidator` methods directly).
 - Protected fields relocated from `BaseTypeVisitor` to `BaseTypeValidator`:
   - `qualAllowedLocations`, `noQualHasTargetLocations`, `ignoreTargetLocations`
 - Renamed and extracted methods within `BaseTypeValidator` for consistency:

--- a/framework/jtreg/striplocation/StripLocationOff.out
+++ b/framework/jtreg/striplocation/StripLocationOff.out
@@ -1,8 +1,8 @@
+StripLocationTest.java:21:27: compiler.err.proc.messager: [type.invalid.annotations.on.location] annotation @org.checkerframework.framework.testchecker.striplocation.quals.StripUpperOnly used on prohibited locations LOWER_BOUND
 StripLocationTest.java:21:27: compiler.err.proc.messager: [bound.type.incompatible] incompatible bounds in type parameter
 type: T extends @StripBottom Object
 upper bound: @StripBottom Object
 lower bound: @StripUpperOnly NullType
-StripLocationTest.java:21:27: compiler.err.proc.messager: [type.invalid.annotations.on.location] annotation @org.checkerframework.framework.testchecker.striplocation.quals.StripUpperOnly used on prohibited locations LOWER_BOUND
 StripLocationTest.java:24:10: compiler.err.proc.messager: [type.invalid.annotations.on.location] annotation @org.checkerframework.framework.testchecker.striplocation.quals.StripUpperOnly used on prohibited locations SUPER_WILDCARD
 StripLocationTest.java:24:10: compiler.err.proc.messager: [bound.type.incompatible] incompatible bounds in wildcard
 type: ? extends @StripBottom Object

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -884,11 +884,14 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 boolean issueError = true;
                 switch (elemKind) {
                     case LOCAL_VARIABLE:
-                        if (locations.contains(TypeUseLocation.LOCAL_VARIABLE)) issueError = false;
+                        if (locations.contains(TypeUseLocation.LOCAL_VARIABLE)) {
+                            issueError = false;
+                        }
                         break;
                     case EXCEPTION_PARAMETER:
-                        if (locations.contains(TypeUseLocation.EXCEPTION_PARAMETER))
+                        if (locations.contains(TypeUseLocation.EXCEPTION_PARAMETER)) {
                             issueError = false;
+                        }
                         break;
                     case PARAMETER:
                         if (InternalUtils.isThisName(((VariableTree) tree).getName())) {

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -1032,7 +1032,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #shouldStripInvalidLocationQualifiers
      */
-    public List<AnnotationMirror> annotationsDisallowedAtLocation(
+    protected List<AnnotationMirror> annotationsDisallowedAtLocation(
             AnnotatedTypeMirror type, TypeUseLocation required) {
         List<AnnotationMirror> result = Collections.emptyList();
         for (AnnotationMirror am : type.getAnnotations()) {
@@ -1064,7 +1064,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, TypeUseLocation)
      * @see #additionalAnnotationsToStripFromWildcardBound
      */
-    public List<AnnotationMirror> annotationsDisallowedAtLocation(
+    protected List<AnnotationMirror> annotationsDisallowedAtLocation(
             AnnotatedTypeMirror type, Set<TypeUseLocation> allowedLocations) {
         List<AnnotationMirror> result = Collections.emptyList();
         for (AnnotationMirror am : type.getAnnotations()) {
@@ -1090,7 +1090,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @return true if the effective annotations on the upperBound are above (or equal to) those on
      *     the lowerBound
      */
-    public boolean areBoundsValid(AnnotatedTypeMirror upperBound, AnnotatedTypeMirror lowerBound) {
+    protected boolean areBoundsValid(
+            AnnotatedTypeMirror upperBound, AnnotatedTypeMirror lowerBound) {
         AnnotationMirrorSet upperBoundAnnos =
                 AnnotatedTypes.findEffectiveAnnotations(qualHierarchy, upperBound);
         AnnotationMirrorSet lowerBoundAnnos =

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -13,6 +13,8 @@ import com.sun.source.tree.VariableTree;
 
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.CanonicalName;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.source.DiagMessage;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -31,6 +33,7 @@ import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.InternalUtils;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
@@ -38,13 +41,17 @@ import org.plumelib.util.ArrayMap;
 import org.plumelib.util.IPair;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -83,6 +90,22 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
     /** The qualifer hierarchy. */
     protected final QualifierHierarchy qualHierarchy;
 
+    /** True if "-AignoreTargetLocations" was passed on the command line. */
+    protected final boolean ignoreTargetLocations;
+
+    /**
+     * Mapping from qualifier canonical names to their declared type-use locations, as specified by
+     * the {@link org.checkerframework.framework.qual.TargetLocations} meta-annotation.
+     */
+    protected final Map<@CanonicalName String, List<TypeUseLocation>> qualAllowedLocations;
+
+    /**
+     * True if no supported qualifier in this type system declares {@link
+     * org.checkerframework.framework.qual.TargetLocations}. Used to short-circuit target-location
+     * checks.
+     */
+    protected final boolean noQualHasTargetLocations;
+
     // TODO: clean up coupling between components
     public BaseTypeValidator(
             BaseTypeChecker checker,
@@ -92,6 +115,41 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         this.visitor = visitor;
         this.atypeFactory = atypeFactory;
         this.qualHierarchy = atypeFactory.getQualifierHierarchy();
+        this.ignoreTargetLocations = checker.hasOption("ignoreTargetLocations");
+        this.qualAllowedLocations = createQualAllowedLocations(atypeFactory);
+        boolean anyHas = false;
+        for (List<TypeUseLocation> locs : qualAllowedLocations.values()) {
+            if (locs != null) {
+                anyHas = true;
+                break;
+            }
+        }
+        this.noQualHasTargetLocations = !anyHas;
+    }
+
+    /**
+     * Create a new map, which is used for declared type-use locations lookup.
+     *
+     * @param atypeFactory the annotated type factory
+     * @return a new mapping from strings of qualifier names to their declared type-use locations
+     */
+    protected static Map<@CanonicalName String, List<TypeUseLocation>> createQualAllowedLocations(
+            AnnotatedTypeFactory atypeFactory) {
+        HashMap<@CanonicalName String, List<TypeUseLocation>> qualAllowedLocations =
+                new HashMap<>();
+        for (String qual : atypeFactory.getSupportedTypeQualifierNames()) {
+            Element elem = atypeFactory.getElementUtils().getTypeElement(qual);
+            TargetLocations tls = elem.getAnnotation(TargetLocations.class);
+            // @Target({ElementType.TYPE_USE})} together with no @TargetLocations(...) means that
+            // the qualifier can be written on any type use.
+            if (tls == null) {
+                qualAllowedLocations.put(qual, null);
+                continue;
+            }
+            List<TypeUseLocation> locations = Arrays.asList(tls.value());
+            qualAllowedLocations.put(qual, locations);
+        }
+        return qualAllowedLocations;
     }
 
     /**
@@ -777,11 +835,199 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
             return getVisited(type);
         }
 
-        validateWildCardTargetLocation(type, tree);
+        validateWildcardTargetLocations(type, tree);
         if (!areBoundsValid(type.getExtendsBound(), type.getSuperBound())) {
             reportInvalidBounds(type, tree);
         }
         return super.visitWildcard(type, tree);
+    }
+
+    /**
+     * Validates whether the qualifiers on the tree are at the correct type-use locations, as
+     * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
+     *
+     * <p>More specifically, this method only checks qualifiers on a VariableTree and thus checks
+     * for the following type-use locations: FIELD, LOCAL_VARIABLE, RESOURCE_VARIABLE,
+     * EXCEPTION_PARAMETER, PARAMETER, RECEIVER and CONSTRUCTOR_RESULT.
+     *
+     * <p>The other two validate methods achieve the same goal but perform checks on different trees
+     * and different type-use locations. This separation exists because variables can automatically
+     * infer their type-use location from their {@link javax.lang.model.element.ElementKind}. By
+     * contrast, other constructs (like method returns or type bounds) have context-dependent
+     * locations that must be explicitly provided by the caller, and wildcards do not have an
+     * element. See {@link #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)} and
+     * {@link #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)}.
+     *
+     * @param tree the tree whose qualifiers are to be validated
+     * @param type the type of the tree
+     * @see #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
+     * @see #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)
+     */
+    @Override
+    public void validateVariableTargetLocation(Tree tree, AnnotatedTypeMirror type) {
+        if (ignoreTargetLocations || noQualHasTargetLocations) {
+            return;
+        }
+        Element element = TreeUtils.elementFromTree(tree);
+
+        if (element != null) {
+            ElementKind elemKind = element.getKind();
+            // TypeUseLocation.java doesn't have ENUM type use location right now.
+            for (AnnotationMirror am : type.getAnnotations()) {
+                List<TypeUseLocation> locations =
+                        qualAllowedLocations.get(AnnotationUtils.annotationName(am));
+                if (locations == null || locations.contains(TypeUseLocation.ALL)) {
+                    continue;
+                }
+                boolean issueError = true;
+                switch (elemKind) {
+                    case LOCAL_VARIABLE:
+                        if (locations.contains(TypeUseLocation.LOCAL_VARIABLE)) issueError = false;
+                        break;
+                    case EXCEPTION_PARAMETER:
+                        if (locations.contains(TypeUseLocation.EXCEPTION_PARAMETER))
+                            issueError = false;
+                        break;
+                    case PARAMETER:
+                        if (InternalUtils.isThisName(((VariableTree) tree).getName())) {
+                            if (locations.contains(TypeUseLocation.RECEIVER)) {
+                                issueError = false;
+                            }
+                        } else {
+                            if (locations.contains(TypeUseLocation.PARAMETER)) {
+                                issueError = false;
+                            }
+                        }
+                        break;
+                    case RESOURCE_VARIABLE:
+                        if (locations.contains(TypeUseLocation.RESOURCE_VARIABLE)) {
+                            issueError = false;
+                        }
+                        break;
+                    case FIELD:
+                        if (locations.contains(TypeUseLocation.FIELD)) {
+                            issueError = false;
+                        }
+                        break;
+                    case ENUM_CONSTANT:
+                        if (locations.contains(TypeUseLocation.FIELD)
+                                || locations.contains(TypeUseLocation.CONSTRUCTOR_RESULT)) {
+                            issueError = false;
+                        }
+                        break;
+                    default:
+                        throw new BugInCF("Location not matched");
+                }
+                if (issueError) {
+                    checker.reportError(
+                            tree,
+                            "type.invalid.annotations.on.location",
+                            am.toString(),
+                            element.getKind().name());
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates whether the qualifiers on the tree are at the correct type-use locations, as
+     * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
+     *
+     * <p>More specifically, this method only checks qualifiers on a TypeParameter or Method tree
+     * and thus checks for the following type-use locations: LOWER_BOUND, UPPER_BOUND,
+     * CONSTRUCTOR_RESULT and RETURN.
+     *
+     * <p>The other two validate methods achieve the same goal but perform checks on different trees
+     * and different type-use locations. This separation exists because constructs handled by this
+     * method have context-dependent locations that must be explicitly provided by the caller. By
+     * contrast, variables can automatically infer their type-use location from their ElementKind,
+     * and wildcards do not have an element. See {@link #validateVariableTargetLocation(Tree,
+     * AnnotatedTypeMirror)} and {@link #validateWildcardTargetLocations(AnnotatedWildcardType,
+     * Tree)}.
+     *
+     * @param tree the tree whose qualifiers are to be validated
+     * @param type the type of the tree
+     * @param required the required TypeUseLocation. If it is not present in the specification of
+     *     the meta-annotation ({@link org.checkerframework.framework.qual.TargetLocations}), issue
+     *     an error.
+     * @see #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)
+     * @see #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)
+     */
+    @Override
+    public void validateTargetLocation(
+            Tree tree, AnnotatedTypeMirror type, TypeUseLocation required) {
+        if (ignoreTargetLocations || noQualHasTargetLocations) {
+            return;
+        }
+        for (AnnotationMirror am : annotationsDisallowedAtLocation(type, required)) {
+            checker.reportError(
+                    tree,
+                    "type.invalid.annotations.on.location",
+                    am.toString(),
+                    required.toString());
+        }
+    }
+
+    /**
+     * Returns the primary annotations on {@code type} that are not permitted at the given type-use
+     * location, according to their {@link org.checkerframework.framework.qual.TargetLocations}
+     * meta-annotation. A qualifier without a {@code TargetLocations} meta-annotation, or one that
+     * lists {@link TypeUseLocation#ALL}, is permitted everywhere and is never returned.
+     *
+     * @param type the type whose primary annotations to check
+     * @param required the type-use location at which {@code type} appears
+     * @return the primary annotations on {@code type} that {@code required} does not permit
+     * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, Set)
+     * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
+     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
+     */
+    public List<AnnotationMirror> annotationsDisallowedAtLocation(
+            AnnotatedTypeMirror type, TypeUseLocation required) {
+        List<AnnotationMirror> result = Collections.emptyList();
+        for (AnnotationMirror am : type.getAnnotations()) {
+            List<TypeUseLocation> locations =
+                    qualAllowedLocations.get(AnnotationUtils.annotationName(am));
+            if (locations == null || locations.contains(TypeUseLocation.ALL)) {
+                continue;
+            }
+            if (!locations.contains(required)) {
+                if (result.isEmpty()) {
+                    result = new ArrayList<>(1);
+                }
+                result.add(am);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the primary annotations on {@code type} that are not permitted at any of the given
+     * type-use locations, according to their {@link
+     * org.checkerframework.framework.qual.TargetLocations} meta-annotation. A qualifier without a
+     * {@code TargetLocations} meta-annotation, or one that lists {@link TypeUseLocation#ALL}, is
+     * permitted everywhere and is never returned.
+     *
+     * @param type the type whose primary annotations to check
+     * @param allowedLocations the type-use locations {@code type} may be annotated at
+     * @return the primary annotations on {@code type} that {@code allowedLocations} does not permit
+     * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, TypeUseLocation)
+     * @see #additionalAnnotationsToStripFromWildcardBound
+     */
+    public List<AnnotationMirror> annotationsDisallowedAtLocation(
+            AnnotatedTypeMirror type, Set<TypeUseLocation> allowedLocations) {
+        List<AnnotationMirror> result = Collections.emptyList();
+        for (AnnotationMirror am : type.getAnnotations()) {
+            List<TypeUseLocation> locations =
+                    qualAllowedLocations.get(AnnotationUtils.annotationName(am));
+            if (locations == null || containsAny(locations, allowedLocations)) {
+                continue;
+            }
+            if (result.isEmpty()) {
+                result = new ArrayList<>(1);
+            }
+            result.add(am);
+        }
+        return result;
     }
 
     /**
@@ -827,7 +1073,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @param lowerBound {@code type}'s lower bound
      * @param tree the tree for {@code type}'s declaration
      * @see #additionalAnnotationsToStripFromTypeVariableBound
-     * @see #validateWildCardTargetLocation
+     * @see #validateWildcardTargetLocations
      * @see #additionalAnnotationsToStripFromWildcardBound
      * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
      */
@@ -838,7 +1084,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
             Tree tree) {
         boolean stripped = false;
         for (AnnotationMirror am :
-                visitor.annotationsDisallowedAtLocation(upperBound, TypeUseLocation.UPPER_BOUND)) {
+                annotationsDisallowedAtLocation(upperBound, TypeUseLocation.UPPER_BOUND)) {
             upperBound.removeAnnotation(am);
             stripped = true;
         }
@@ -849,7 +1095,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
             stripped = true;
         }
         for (AnnotationMirror am :
-                visitor.annotationsDisallowedAtLocation(lowerBound, TypeUseLocation.LOWER_BOUND)) {
+                annotationsDisallowedAtLocation(lowerBound, TypeUseLocation.LOWER_BOUND)) {
             lowerBound.removeAnnotation(am);
             stripped = true;
         }
@@ -866,8 +1112,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
 
     /**
      * Returns additional annotations to strip from {@code bound} (one of {@code type}'s upper or
-     * lower bound), beyond whatever {@link BaseTypeVisitor#annotationsDisallowedAtLocation} already
-     * found. Called only when the checker opts in via {@link
+     * lower bound), beyond whatever {@link #annotationsDisallowedAtLocation(AnnotatedTypeMirror,
+     * TypeUseLocation)} already found. Called only when the checker opts in via {@link
      * BaseTypeVisitor#shouldStripInvalidLocationQualifiers}. The default returns an empty list, so
      * opted-in checkers whose qualifiers use {@code @TargetLocations} are unaffected ({@code
      * annotationsDisallowedAtLocation} already covers their case).
@@ -885,7 +1131,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @return additional annotations on {@code bound} to strip
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromWildcardBound
-     * @see BaseTypeVisitor#annotationsDisallowedAtLocation
+     * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, TypeUseLocation)
      * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
      */
     protected List<AnnotationMirror> additionalAnnotationsToStripFromTypeVariableBound(
@@ -913,8 +1159,9 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                     TypeUseLocation.EXPLICIT_UPPER_BOUND);
 
     /**
-     * Validates whether the qualifiers on the tree are at the correct type-use locations, as
-     * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
+     * Validates whether the qualifiers on the wildcard tree are at the correct type-use locations,
+     * as specified by the meta-annotation {@link
+     * org.checkerframework.framework.qual.TargetLocations}.
      *
      * <p>More specifically, this method only checks qualifiers on a WildcardTree and thus checks
      * for the following type-use locations: (EXPLICIT/IMPLICIT) LOWER_BOUND and (EXPLICIT/IMPLICIT)
@@ -925,34 +1172,33 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * element and determine their locations based on their bounds. By contrast, variables can
      * automatically infer their type-use location from their ElementKind, and other constructs have
      * context-dependent locations that must be explicitly provided by the caller. See {@link
-     * BaseTypeVisitor#validateVariablesTargetLocation(Tree, AnnotatedTypeMirror)} and {@link
-     * BaseTypeVisitor#validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)}.
+     * #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)} and {@link
+     * #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)}.
      *
      * @param type the type to check
      * @param tree the tree of this type
-     * @see BaseTypeVisitor#validateVariablesTargetLocation(Tree, AnnotatedTypeMirror)
-     * @see BaseTypeVisitor#validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
+     * @see #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)
+     * @see #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromWildcardBound
      * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
      */
-    protected void validateWildCardTargetLocation(AnnotatedWildcardType type, Tree tree) {
+    public void validateWildcardTargetLocations(AnnotatedWildcardType type, Tree tree) {
         // noQualHasTargetLocations is a pure optimization for the common case (skip a check that
         // can never find anything). It must not also skip a checker that has opted in to
         // stripping via shouldStripInvalidLocationQualifiers: such a checker may override
-        // annotationsDisallowedAtWildcardBound with its own tree-based detection, independent of
+        // annotationsDisallowedAtLocation with its own tree-based detection, independent of
         // @TargetLocations, in which case no qualifier having @TargetLocations says nothing about
         // whether there is something to detect and strip.
-        if (visitor.ignoreTargetLocations
-                || (visitor.noQualHasTargetLocations
-                        && !visitor.shouldStripInvalidLocationQualifiers())) {
+        if (ignoreTargetLocations
+                || (noQualHasTargetLocations && !visitor.shouldStripInvalidLocationQualifiers())) {
             return;
         }
 
         boolean strip = visitor.shouldStripInvalidLocationQualifiers();
 
         List<AnnotationMirror> superDisallowed =
-                annotationsDisallowedAtWildcardBound(
+                annotationsDisallowedAtLocation(
                         type.getSuperBound(), WILDCARD_SUPER_BOUND_LOCATIONS);
         for (AnnotationMirror am : superDisallowed) {
             checker.reportError(
@@ -960,7 +1206,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         }
 
         List<AnnotationMirror> extendsDisallowed =
-                annotationsDisallowedAtWildcardBound(
+                annotationsDisallowedAtLocation(
                         type.getExtendsBound(), WILDCARD_EXTENDS_BOUND_LOCATIONS);
         for (AnnotationMirror am : extendsDisallowed) {
             checker.reportError(
@@ -976,80 +1222,84 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
             // re-defaults exactly the stripped bound(s) and leaves every other qualifier untouched.
             // visitWildcard runs this before areBoundsValid, so no bound.type.incompatible cascade
             // is reported for the stripped qualifier.
-            boolean stripped = false;
-            for (AnnotationMirror am : superDisallowed) {
-                type.getSuperBound().removeAnnotation(am);
-                stripped = true;
-            }
-            for (AnnotationMirror am :
-                    additionalAnnotationsToStripFromWildcardBound(
-                            type, tree, type.getSuperBound(), WILDCARD_SUPER_BOUND_LOCATIONS)) {
-                type.getSuperBound().removeAnnotation(am);
-                stripped = true;
-            }
-            for (AnnotationMirror am : extendsDisallowed) {
-                type.getExtendsBound().removeAnnotation(am);
-                stripped = true;
-            }
-            for (AnnotationMirror am :
-                    additionalAnnotationsToStripFromWildcardBound(
-                            type, tree, type.getExtendsBound(), WILDCARD_EXTENDS_BOUND_LOCATIONS)) {
-                type.getExtendsBound().removeAnnotation(am);
-                stripped = true;
-            }
-            if (stripped) {
-                atypeFactory.addDefaultAnnotations(type);
-            }
+            stripInvalidLocationQualifiersFromWildcardBounds(
+                    type, tree, superDisallowed, extendsDisallowed);
         }
     }
 
     /**
-     * Returns the annotations on {@code bound} (one of a wildcard's super or extends bound) that
-     * {@code allowedLocations} does not permit, according to the {@link
-     * org.checkerframework.framework.qual.TargetLocations} meta-annotation. Used to report {@code
-     * type.invalid.annotations.on.location}; see {@link
-     * #additionalAnnotationsToStripFromWildcardBound} for the corresponding stripping hook.
+     * Removes from the bounds of a wildcard type any primary annotation that its {@link
+     * org.checkerframework.framework.qual.TargetLocations} does not permit at that bound (or that
+     * {@link #additionalAnnotationsToStripFromWildcardBound} specifies to strip), then re-defaults
+     * the now-bare positions. Called only when the checker opts in via {@link
+     * BaseTypeVisitor#shouldStripInvalidLocationQualifiers}.
      *
-     * @param bound a wildcard's super or extends bound
-     * @param allowedLocations the type-use locations {@code bound} may be annotated at
-     * @return the annotations on {@code bound} that {@code allowedLocations} does not permit
-     * @see BaseTypeVisitor#annotationsDisallowedAtLocation
+     * <p>{@code addDefaultAnnotations} fills only positions that are missing an annotation, so it
+     * re-defaults exactly the stripped bound(s) with the correct bound context and leaves every
+     * other qualifier untouched.
+     *
+     * @param type the wildcard type whose bounds to fix up and re-default
+     * @param tree the tree for {@code type}
+     * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromWildcardBound
+     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
      */
-    protected List<AnnotationMirror> annotationsDisallowedAtWildcardBound(
-            AnnotatedTypeMirror bound, Set<TypeUseLocation> allowedLocations) {
-        List<AnnotationMirror> result = Collections.emptyList();
-        for (AnnotationMirror am : bound.getAnnotations()) {
-            List<TypeUseLocation> locations =
-                    visitor.qualAllowedLocations.get(AnnotationUtils.annotationName(am));
-            // @Target({ElementType.TYPE_USE})} together with no @TargetLocations(...) means
-            // that the qualifier can be written on any type use. Otherwise, for a valid use of
-            // qualifier on this bound, that qualifier must declare one of the permitted
-            // type-use locations in the @TargetLocations meta-annotation.
-            if (locations == null || containsAny(locations, allowedLocations)) {
-                continue;
-            }
-            if (result.isEmpty()) {
-                result = new ArrayList<>(1);
-            }
-            result.add(am);
+    protected void stripInvalidLocationQualifiersFromWildcardBounds(
+            AnnotatedWildcardType type, Tree tree) {
+        List<AnnotationMirror> superDisallowed =
+                annotationsDisallowedAtLocation(
+                        type.getSuperBound(), WILDCARD_SUPER_BOUND_LOCATIONS);
+        List<AnnotationMirror> extendsDisallowed =
+                annotationsDisallowedAtLocation(
+                        type.getExtendsBound(), WILDCARD_EXTENDS_BOUND_LOCATIONS);
+        stripInvalidLocationQualifiersFromWildcardBounds(
+                type, tree, superDisallowed, extendsDisallowed);
+    }
+
+    private void stripInvalidLocationQualifiersFromWildcardBounds(
+            AnnotatedWildcardType type,
+            Tree tree,
+            List<AnnotationMirror> superDisallowed,
+            List<AnnotationMirror> extendsDisallowed) {
+        boolean stripped = false;
+        for (AnnotationMirror am : superDisallowed) {
+            type.getSuperBound().removeAnnotation(am);
+            stripped = true;
         }
-        return result;
+        for (AnnotationMirror am :
+                additionalAnnotationsToStripFromWildcardBound(
+                        type, tree, type.getSuperBound(), WILDCARD_SUPER_BOUND_LOCATIONS)) {
+            type.getSuperBound().removeAnnotation(am);
+            stripped = true;
+        }
+        for (AnnotationMirror am : extendsDisallowed) {
+            type.getExtendsBound().removeAnnotation(am);
+            stripped = true;
+        }
+        for (AnnotationMirror am :
+                additionalAnnotationsToStripFromWildcardBound(
+                        type, tree, type.getExtendsBound(), WILDCARD_EXTENDS_BOUND_LOCATIONS)) {
+            type.getExtendsBound().removeAnnotation(am);
+            stripped = true;
+        }
+        if (stripped) {
+            atypeFactory.addDefaultAnnotations(type);
+        }
     }
 
     /**
      * Returns additional annotations to strip from {@code bound} (one of {@code type}'s super or
-     * extends bound), beyond whatever {@link #annotationsDisallowedAtWildcardBound} already found.
-     * Called only when the checker opts in via {@link
+     * extends bound), beyond whatever {@link #annotationsDisallowedAtLocation(AnnotatedTypeMirror,
+     * Set)} already found. Called only when the checker opts in via {@link
      * BaseTypeVisitor#shouldStripInvalidLocationQualifiers}. The default returns an empty list, so
      * opted-in checkers whose qualifiers use {@code @TargetLocations} are unaffected ({@code
-     * annotationsDisallowedAtWildcardBound} already covers their case, for both reporting and
+     * annotationsDisallowedAtLocation} already covers their case, for both reporting and
      * stripping).
      *
      * <p>{@code type} and {@code tree} let a checker whose validity check is tree-based instead
      * (e.g., it must tell an explicitly written annotation apart from the same qualifier arriving
      * through defaulting, which {@code @TargetLocations} cannot express) decide independently what
-     * to strip, without also triggering {@code annotationsDisallowedAtWildcardBound}'s {@code
+     * to strip, without also triggering {@code annotationsDisallowedAtLocation}'s {@code
      * type.invalid.annotations.on.location} report for annotations the checker already reports
      * through its own, more specific mechanism.
      *
@@ -1060,8 +1310,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @return additional annotations on {@code bound} to strip
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromTypeVariableBound
-     * @see #validateWildCardTargetLocation
-     * @see #annotationsDisallowedAtWildcardBound
+     * @see #validateWildcardTargetLocations
+     * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, Set)
      * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
      */
     protected List<AnnotationMirror> additionalAnnotationsToStripFromWildcardBound(

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -367,6 +367,20 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         reportValidityResultOnUnannotatedType("type.invalid.annotations.on.use", type, p);
     }
 
+    /**
+     * Returns whether this checker makes a qualifier that appears at a type-use location not
+     * permitted by its {@link org.checkerframework.framework.qual.TargetLocations} meta-annotation
+     * inert, rather than letting it keep influencing type checking.
+     *
+     * <p>Subclasses of {@code BaseTypeValidator} may override this method to enable the stripping
+     * behavior.
+     *
+     * @return true if location-invalid qualifiers on bounds should be made inert
+     */
+    protected boolean shouldStripInvalidLocationQualifiers() {
+        return false;
+    }
+
     @Override
     public Void visitDeclared(AnnotatedDeclaredType type, Tree tree) {
         if (hasVisited(type)) {
@@ -595,12 +609,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
 
     @Override
     public Void visitArray(AnnotatedArrayType type, Tree tree) {
-        // TODO: is there already or add a helper method
-        // to determine the non-array component type
-        AnnotatedTypeMirror comp = type;
-        do {
-            comp = ((AnnotatedArrayType) comp).getComponentType();
-        } while (comp.getKind() == TypeKind.ARRAY);
+        AnnotatedTypeMirror comp = AnnotatedTypes.innerMostType(type);
 
         if (comp.getKind() == TypeKind.DECLARED
                 && checker.shouldSkipUses(
@@ -806,14 +815,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         }
 
         if (type.isDeclaration()) {
-            // When the checker opts in, strip any location-invalid qualifier from the bounds and
-            // re-default before areBoundsValid runs, so that the meaningless qualifier does not
-            // produce a bound.type.incompatible cascade.  The location error itself is issued
-            // separately by BaseTypeVisitor#validateTypeOf (via visitTypeParameter).
-            if (visitor.shouldStripInvalidLocationQualifiers()) {
-                stripInvalidLocationQualifiersFromTypeVariableBounds(
-                        type, type.getUpperBound(), type.getLowerBound(), tree);
-            }
+            validateTypeParameterTargetLocations(type, tree);
             if (!areBoundsValid(type.getUpperBound(), type.getLowerBound())) {
                 reportInvalidBounds(type, tree);
             }
@@ -930,20 +932,65 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
     }
 
     /**
+     * Validates whether the qualifiers on the type parameter bounds are at the correct type-use
+     * locations, as specified by the meta-annotation {@link
+     * org.checkerframework.framework.qual.TargetLocations}.
+     *
+     * <p>More specifically, this method checks qualifiers on a TypeParameterTree for the {@link
+     * TypeUseLocation#UPPER_BOUND} and {@link TypeUseLocation#LOWER_BOUND} locations.
+     *
+     * @param type the type variable declaration whose bounds are to be validated
+     * @param tree the tree of this type parameter
+     * @see #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)
+     * @see #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)
+     * @see #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
+     * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
+     * @see #shouldStripInvalidLocationQualifiers
+     */
+    protected void validateTypeParameterTargetLocations(AnnotatedTypeVariable type, Tree tree) {
+        if (ignoreTargetLocations
+                || (noQualHasTargetLocations && !shouldStripInvalidLocationQualifiers())) {
+            return;
+        }
+
+        for (AnnotationMirror am :
+                annotationsDisallowedAtLocation(
+                        type.getUpperBound(), TypeUseLocation.UPPER_BOUND)) {
+            checker.reportError(
+                    tree,
+                    "type.invalid.annotations.on.location",
+                    am.toString(),
+                    TypeUseLocation.UPPER_BOUND.toString());
+        }
+
+        for (AnnotationMirror am :
+                annotationsDisallowedAtLocation(
+                        type.getLowerBound(), TypeUseLocation.LOWER_BOUND)) {
+            checker.reportError(
+                    tree,
+                    "type.invalid.annotations.on.location",
+                    am.toString(),
+                    TypeUseLocation.LOWER_BOUND.toString());
+        }
+
+        if (shouldStripInvalidLocationQualifiers()) {
+            stripInvalidLocationQualifiersFromTypeVariableBounds(
+                    type, type.getUpperBound(), type.getLowerBound(), tree);
+        }
+    }
+
+    /**
      * Validates whether the qualifiers on the tree are at the correct type-use locations, as
      * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
      *
-     * <p>More specifically, this method only checks qualifiers on a TypeParameter or Method tree
-     * and thus checks for the following type-use locations: LOWER_BOUND, UPPER_BOUND,
-     * CONSTRUCTOR_RESULT and RETURN.
+     * <p>This method checks qualifiers for context-dependent locations such as {@link
+     * TypeUseLocation#CONSTRUCTOR_RESULT} and {@link TypeUseLocation#RETURN} on Method trees, or
+     * other caller-specified locations.
      *
-     * <p>The other two validate methods achieve the same goal but perform checks on different trees
-     * and different type-use locations. This separation exists because constructs handled by this
-     * method have context-dependent locations that must be explicitly provided by the caller. By
-     * contrast, variables can automatically infer their type-use location from their ElementKind,
-     * and wildcards do not have an element. See {@link #validateVariableTargetLocation(Tree,
-     * AnnotatedTypeMirror)} and {@link #validateWildcardTargetLocations(AnnotatedWildcardType,
-     * Tree)}.
+     * <p>The other validate methods achieve the same goal but perform checks on specific trees and
+     * their associated type-use locations: {@link #validateVariableTargetLocation(Tree,
+     * AnnotatedTypeMirror)}, {@link #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)},
+     * and {@link #validateTypeParameterTargetLocations(AnnotatedTypeVariable, Tree)}.
      *
      * @param tree the tree whose qualifiers are to be validated
      * @param type the type of the tree
@@ -952,6 +999,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      *     an error.
      * @see #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)
      * @see #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)
+     * @see #validateTypeParameterTargetLocations(AnnotatedTypeVariable, Tree)
      */
     @Override
     public void validateTargetLocation(
@@ -979,7 +1027,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @return the primary annotations on {@code type} that {@code required} does not permit
      * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, Set)
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
-     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
+     * @see #shouldStripInvalidLocationQualifiers
      */
     public List<AnnotationMirror> annotationsDisallowedAtLocation(
             AnnotatedTypeMirror type, TypeUseLocation required) {
@@ -1062,7 +1110,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * org.checkerframework.framework.qual.TargetLocations} does not permit at that bound (or that
      * {@link #additionalAnnotationsToStripFromTypeVariableBound} specifies to strip), then
      * re-defaults the now-bare positions. Called only when the checker opts in via {@link
-     * BaseTypeVisitor#shouldStripInvalidLocationQualifiers}.
+     * #shouldStripInvalidLocationQualifiers}.
      *
      * <p>{@code addDefaultAnnotations} fills only positions that are missing an annotation, so it
      * re-defaults exactly the stripped bound(s) with the correct bound context and leaves every
@@ -1075,7 +1123,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @see #additionalAnnotationsToStripFromTypeVariableBound
      * @see #validateWildcardTargetLocations
      * @see #additionalAnnotationsToStripFromWildcardBound
-     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
+     * @see #shouldStripInvalidLocationQualifiers
      */
     protected void stripInvalidLocationQualifiersFromTypeVariableBounds(
             AnnotatedTypeVariable type,
@@ -1114,8 +1162,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * Returns additional annotations to strip from {@code bound} (one of {@code type}'s upper or
      * lower bound), beyond whatever {@link #annotationsDisallowedAtLocation(AnnotatedTypeMirror,
      * TypeUseLocation)} already found. Called only when the checker opts in via {@link
-     * BaseTypeVisitor#shouldStripInvalidLocationQualifiers}. The default returns an empty list, so
-     * opted-in checkers whose qualifiers use {@code @TargetLocations} are unaffected ({@code
+     * #shouldStripInvalidLocationQualifiers}. The default returns an empty list, so opted-in
+     * checkers whose qualifiers use {@code @TargetLocations} are unaffected ({@code
      * annotationsDisallowedAtLocation} already covers their case).
      *
      * <p>{@code tree} is the type-parameter declaration's own tree (as received by {@link
@@ -1132,7 +1180,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromWildcardBound
      * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, TypeUseLocation)
-     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
+     * @see #shouldStripInvalidLocationQualifiers
      */
     protected List<AnnotationMirror> additionalAnnotationsToStripFromTypeVariableBound(
             AnnotatedTypeVariable type,
@@ -1181,9 +1229,9 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @see #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromWildcardBound
-     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
+     * @see #shouldStripInvalidLocationQualifiers
      */
-    public void validateWildcardTargetLocations(AnnotatedWildcardType type, Tree tree) {
+    protected void validateWildcardTargetLocations(AnnotatedWildcardType type, Tree tree) {
         // noQualHasTargetLocations is a pure optimization for the common case (skip a check that
         // can never find anything). It must not also skip a checker that has opted in to
         // stripping via shouldStripInvalidLocationQualifiers: such a checker may override
@@ -1191,11 +1239,11 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         // @TargetLocations, in which case no qualifier having @TargetLocations says nothing about
         // whether there is something to detect and strip.
         if (ignoreTargetLocations
-                || (noQualHasTargetLocations && !visitor.shouldStripInvalidLocationQualifiers())) {
+                || (noQualHasTargetLocations && !shouldStripInvalidLocationQualifiers())) {
             return;
         }
 
-        boolean strip = visitor.shouldStripInvalidLocationQualifiers();
+        boolean strip = shouldStripInvalidLocationQualifiers();
 
         List<AnnotationMirror> superDisallowed =
                 annotationsDisallowedAtLocation(
@@ -1232,7 +1280,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * org.checkerframework.framework.qual.TargetLocations} does not permit at that bound (or that
      * {@link #additionalAnnotationsToStripFromWildcardBound} specifies to strip), then re-defaults
      * the now-bare positions. Called only when the checker opts in via {@link
-     * BaseTypeVisitor#shouldStripInvalidLocationQualifiers}.
+     * #shouldStripInvalidLocationQualifiers}.
      *
      * <p>{@code addDefaultAnnotations} fills only positions that are missing an annotation, so it
      * re-defaults exactly the stripped bound(s) with the correct bound context and leaves every
@@ -1242,7 +1290,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @param tree the tree for {@code type}
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromWildcardBound
-     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
+     * @see #shouldStripInvalidLocationQualifiers
      */
     protected void stripInvalidLocationQualifiersFromWildcardBounds(
             AnnotatedWildcardType type, Tree tree) {
@@ -1291,8 +1339,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * Returns additional annotations to strip from {@code bound} (one of {@code type}'s super or
      * extends bound), beyond whatever {@link #annotationsDisallowedAtLocation(AnnotatedTypeMirror,
      * Set)} already found. Called only when the checker opts in via {@link
-     * BaseTypeVisitor#shouldStripInvalidLocationQualifiers}. The default returns an empty list, so
-     * opted-in checkers whose qualifiers use {@code @TargetLocations} are unaffected ({@code
+     * #shouldStripInvalidLocationQualifiers}. The default returns an empty list, so opted-in
+     * checkers whose qualifiers use {@code @TargetLocations} are unaffected ({@code
      * annotationsDisallowedAtLocation} already covers their case, for both reporting and
      * stripping).
      *
@@ -1312,7 +1360,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @see #additionalAnnotationsToStripFromTypeVariableBound
      * @see #validateWildcardTargetLocations
      * @see #annotationsDisallowedAtLocation(AnnotatedTypeMirror, Set)
-     * @see BaseTypeVisitor#shouldStripInvalidLocationQualifiers
+     * @see #shouldStripInvalidLocationQualifiers
      */
     protected List<AnnotationMirror> additionalAnnotationsToStripFromWildcardBound(
             AnnotatedWildcardType type,

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -106,6 +106,13 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      */
     protected final boolean noQualHasTargetLocations;
 
+    /**
+     * Creates a new BaseTypeValidator.
+     *
+     * @param checker the checker
+     * @param visitor the visitor
+     * @param atypeFactory the type factory
+     */
     // TODO: clean up coupling between components
     public BaseTypeValidator(
             BaseTypeChecker checker,
@@ -857,16 +864,16 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * infer their type-use location from their {@link javax.lang.model.element.ElementKind}. By
      * contrast, other constructs (like method returns or type bounds) have context-dependent
      * locations that must be explicitly provided by the caller, and wildcards do not have an
-     * element. See {@link #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)} and
+     * element. See {@link #validateTargetLocation(AnnotatedTypeMirror, Tree, TypeUseLocation)} and
      * {@link #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)}.
      *
-     * @param tree the tree whose qualifiers are to be validated
      * @param type the type of the tree
-     * @see #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
+     * @param tree the tree whose qualifiers are to be validated
+     * @see #validateTargetLocation(AnnotatedTypeMirror, Tree, TypeUseLocation)
      * @see #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)
      */
     @Override
-    public void validateVariableTargetLocation(Tree tree, AnnotatedTypeMirror type) {
+    public void validateVariableTargetLocation(AnnotatedTypeMirror type, Tree tree) {
         if (ignoreTargetLocations || noQualHasTargetLocations) {
             return;
         }
@@ -945,8 +952,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * @param type the type variable declaration whose bounds are to be validated
      * @param tree the tree of this type parameter
      * @see #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)
-     * @see #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)
-     * @see #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
+     * @see #validateVariableTargetLocation(AnnotatedTypeMirror, Tree)
+     * @see #validateTargetLocation(AnnotatedTypeMirror, Tree, TypeUseLocation)
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #shouldStripInvalidLocationQualifiers
      */
@@ -991,22 +998,23 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * other caller-specified locations.
      *
      * <p>The other validate methods achieve the same goal but perform checks on specific trees and
-     * their associated type-use locations: {@link #validateVariableTargetLocation(Tree,
-     * AnnotatedTypeMirror)}, {@link #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)},
-     * and {@link #validateTypeParameterTargetLocations(AnnotatedTypeVariable, Tree)}.
+     * their associated type-use locations: {@link
+     * #validateVariableTargetLocation(AnnotatedTypeMirror, Tree)}, {@link
+     * #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)}, and {@link
+     * #validateTypeParameterTargetLocations(AnnotatedTypeVariable, Tree)}.
      *
-     * @param tree the tree whose qualifiers are to be validated
      * @param type the type of the tree
+     * @param tree the tree whose qualifiers are to be validated
      * @param required the required TypeUseLocation. If it is not present in the specification of
      *     the meta-annotation ({@link org.checkerframework.framework.qual.TargetLocations}), issue
      *     an error.
-     * @see #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)
+     * @see #validateVariableTargetLocation(AnnotatedTypeMirror, Tree)
      * @see #validateWildcardTargetLocations(AnnotatedWildcardType, Tree)
      * @see #validateTypeParameterTargetLocations(AnnotatedTypeVariable, Tree)
      */
     @Override
     public void validateTargetLocation(
-            Tree tree, AnnotatedTypeMirror type, TypeUseLocation required) {
+            AnnotatedTypeMirror type, Tree tree, TypeUseLocation required) {
         if (ignoreTargetLocations || noQualHasTargetLocations) {
             return;
         }
@@ -1224,13 +1232,13 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * element and determine their locations based on their bounds. By contrast, variables can
      * automatically infer their type-use location from their ElementKind, and other constructs have
      * context-dependent locations that must be explicitly provided by the caller. See {@link
-     * #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)} and {@link
-     * #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)}.
+     * #validateVariableTargetLocation(AnnotatedTypeMirror, Tree)} and {@link
+     * #validateTargetLocation(AnnotatedTypeMirror, Tree, TypeUseLocation)}.
      *
      * @param type the type to check
      * @param tree the tree of this type
-     * @see #validateVariableTargetLocation(Tree, AnnotatedTypeMirror)
-     * @see #validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
+     * @see #validateVariableTargetLocation(AnnotatedTypeMirror, Tree)
+     * @see #validateTargetLocation(AnnotatedTypeMirror, Tree, TypeUseLocation)
      * @see #stripInvalidLocationQualifiersFromTypeVariableBounds
      * @see #additionalAnnotationsToStripFromWildcardBound
      * @see #shouldStripInvalidLocationQualifiers
@@ -1308,6 +1316,14 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 type, tree, superDisallowed, extendsDisallowed);
     }
 
+    /**
+     * Strips the specified disallowed annotations from the bounds of a wildcard type.
+     *
+     * @param type the wildcard type
+     * @param tree the tree for the wildcard type
+     * @param superDisallowed annotations to remove from the super bound
+     * @param extendsDisallowed annotations to remove from the extends bound
+     */
     private void stripInvalidLocationQualifiersFromWildcardBounds(
             AnnotatedWildcardType type,
             Tree tree,

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -1247,7 +1247,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         // noQualHasTargetLocations is a pure optimization for the common case (skip a check that
         // can never find anything). It must not also skip a checker that has opted in to
         // stripping via shouldStripInvalidLocationQualifiers: such a checker may override
-        // annotationsDisallowedAtLocation with its own tree-based detection, independent of
+        // additionalAnnotationsToStripFromWildcardBound with its own tree-based detection,
+        // independent of
         // @TargetLocations, in which case no qualifier having @TargetLocations says nothing about
         // whether there is something to detect and strip.
         if (ignoreTargetLocations

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -5525,18 +5525,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             case EXTENDS_WILDCARD:
             case SUPER_WILDCARD:
             case ANNOTATED_TYPE:
-                type = atypeFactory.getAnnotatedTypeFromTypeTree(tree);
-                break;
             case TYPE_PARAMETER:
                 type = atypeFactory.getAnnotatedTypeFromTypeTree(tree);
-                typeValidator.validateTargetLocation(
-                        ((AnnotatedTypeVariable) type).getUpperBound(),
-                        tree,
-                        TypeUseLocation.UPPER_BOUND);
-                typeValidator.validateTargetLocation(
-                        ((AnnotatedTypeVariable) type).getLowerBound(),
-                        tree,
-                        TypeUseLocation.LOWER_BOUND);
                 break;
             case METHOD:
                 type = atypeFactory.getMethodReturnType((MethodTree) tree);

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1870,7 +1870,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             // so only validate if commonAssignmentCheck wasn't called
             validateTypeOf(tree);
         }
-        typeValidator.validateVariableTargetLocation(tree, variableType);
+        typeValidator.validateVariableTargetLocation(variableType, tree);
         warnRedundantAnnotations(tree, variableType);
         Void result = super.visitVariable(tree, p);
 
@@ -5530,12 +5530,12 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             case TYPE_PARAMETER:
                 type = atypeFactory.getAnnotatedTypeFromTypeTree(tree);
                 typeValidator.validateTargetLocation(
-                        tree,
                         ((AnnotatedTypeVariable) type).getUpperBound(),
+                        tree,
                         TypeUseLocation.UPPER_BOUND);
                 typeValidator.validateTargetLocation(
-                        tree,
                         ((AnnotatedTypeVariable) type).getLowerBound(),
+                        tree,
                         TypeUseLocation.LOWER_BOUND);
                 break;
             case METHOD:
@@ -5548,9 +5548,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 }
                 if (TreeUtils.isConstructor((MethodTree) tree)) {
                     typeValidator.validateTargetLocation(
-                            tree, type, TypeUseLocation.CONSTRUCTOR_RESULT);
+                            type, tree, TypeUseLocation.CONSTRUCTOR_RESULT);
                 } else {
-                    typeValidator.validateTargetLocation(tree, type, TypeUseLocation.RETURN);
+                    typeValidator.validateTargetLocation(type, tree, TypeUseLocation.RETURN);
                 }
                 break;
             default:

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1880,33 +1880,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     /**
-     * Returns whether this checker makes a qualifier that appears at a type-use location not
-     * permitted by its {@link org.checkerframework.framework.qual.TargetLocations} meta-annotation
-     * inert, rather than letting it keep influencing type checking.
-     *
-     * <p>When this method returns {@code true} and a qualifier is found at a bound location (a type
-     * variable's upper or lower bound, or a wildcard's extends or super bound) that its {@code
-     * TargetLocations} do not allow, the qualifier is removed from the annotated type
-     * <em>after</em> the {@code type.invalid.annotations.on.location} error is issued, and the
-     * now-bare bound is re-defaulted (see {@link
-     * BaseTypeValidator#stripInvalidLocationQualifiersFromTypeVariableBounds} for type variables
-     * and {@link BaseTypeValidator#validateWildcardTargetLocations} for wildcards). This suppresses
-     * the {@code bound.type.incompatible} cascade that the meaningless qualifier would otherwise
-     * produce.
-     *
-     * <p>This method returns {@code false} by default, so existing checkers are unaffected: a
-     * qualifier in an invalid location is still reported and still takes effect. A checker opts in
-     * by overriding this method to return {@code true} (typically only for qualifiers whose spec
-     * says they "have no meaning" outside their recognized locations, such as JSpecify's nullness
-     * qualifiers).
-     *
-     * @return true if location-invalid qualifiers on bounds should be stripped and re-defaulted
-     */
-    protected boolean shouldStripInvalidLocationQualifiers() {
-        return false;
-    }
-
-    /**
      * Issues a "redundant.anno" warning if the annotation written on the type is the same as the
      * default annotation for this type and location.
      *

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -49,7 +49,6 @@ import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.signature.qual.CanonicalName;
 import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.node.BooleanLiteralNode;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -72,7 +71,6 @@ import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.flow.CFAbstractValue;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import org.checkerframework.framework.qual.HasQualifierParameter;
-import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.qual.Unused;
 import org.checkerframework.framework.source.DiagMessage;
@@ -284,9 +282,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     /** True if "-AwarnRedundantAnnotations" was passed on the command line. */
     protected final boolean warnRedundantAnnotations;
 
-    /** True if "-AignoreTargetLocations" was passed on the command line. */
-    protected final boolean ignoreTargetLocations;
-
     /** True if "-AcheckEnclosingExpr" was passed on the command line. */
     private final boolean checkEnclosingExpr;
 
@@ -301,20 +296,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
     /** The tree of the enclosing method that is currently being visited, if any. */
     protected @Nullable MethodTree methodTree = null;
-
-    /**
-     * Map from String (canonical name of the qualifier) to its type-use locations declared in
-     * {@link org.checkerframework.framework.qual.TargetLocations}.
-     */
-    protected final Map<@CanonicalName String, List<TypeUseLocation>> qualAllowedLocations;
-
-    /**
-     * True iff no supported qualifier is meta-annotated with {@link
-     * org.checkerframework.framework.qual.TargetLocations}. When true, target-location validation
-     * has nothing to do for any annotation and can be skipped entirely. Set in the constructor
-     * after {@link #createQualAllowedLocations()} is called.
-     */
-    protected final boolean noQualHasTargetLocations;
 
     /**
      * The number of seconds that typechecking must take for a single tree, to issue a "slow
@@ -368,16 +349,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         suggestPureMethods = checker.hasOption("suggestPureMethods"); // NO-AFU || infer;
         checkPurityAnnotations = checker.hasOption("checkPurityAnnotations") || suggestPureMethods;
         warnRedundantAnnotations = checker.hasOption("warnRedundantAnnotations");
-        ignoreTargetLocations = checker.hasOption("ignoreTargetLocations");
-        qualAllowedLocations = createQualAllowedLocations();
-        boolean anyHas = false;
-        for (List<TypeUseLocation> locs : qualAllowedLocations.values()) {
-            if (locs != null) {
-                anyHas = true;
-                break;
-            }
-        }
-        noQualHasTargetLocations = !anyHas;
         checkEnclosingExpr = checker.hasOption("checkEnclosingExpr");
 
         boolean ajavaChecksOptions = checker.hasOption("ajavaChecks");
@@ -1899,7 +1870,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             // so only validate if commonAssignmentCheck wasn't called
             validateTypeOf(tree);
         }
-        validateVariablesTargetLocation(tree, variableType);
+        typeValidator.validateVariableTargetLocation(tree, variableType);
         warnRedundantAnnotations(tree, variableType);
         Void result = super.visitVariable(tree, p);
 
@@ -1919,7 +1890,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      * <em>after</em> the {@code type.invalid.annotations.on.location} error is issued, and the
      * now-bare bound is re-defaulted (see {@link
      * BaseTypeValidator#stripInvalidLocationQualifiersFromTypeVariableBounds} for type variables
-     * and {@link BaseTypeValidator#validateWildCardTargetLocation} for wildcards). This suppresses
+     * and {@link BaseTypeValidator#validateWildcardTargetLocations} for wildcards). This suppresses
      * the {@code bound.type.incompatible} cascade that the meaningless qualifier would otherwise
      * produce.
      *
@@ -1933,193 +1904,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      */
     protected boolean shouldStripInvalidLocationQualifiers() {
         return false;
-    }
-
-    /**
-     * Validates whether the qualifiers on the tree are at the correct type-use locations, as
-     * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
-     *
-     * <p>More specifically, this method only checks qualifiers on a VariableTree and thus checks
-     * for the following type-use locations: FIELD, LOCAL_VARIABLE, RESOURCE_VARIABLE,
-     * EXCEPTION_PARAMETER, PARAMETER, RECEIVER and CONSTRUCTOR_RESULT.
-     *
-     * <p>The other two validate methods achieve the same goal but perform checks on different trees
-     * and different type-use locations. This separation exists because variables can automatically
-     * infer their type-use location from their {@link javax.lang.model.element.ElementKind}. By
-     * contrast, other constructs (like method returns or type bounds) have context-dependent
-     * locations that must be explicitly provided by the caller, and wildcards do not have an
-     * element. See {@link BaseTypeVisitor#validateTargetLocation(Tree, AnnotatedTypeMirror,
-     * TypeUseLocation)} and {@link
-     * BaseTypeValidator#validateWildCardTargetLocation(AnnotatedTypeMirror.AnnotatedWildcardType,
-     * Tree)}.
-     *
-     * @param tree the tree whose qualifiers are to be validated
-     * @param type the type of the tree
-     * @see BaseTypeVisitor#validateTargetLocation(Tree, AnnotatedTypeMirror, TypeUseLocation)
-     * @see
-     *     BaseTypeValidator#validateWildCardTargetLocation(AnnotatedTypeMirror.AnnotatedWildcardType,
-     *     Tree)
-     */
-    // TODO: rename to validateVariableTargetLocation
-    protected void validateVariablesTargetLocation(Tree tree, AnnotatedTypeMirror type) {
-        if (ignoreTargetLocations || noQualHasTargetLocations) {
-            return;
-        }
-        Element element = TreeUtils.elementFromTree(tree);
-
-        if (element != null) {
-            ElementKind elemKind = element.getKind();
-            // TypeUseLocation.java doesn't have ENUM type use location right now.
-            for (AnnotationMirror am : type.getAnnotations()) {
-                List<TypeUseLocation> locations =
-                        qualAllowedLocations.get(AnnotationUtils.annotationName(am));
-                if (locations == null || locations.contains(TypeUseLocation.ALL)) {
-                    continue;
-                }
-                boolean issueError = true;
-                switch (elemKind) {
-                    case LOCAL_VARIABLE:
-                        if (locations.contains(TypeUseLocation.LOCAL_VARIABLE)) issueError = false;
-                        break;
-                    case EXCEPTION_PARAMETER:
-                        if (locations.contains(TypeUseLocation.EXCEPTION_PARAMETER))
-                            issueError = false;
-                        break;
-                    case PARAMETER:
-                        if (InternalUtils.isThisName(((VariableTree) tree).getName())) {
-                            if (locations.contains(TypeUseLocation.RECEIVER)) {
-                                issueError = false;
-                            }
-                        } else {
-                            if (locations.contains(TypeUseLocation.PARAMETER)) {
-                                issueError = false;
-                            }
-                        }
-                        break;
-                    case RESOURCE_VARIABLE:
-                        if (locations.contains(TypeUseLocation.RESOURCE_VARIABLE)) {
-                            issueError = false;
-                        }
-                        break;
-                    case FIELD:
-                        if (locations.contains(TypeUseLocation.FIELD)) {
-                            issueError = false;
-                        }
-                        break;
-                    case ENUM_CONSTANT:
-                        if (locations.contains(TypeUseLocation.FIELD)
-                                || locations.contains(TypeUseLocation.CONSTRUCTOR_RESULT)) {
-                            issueError = false;
-                        }
-                        break;
-                    default:
-                        throw new BugInCF("Location not matched");
-                }
-                if (issueError) {
-                    checker.reportError(
-                            tree,
-                            "type.invalid.annotations.on.location",
-                            am.toString(),
-                            element.getKind().name());
-                }
-            }
-        }
-    }
-
-    /**
-     * Validates whether the qualifiers on the tree are at the correct type-use locations, as
-     * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
-     *
-     * <p>More specifically, this method only checks qualifiers on a TypeParameter or Method tree
-     * and thus checks for the following type-use locations: LOWER_BOUND, UPPER_BOUND,
-     * CONSTRUCTOR_RESULT and RETURN.
-     *
-     * <p>The other two validate methods achieve the same goal but perform checks on different trees
-     * and different type-use locations. This separation exists because constructs handled by this
-     * method have context-dependent locations that must be explicitly provided by the caller. By
-     * contrast, variables can automatically infer their type-use location from their ElementKind,
-     * and wildcards do not have an element. See {@link
-     * BaseTypeVisitor#validateVariablesTargetLocation(Tree, AnnotatedTypeMirror)} and {@link
-     * BaseTypeValidator#validateWildCardTargetLocation(AnnotatedTypeMirror.AnnotatedWildcardType,
-     * Tree)}.
-     *
-     * @param tree the tree whose qualifiers are to be validated
-     * @param type the type of the tree
-     * @param required the required TypeUseLocation. If it is not present in the specification of
-     *     the meta-annotation ({@link org.checkerframework.framework.qual.TargetLocations}), issue
-     *     an error.
-     * @see BaseTypeVisitor#validateVariablesTargetLocation(Tree, AnnotatedTypeMirror)
-     * @see
-     *     BaseTypeValidator#validateWildCardTargetLocation(AnnotatedTypeMirror.AnnotatedWildcardType,
-     *     Tree)
-     */
-    protected void validateTargetLocation(
-            Tree tree, AnnotatedTypeMirror type, TypeUseLocation required) {
-        if (ignoreTargetLocations || noQualHasTargetLocations) {
-            return;
-        }
-        for (AnnotationMirror am : annotationsDisallowedAtLocation(type, required)) {
-            checker.reportError(
-                    tree,
-                    "type.invalid.annotations.on.location",
-                    am.toString(),
-                    required.toString());
-        }
-    }
-
-    /**
-     * Returns the primary annotations on {@code type} that are not permitted at the given type-use
-     * location, according to their {@link org.checkerframework.framework.qual.TargetLocations}
-     * meta-annotation. A qualifier without a {@code TargetLocations} meta-annotation, or one that
-     * lists {@link TypeUseLocation#ALL}, is permitted everywhere and is never returned.
-     *
-     * @param type the type whose primary annotations to check
-     * @param required the type-use location at which {@code type} appears
-     * @return the primary annotations on {@code type} that {@code required} does not permit
-     * @see BaseTypeValidator#annotationsDisallowedAtWildcardBound
-     * @see BaseTypeValidator#stripInvalidLocationQualifiersFromTypeVariableBounds
-     * @see #shouldStripInvalidLocationQualifiers
-     */
-    protected List<AnnotationMirror> annotationsDisallowedAtLocation(
-            AnnotatedTypeMirror type, TypeUseLocation required) {
-        List<AnnotationMirror> result = Collections.emptyList();
-        for (AnnotationMirror am : type.getAnnotations()) {
-            List<TypeUseLocation> locations =
-                    qualAllowedLocations.get(AnnotationUtils.annotationName(am));
-            if (locations == null || locations.contains(TypeUseLocation.ALL)) {
-                continue;
-            }
-            if (!locations.contains(required)) {
-                if (result.isEmpty()) {
-                    result = new ArrayList<>(1);
-                }
-                result.add(am);
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Create a new map, which is used for declared type-use locations lookup.
-     *
-     * @return a new mapping from strings of qualifier names to their declared type-use locations.
-     */
-    protected Map<@CanonicalName String, List<TypeUseLocation>> createQualAllowedLocations() {
-        HashMap<@CanonicalName String, List<TypeUseLocation>> qualAllowedLocations =
-                new HashMap<>();
-        for (String qual : atypeFactory.getSupportedTypeQualifierNames()) {
-            Element elem = elements.getTypeElement(qual);
-            TargetLocations tls = elem.getAnnotation(TargetLocations.class);
-            // @Target({ElementType.TYPE_USE})} together with no @TargetLocations(...) means that
-            // the qualifier can be written on any type use.
-            if (tls == null) {
-                qualAllowedLocations.put(qual, null);
-                continue;
-            }
-            List<TypeUseLocation> locations = Arrays.asList(tls.value());
-            qualAllowedLocations.put(qual, locations);
-        }
-        return qualAllowedLocations;
     }
 
     /**
@@ -5772,11 +5556,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 break;
             case TYPE_PARAMETER:
                 type = atypeFactory.getAnnotatedTypeFromTypeTree(tree);
-                validateTargetLocation(
+                typeValidator.validateTargetLocation(
                         tree,
                         ((AnnotatedTypeVariable) type).getUpperBound(),
                         TypeUseLocation.UPPER_BOUND);
-                validateTargetLocation(
+                typeValidator.validateTargetLocation(
                         tree,
                         ((AnnotatedTypeVariable) type).getLowerBound(),
                         TypeUseLocation.LOWER_BOUND);
@@ -5790,9 +5574,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     return true;
                 }
                 if (TreeUtils.isConstructor((MethodTree) tree)) {
-                    validateTargetLocation(tree, type, TypeUseLocation.CONSTRUCTOR_RESULT);
+                    typeValidator.validateTargetLocation(
+                            tree, type, TypeUseLocation.CONSTRUCTOR_RESULT);
                 } else {
-                    validateTargetLocation(tree, type, TypeUseLocation.RETURN);
+                    typeValidator.validateTargetLocation(tree, type, TypeUseLocation.RETURN);
                 }
                 break;
             default:

--- a/framework/src/main/java/org/checkerframework/common/basetype/TypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/TypeValidator.java
@@ -19,7 +19,7 @@ public interface TypeValidator {
      *     validate its return type. If the tree is a variable tree, then validate its field type.
      * @return true, iff the type is valid
      */
-    public boolean isValid(AnnotatedTypeMirror type, Tree tree);
+    boolean isValid(AnnotatedTypeMirror type, Tree tree);
 
     /**
      * Validates whether the qualifiers on the variable tree are at the correct type-use locations,
@@ -29,7 +29,7 @@ public interface TypeValidator {
      * @param type the annotated type of the variable
      * @param tree the variable tree
      */
-    public void validateVariableTargetLocation(AnnotatedTypeMirror type, Tree tree);
+    void validateVariableTargetLocation(AnnotatedTypeMirror type, Tree tree);
 
     /**
      * Validates whether the qualifiers on the tree are at the correct type-use locations, as
@@ -39,6 +39,5 @@ public interface TypeValidator {
      * @param tree the tree whose qualifiers are to be validated
      * @param required the required TypeUseLocation
      */
-    public void validateTargetLocation(
-            AnnotatedTypeMirror type, Tree tree, TypeUseLocation required);
+    void validateTargetLocation(AnnotatedTypeMirror type, Tree tree, TypeUseLocation required);
 }

--- a/framework/src/main/java/org/checkerframework/common/basetype/TypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/TypeValidator.java
@@ -26,19 +26,19 @@ public interface TypeValidator {
      * as specified by the meta-annotation {@link
      * org.checkerframework.framework.qual.TargetLocations}.
      *
-     * @param tree the variable tree
      * @param type the annotated type of the variable
+     * @param tree the variable tree
      */
-    public void validateVariableTargetLocation(Tree tree, AnnotatedTypeMirror type);
+    public void validateVariableTargetLocation(AnnotatedTypeMirror type, Tree tree);
 
     /**
      * Validates whether the qualifiers on the tree are at the correct type-use locations, as
      * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
      *
-     * @param tree the tree whose qualifiers are to be validated
      * @param type the type of the tree
+     * @param tree the tree whose qualifiers are to be validated
      * @param required the required TypeUseLocation
      */
     public void validateTargetLocation(
-            Tree tree, AnnotatedTypeMirror type, TypeUseLocation required);
+            AnnotatedTypeMirror type, Tree tree, TypeUseLocation required);
 }

--- a/framework/src/main/java/org/checkerframework/common/basetype/TypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/TypeValidator.java
@@ -2,6 +2,7 @@ package org.checkerframework.common.basetype;
 
 import com.sun.source.tree.Tree;
 
+import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 
 /**
@@ -19,4 +20,25 @@ public interface TypeValidator {
      * @return true, iff the type is valid
      */
     public boolean isValid(AnnotatedTypeMirror type, Tree tree);
+
+    /**
+     * Validates whether the qualifiers on the variable tree are at the correct type-use locations,
+     * as specified by the meta-annotation {@link
+     * org.checkerframework.framework.qual.TargetLocations}.
+     *
+     * @param tree the variable tree
+     * @param type the annotated type of the variable
+     */
+    public void validateVariableTargetLocation(Tree tree, AnnotatedTypeMirror type);
+
+    /**
+     * Validates whether the qualifiers on the tree are at the correct type-use locations, as
+     * specified by the meta-annotation {@link org.checkerframework.framework.qual.TargetLocations}.
+     *
+     * @param tree the tree whose qualifiers are to be validated
+     * @param type the type of the tree
+     * @param required the required TypeUseLocation
+     */
+    public void validateTargetLocation(
+            Tree tree, AnnotatedTypeMirror type, TypeUseLocation required);
 }

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationValidator.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationValidator.java
@@ -53,6 +53,11 @@ public class StripLocationValidator extends BaseTypeValidator {
     }
 
     @Override
+    protected boolean shouldStripInvalidLocationQualifiers() {
+        return checker.hasOption("stripInvalidLocationQualifiers");
+    }
+
+    @Override
     protected List<AnnotationMirror> additionalAnnotationsToStripFromTypeVariableBound(
             AnnotatedTypeVariable type,
             Tree tree,

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationValidator.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationValidator.java
@@ -7,7 +7,6 @@ import com.sun.source.tree.WildcardTree;
 
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeValidator;
-import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.testchecker.striplocation.quals.StripTop;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -25,12 +24,12 @@ import javax.lang.model.element.AnnotationMirror;
 /**
  * A validator that additionally enforces a rule {@code @TargetLocations} cannot express: {@link
  * StripTop}, the checker's whole-system top qualifier, carries no {@code @TargetLocations} of its
- * own, so {@link BaseTypeVisitor#annotationsDisallowedAtLocation} and {@link
- * #annotationsDisallowedAtWildcardBound} never flag or strip it, no matter where it appears. This
- * validator additionally forbids writing it explicitly at a lower-bound location -- it may only
- * arrive there through defaulting -- by inspecting the declaration/bound tree directly, exercising
- * the {@link #additionalAnnotationsToStripFromTypeVariableBound} and {@link
- * #additionalAnnotationsToStripFromWildcardBound} hooks.
+ * own, so {@link #annotationsDisallowedAtLocation(AnnotatedTypeMirror, TypeUseLocation)} and {@link
+ * #annotationsDisallowedAtLocation(AnnotatedTypeMirror, Set)} never flag or strip it, no matter
+ * where it appears. This validator additionally forbids writing it explicitly at a lower-bound
+ * location -- it may only arrive there through defaulting -- by inspecting the declaration/bound
+ * tree directly, exercising the {@link #additionalAnnotationsToStripFromTypeVariableBound} and
+ * {@link #additionalAnnotationsToStripFromWildcardBound} hooks.
  *
  * <p>Because an explicit {@code @StripTop} lower bound is incompatible with an explicit non-top
  * upper bound, stripping it (rather than merely reporting it) has an observable effect: it avoids a

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationValidator.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationValidator.java
@@ -38,6 +38,9 @@ import javax.lang.model.element.AnnotationMirror;
  */
 public class StripLocationValidator extends BaseTypeValidator {
 
+    /** Whether to strip invalid location qualifiers. */
+    private final boolean stripInvalidLocationQualifiers;
+
     /**
      * Creates a new StripLocationValidator.
      *
@@ -50,11 +53,12 @@ public class StripLocationValidator extends BaseTypeValidator {
             StripLocationVisitor visitor,
             AnnotatedTypeFactory atypeFactory) {
         super(checker, visitor, atypeFactory);
+        this.stripInvalidLocationQualifiers = checker.hasOption("stripInvalidLocationQualifiers");
     }
 
     @Override
     protected boolean shouldStripInvalidLocationQualifiers() {
-        return checker.hasOption("stripInvalidLocationQualifiers");
+        return stripInvalidLocationQualifiers;
     }
 
     @Override

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationVisitor.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/striplocation/StripLocationVisitor.java
@@ -21,11 +21,6 @@ public class StripLocationVisitor extends BaseTypeVisitor<StripLocationAnnotated
     }
 
     @Override
-    protected boolean shouldStripInvalidLocationQualifiers() {
-        return checker.hasOption("stripInvalidLocationQualifiers");
-    }
-
-    @Override
     protected BaseTypeValidator createTypeValidator() {
         return new StripLocationValidator(checker, this, atypeFactory);
     }


### PR DESCRIPTION
This pull request consolidates target-location validation and bound-stripping logic from BaseTypeVisitor into BaseTypeValidator. It also minimizes the TypeValidator interface by removing internal methods and exposing them as protected hooks in BaseTypeValidator. Wrapper methods in BaseTypeVisitor were removed, and it now delegates directly to TypeValidator.

Done with Antigravity.