### PR TITLE
BaseTypeValidator: check enclosing types' type arguments against their bounds

### DIFF
--- a/checker/tests/nullness/EnclosingTypeArgs.java
+++ b/checker/tests/nullness/EnclosingTypeArgs.java
@@ -4,7 +4,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 // Test that type arguments of an explicitly-written enclosing type are checked against the
 // enclosing type parameter's declared bound, just like the arguments of a direct (non-enclosing)
 // parameterized type.  See https://github.com/eisop/checker-framework/issues/737.
-class EnclosingTypeArgs {
+abstract class EnclosingTypeArgs {
 
     static class Min<XXX extends @NonNull Object> {
         class Inner {}
@@ -23,4 +23,28 @@ class EnclosingTypeArgs {
 
     // Direct in-bound argument: no error.
     void okDirect(Min<@NonNull String> p) {}
+
+    // Return-type position (validateTypeOf is called with the whole MethodTree, not a type-use
+    // tree): the out-of-bound enclosing argument must also be rejected here.
+    // :: error: (type.argument.type.incompatible)
+    abstract Min<@Nullable String>.Inner returnType();
+
+    // In-bound enclosing argument in return-type position: no error.
+    abstract Min<@NonNull String>.Inner okReturnType();
+
+    // Unqualified class instance creation (validateTypeOf is called with the NewClassTree): the
+    // out-of-bound enclosing argument must also be rejected here. The enclosing instance ("this")
+    // is provided structurally by extending Min<String>; the type argument written on the `new`
+    // expression itself is what is being validated here, independent of that receiver.
+    static class Sub extends Min<String> {
+        void make() {
+            // :: error: (type.argument.type.incompatible)
+            Min<@Nullable String>.Inner x = new Min<@Nullable String>.Inner();
+        }
+
+        // In-bound enclosing argument in the same position: no error.
+        void okMake() {
+            Min<@NonNull String>.Inner x = new Min<@NonNull String>.Inner();
+        }
+    }
 }

--- a/checker/tests/nullness/EnclosingTypeArgs.java
+++ b/checker/tests/nullness/EnclosingTypeArgs.java
@@ -1,0 +1,26 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// Test that type arguments of an explicitly-written enclosing type are checked against the
+// enclosing type parameter's declared bound, just like the arguments of a direct (non-enclosing)
+// parameterized type.  See https://github.com/eisop/checker-framework/issues/737.
+class EnclosingTypeArgs {
+
+    static class Min<XXX extends @NonNull Object> {
+        class Inner {}
+    }
+
+    // Direct (non-enclosing) position: out-of-bound argument is rejected.
+    // :: error: (type.argument.type.incompatible)
+    void direct(Min<@Nullable String> p) {}
+
+    // Enclosing position: the same out-of-bound argument must also be rejected.
+    // :: error: (type.argument.type.incompatible)
+    void enclosing(Min<@Nullable String>.Inner p) {}
+
+    // In-bound enclosing argument: no error.
+    void okEnclosing(Min<@NonNull String>.Inner p) {}
+
+    // Direct in-bound argument: no error.
+    void okDirect(Min<@NonNull String> p) {}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -171,6 +171,16 @@ the final supertype on the built-in lattices (later substitution already
 corrected it), but the intermediate type is now faithful, which matters for
 type systems with stricter substitution.
 
+`BaseTypeValidator` now checks the type arguments of an explicitly-written
+enclosing type against the enclosing type parameters' declared bounds, so
+`Outer<@NonNull String>.Inner` is rejected when `@NonNull String` violates
+`Outer`'s type-parameter bound, matching the existing behavior for the
+non-enclosing `Outer<@NonNull String>` (further work on eisop#737).
+Previously an enclosing type's arguments were never validated. The extends and
+implements clauses are not yet covered, because their type computation drops
+the written enclosing-argument qualifier before validation; that is a separate,
+still-open part of eisop#737.
+
 `SourceChecker.reportError` and `SourceChecker.reportWarning` now accept a null
 source, for a message that has no source position. Such a message is reported
 against the compilation as a whole, and is suppressed only by

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -176,10 +176,13 @@ enclosing type against the enclosing type parameters' declared bounds, so
 `Outer<@NonNull String>.Inner` is rejected when `@NonNull String` violates
 `Outer`'s type-parameter bound, matching the existing behavior for the
 non-enclosing `Outer<@NonNull String>` (further work on eisop#737).
-Previously an enclosing type's arguments were never validated. The extends and
-implements clauses are not yet covered, because their type computation drops
-the written enclosing-argument qualifier before validation; that is a separate,
-still-open part of eisop#737.
+Previously an enclosing type's arguments were never validated. This covers a
+method's return type (e.g. `Outer<@NonNull String>.Inner returnType()`) and a
+`new` expression's instantiated type (e.g. `new Outer<@NonNull String>.Inner()`)
+in addition to fields, parameters, and other ordinary type-use positions. The
+extends and implements clauses are not yet covered, because their type
+computation drops the written enclosing-argument qualifier before validation;
+that is a separate, still-open part of eisop#737.
 
 `SourceChecker.reportError` and `SourceChecker.reportWarning` now accept a null
 source, for a message that has no source position. Such a message is reported

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -655,24 +655,52 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      * or an inner type named by a simple identifier with the enclosing arguments left implicit)
      * have no argument tree to check and are skipped, matching the direct-position behavior.
      *
+     * <p>For most tree shapes, each enclosing type checked is read off {@code type}'s own
+     * enclosing-type chain ({@link AnnotatedDeclaredType#getEnclosingType()}), matching the
+     * qualifier chain in the tree level for level. The exception is an unqualified class instance
+     * creation (e.g. {@code new Outer<...>.Inner()}): there, {@code type}'s enclosing type is the
+     * *receiver* used to viewpoint-adapt the constructor invocation (see {@link
+     * AnnotatedTypeFactory#getConstructorReceiverType}), which need not be, and need not carry the
+     * annotations of, the type actually written in the {@code new} expression. In that case, every
+     * enclosing type checked is instead derived directly from its own written tree via {@link
+     * AnnotatedTypeFactory#getAnnotatedTypeFromTypeTree}.
+     *
      * @param type the declared type whose enclosing types should be validated
-     * @param tree the tree for {@code type}
+     * @param tree the tree for {@code type}; besides a type-use tree, this may also be a {@link
+     *     MethodTree} (return type validation, see {@link BaseTypeVisitor#validateTypeOf}) or a
+     *     {@link NewClassTree} (the instantiated type), matching what {@link
+     *     #extractParameterizedTypeTree} accepts
      */
     protected void validateEnclosingTypeArgs(AnnotatedDeclaredType type, Tree tree) {
-        AnnotatedDeclaredType enclosing = type.getEnclosingType();
-        if (enclosing == null) {
+        if (type.getEnclosingType() == null) {
             return;
         }
 
+        // An unqualified `new Outer<...>.Inner()` has no enclosing expression to supply a receiver
+        // for viewpoint adaptation; `type`'s enclosing type is then some other applicable receiver
+        // (e.g. the type of an enclosing `this`), not the type written in the `new` expression.
+        boolean unqualifiedNewClass =
+                tree instanceof NewClassTree
+                        && ((NewClassTree) tree).getEnclosingExpression() == null;
+
         // Unwrap the type tree down to the tree that actually names the type: strip a surrounding
-        // VariableTree or AnnotatedTypeTree, then drop a top-level ParameterizedTypeTree's own type
-        // arguments to reach the (possibly qualified) name.
+        // VariableTree or AnnotatedTypeTree, unwrap a MethodTree to its return type or a
+        // NewClassTree to its instantiated type, then drop a top-level ParameterizedTypeTree's own
+        // type arguments to reach the (possibly qualified) name.
         Tree nameTree = tree;
         while (true) {
             if (nameTree instanceof VariableTree) {
                 nameTree = ((VariableTree) nameTree).getType();
             } else if (nameTree instanceof AnnotatedTypeTree) {
                 nameTree = ((AnnotatedTypeTree) nameTree).getUnderlyingType();
+            } else if (nameTree instanceof MethodTree) {
+                // A constructor has no written return type to unwrap further.
+                nameTree = ((MethodTree) nameTree).getReturnType();
+                if (nameTree == null) {
+                    return;
+                }
+            } else if (nameTree instanceof NewClassTree) {
+                nameTree = ((NewClassTree) nameTree).getIdentifier();
             } else {
                 break;
             }
@@ -683,17 +711,28 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
 
         // Walk outward through the qualifier chain, validating each enclosing type that is written
         // with explicit type arguments.
-        while (nameTree instanceof MemberSelectTree && enclosing != null) {
+        AnnotatedDeclaredType enclosing = unqualifiedNewClass ? null : type.getEnclosingType();
+        while (nameTree instanceof MemberSelectTree) {
             ExpressionTree enclosingTree = ((MemberSelectTree) nameTree).getExpression();
             if (enclosingTree instanceof ParameterizedTypeTree) {
                 ParameterizedTypeTree enclosingParamTree = (ParameterizedTypeTree) enclosingTree;
-                visitParameterizedType(enclosing, enclosingParamTree);
+                AnnotatedDeclaredType enclosingType =
+                        unqualifiedNewClass
+                                ? (AnnotatedDeclaredType)
+                                        atypeFactory.getAnnotatedTypeFromTypeTree(
+                                                enclosingParamTree)
+                                : enclosing;
+                if (enclosingType != null) {
+                    visitParameterizedType(enclosingType, enclosingParamTree);
+                }
                 nameTree = enclosingParamTree.getType();
             } else {
                 // A raw or simple-name enclosing type has no argument tree to validate.
                 nameTree = enclosingTree;
             }
-            enclosing = enclosing.getEnclosingType();
+            if (!unqualifiedNewClass) {
+                enclosing = enclosing == null ? null : enclosing.getEnclosingType();
+            }
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -4,6 +4,7 @@ import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
@@ -430,6 +431,12 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         ParameterizedTypeTree typeArgTree = p.first;
         type = p.second;
 
+        // Validate the type arguments of any explicitly-written enclosing types, e.g. the
+        // `Outer<...>` in `Outer<...>.Inner`. The scan below (and super.visitDeclared) only
+        // reaches a type's own direct type arguments; an enclosing type's arguments are buried
+        // in a MemberSelectTree and would otherwise never be checked against their bounds.
+        validateEnclosingTypeArgs(type, tree);
+
         if (typeArgTree == null) {
             return super.visitDeclared(type, tree);
         } // else
@@ -629,6 +636,65 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
         }
 
         return super.visitArray(type, tree);
+    }
+
+    /**
+     * Validates the type arguments of the explicitly-written enclosing types of a declared type,
+     * for example the {@code Outer<...>} part of a qualified type {@code Outer<...>.Inner}.
+     *
+     * <p>{@link #visitDeclared} and {@link AnnotatedTypeScanner#visitDeclared} only reach a
+     * declared type's own direct type arguments. An enclosing type's type arguments live inside a
+     * {@link MemberSelectTree} and, without this method, are never checked against the enclosing
+     * type parameters' bounds: {@code Outer<@NonNull String>.Inner} would be accepted even when
+     * {@code @NonNull String} violates the bound of {@code Outer}'s type parameter, whereas the
+     * same argument in the non-enclosing position {@code Outer<@NonNull String>} is rejected.
+     *
+     * <p>This method walks the enclosing-type/qualifier chain outward and runs {@link
+     * #visitParameterizedType} on each enclosing type that is written with explicit type arguments
+     * (a {@link ParameterizedTypeTree}). Enclosing types written without type arguments (raw types,
+     * or an inner type named by a simple identifier with the enclosing arguments left implicit)
+     * have no argument tree to check and are skipped, matching the direct-position behavior.
+     *
+     * @param type the declared type whose enclosing types should be validated
+     * @param tree the tree for {@code type}
+     */
+    protected void validateEnclosingTypeArgs(AnnotatedDeclaredType type, Tree tree) {
+        AnnotatedDeclaredType enclosing = type.getEnclosingType();
+        if (enclosing == null) {
+            return;
+        }
+
+        // Unwrap the type tree down to the tree that actually names the type: strip a surrounding
+        // VariableTree or AnnotatedTypeTree, then drop a top-level ParameterizedTypeTree's own type
+        // arguments to reach the (possibly qualified) name.
+        Tree nameTree = tree;
+        while (true) {
+            if (nameTree instanceof VariableTree) {
+                nameTree = ((VariableTree) nameTree).getType();
+            } else if (nameTree instanceof AnnotatedTypeTree) {
+                nameTree = ((AnnotatedTypeTree) nameTree).getUnderlyingType();
+            } else {
+                break;
+            }
+        }
+        if (nameTree instanceof ParameterizedTypeTree) {
+            nameTree = ((ParameterizedTypeTree) nameTree).getType();
+        }
+
+        // Walk outward through the qualifier chain, validating each enclosing type that is written
+        // with explicit type arguments.
+        while (nameTree instanceof MemberSelectTree && enclosing != null) {
+            ExpressionTree enclosingTree = ((MemberSelectTree) nameTree).getExpression();
+            if (enclosingTree instanceof ParameterizedTypeTree) {
+                ParameterizedTypeTree enclosingParamTree = (ParameterizedTypeTree) enclosingTree;
+                visitParameterizedType(enclosing, enclosingParamTree);
+                nameTree = enclosingParamTree.getType();
+            } else {
+                // A raw or simple-name enclosing type has no argument tree to validate.
+                nameTree = enclosingTree;
+            }
+            enclosing = enclosing.getEnclosingType();
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Second of three PRs closing out eisop#737 (first: #1917). Fixes a real,
  verified gap in `BaseTypeValidator`: an explicitly-written enclosing type's
  type arguments were never checked against the enclosing type parameters'
  declared bounds, so `Outer<@NonNull String>.Inner` was silently accepted
  even when `@NonNull String` violates `Outer`'s type-parameter bound, while
  the same argument on the non-enclosing `Outer<@NonNull String>` was
  correctly rejected.
- `visitDeclared` and `AnnotatedTypeScanner.visitDeclared` only ever reach a
  declared type's own *direct* type arguments; an enclosing type's arguments
  live inside a `MemberSelectTree` that neither reaches. The new
  `validateEnclosingTypeArgs` helper walks the qualifier chain outward and
  reuses the existing `visitParameterizedType` check on each enclosing type
  written with explicit type arguments, so the bound check itself is not
  duplicated.
- This closes the gap for fields, method parameters, and other standard
  type-use positions. The `extends`/`implements` clause and local variables
  are **not yet covered** by this PR: their type computation currently drops
  the written enclosing-argument qualifier before validation reaches it (a
  separate, computation-side part of #737), so there is nothing out-of-bound
  for this new check to see in those two positions yet. That's the third PR
  in the series.
- No allocations are introduced on the common path: for a type with no
  enclosing type (the vast majority of type uses), the new method reads one
  field and returns.

## Test plan

- [x] New regression test `checker/tests/nullness/EnclosingTypeArgs.java`:
      direct and enclosing out-of-bound arguments are both rejected;
      in-bound arguments in both positions are accepted.
- [x] `./gradlew :framework:test` — zero failures.
- [x] `./gradlew :checker:test` (full suite) — zero failures, zero
      diagnostic changes elsewhere in the corpus (the construct does not
      occur in any existing sample).
- [x] CHANGELOG entry added.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
