### PR TITLE
TypeFromTypeTreeVisitor: restore written enclosing type arguments of qualified types

### DIFF
--- a/checker/tests/nullness/EnclosingTypeArgs.java
+++ b/checker/tests/nullness/EnclosingTypeArgs.java
@@ -47,4 +47,26 @@ abstract class EnclosingTypeArgs {
             Min<@NonNull String>.Inner x = new Min<@NonNull String>.Inner();
         }
     }
+
+    // Local variable, enclosing position: the written enclosing argument must reach the
+    // validator and be rejected, just like the field/parameter positions above.
+    void localVars() {
+        // :: error: (type.argument.type.incompatible)
+        Min<@Nullable String>.Inner bad = null;
+        Min<@NonNull String>.Inner ok = null;
+        // Direct (non-enclosing) local for contrast.
+        // :: error: (type.argument.type.incompatible)
+        Min<@Nullable String> directBad = null;
+    }
+}
+
+// Extends clause, enclosing position: the written enclosing argument must reach the validator and
+// be rejected.  Sub/SubOk are nested so that an enclosing instance of Outer exists.
+class Outer<XXX extends @NonNull Object> {
+    class Sup {}
+
+    // :: error: (type.argument.type.incompatible)
+    class Sub extends Outer<@Nullable String>.Sup {}
+
+    class SubOk extends Outer<@NonNull String>.Sup {}
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -179,10 +179,19 @@ non-enclosing `Outer<@NonNull String>` (further work on eisop#737).
 Previously an enclosing type's arguments were never validated. This covers a
 method's return type (e.g. `Outer<@NonNull String>.Inner returnType()`) and a
 `new` expression's instantiated type (e.g. `new Outer<@NonNull String>.Inner()`)
-in addition to fields, parameters, and other ordinary type-use positions. The
-extends and implements clauses are not yet covered, because their type
-computation drops the written enclosing-argument qualifier before validation;
-that is a separate, still-open part of eisop#737.
+in addition to fields, parameters, and other ordinary type-use positions.
+
+`TypeFromTypeTreeVisitor` now restores the annotations written on the type
+arguments of an explicitly-written enclosing type of a qualified type, so a
+qualified type used in an extends/implements clause (`class Sub extends
+Outer<@Nullable String>.Sup`) or a local-variable declaration
+(`Outer<@Nullable String>.Inner x`) now carries the written enclosing-argument
+qualifier, and an out-of-bound argument in those positions is rejected. This
+completes the fix for eisop#737. Previously the written qualifier was dropped
+during tree-to-type conversion, so the validator never saw it: for a field or
+method parameter the element-based annotation recovery restored it, but a
+local-variable element does not retain it and an extends/implements clause has
+no element, so those two positions were silently accepted.
 
 `SourceChecker.reportError` and `SourceChecker.reportWarning` now accept a null
 source, for a message that has no source position. Such a message is reported
@@ -339,7 +348,7 @@ Other improvements and bug fixes:
 
 **Closed issues:**
 
-eisop#433, eisop#792, eisop#863, eisop#949, eisop#1015, eisop#1074,
+eisop#433, eisop#737, eisop#792, eisop#863, eisop#949, eisop#1015, eisop#1074,
 eisop#1244, eisop#1315, eisop#1564, eisop#1592, eisop#1642, eisop#1653,
 eisop#1735, eisop#1801, eisop#1818, eisop#1819, eisop#1861, eisop#1862,
 eisop#1863, eisop#1865, eisop#1887.

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -357,9 +357,54 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
         if (type.getKind() == TypeKind.TYPEVAR) {
             return getTypeVariableFromDeclaration((AnnotatedTypeVariable) type, f);
         }
+        restoreWrittenEnclosingType(type, tree, f);
         refineEnclosingTypeVariableBounds(type, f);
 
         return type;
+    }
+
+    /**
+     * Restores the annotations written on the type arguments of an explicitly-written enclosing
+     * type of a qualified type, for example the {@code Outer<@Anno String>} part of {@code
+     * Outer<@Anno String>.Inner}.
+     *
+     * <p>{@link AnnotatedTypeFactory#type(Tree)} derives the enclosing type from the underlying
+     * javac type, whose enclosing type arguments carry defaulted annotations rather than the ones
+     * written in the source (see <a
+     * href="https://github.com/eisop/checker-framework/issues/737">issue #737</a>). For a field or
+     * method parameter, {@code ElementAnnotationApplier} later recovers the written annotations
+     * from the element, but a local-variable element does not retain them and an extends/implements
+     * clause has no element at all, so for those positions the written enclosing-argument
+     * annotation would otherwise be lost. This method rebuilds the enclosing type from its own
+     * subtree (a {@link ParameterizedTypeTree} or a nested {@link MemberSelectTree}), which visits
+     * the written type-argument trees and so preserves their annotations, and transplants it onto
+     * {@code type}.
+     *
+     * @param type the type produced for {@code tree}, side-effected in place
+     * @param tree the member-select tree that {@code type} was produced from
+     * @param f the annotated type factory
+     */
+    private void restoreWrittenEnclosingType(
+            AnnotatedTypeMirror type, MemberSelectTree tree, AnnotatedTypeFactory f) {
+        if (type.getKind() != TypeKind.DECLARED) {
+            return;
+        }
+        AnnotatedDeclaredType declaredType = (AnnotatedDeclaredType) type;
+        if (declaredType.getEnclosingType() == null) {
+            return;
+        }
+        // Only an enclosing type written with explicit type arguments (a ParameterizedTypeTree), or
+        // a further-qualified name that may contain one (a MemberSelectTree), can carry written
+        // annotations to restore. A simple-name enclosing type (IdentifierTree) has none.
+        ExpressionTree enclosingTree = tree.getExpression();
+        if (!(enclosingTree instanceof ParameterizedTypeTree
+                || enclosingTree instanceof MemberSelectTree)) {
+            return;
+        }
+        AnnotatedTypeMirror enclosing = visit(enclosingTree, f);
+        if (enclosing != null && enclosing.getKind() == TypeKind.DECLARED) {
+            declaredType.setEnclosingType((AnnotatedDeclaredType) enclosing);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Third and final PR closing out eisop#737 (after #1917 and #1920, both
merged). Fixes the issue's own headline example: an out-of-bound enclosing
type argument in an `extends`/`implements` clause or a local-variable
declaration was silently accepted.

- `TypeFromTypeTreeVisitor.visitMemberSelect` builds a qualified type
  `Outer<@Anno String>.Inner` via `f.type(tree)`, which derives the enclosing
  `Outer` from the underlying javac type — whose enclosing type arguments
  carry defaulted annotations — and never visits the written enclosing
  subtree `tree.getExpression()`. The written `@Anno` was therefore dropped
  from the enclosing type argument during tree-to-type conversion.
- For a field or method parameter this loss was invisible:
  `ElementAnnotationApplier` later recovers the written annotation from the
  element (a `VarSymbol` retains type-annotation positions), so #1920's
  validator check saw the correct argument. A local-variable element does
  not retain those annotations, and an extends/implements clause is resolved
  through `getTypeOfExtendsImplements` with no element at all, so for those
  two positions the written qualifier never reached the validator and an
  out-of-bound enclosing argument was silently accepted — this was the last
  open part of #737.
- New helper `restoreWrittenEnclosingType`, called from `visitMemberSelect`,
  rebuilds the enclosing type by visiting `tree.getExpression()` when it's a
  `ParameterizedTypeTree` (or a further-qualified `MemberSelectTree`), which
  visits the written type-argument trees and so preserves their annotations,
  and transplants it onto the result. This is the concrete-argument analogue
  of #1917's `refineEnclosingTypeVariableBounds` (which restores
  *type-variable bounds* in enclosing types); the two are complementary and
  both run.
- `checker/tests/nullness/EnclosingTypeArgs.java` is extended to lock in the
  extends-clause and local-variable positions, alongside the direct,
  enclosing, return-type, and new-expression positions already covered by
  #1917/#1920.
- `eisop#737` is added to the CHANGELOG's Closed issues list.

**One pre-existing, orthogonal limitation observed but not addressed:** for
a two-or-more-level enclosing chain whose *outer* argument is out-of-bound
(`A<@Nullable String>.B<@NonNull String>.C`), `BaseTypeValidator` reports the
outer violation twice. This reproduces on `master` for the already-covered
field/parameter position independently of this change, so it's a defect in
that validation walk, not in this computation-side fix. Filed as a separate
follow-up (eisop#1926) rather than folding it into this PR.

## Test plan

- [x] New regression tests: extends-clause (`Outer.Sub`/`Outer.SubOk`) and
      local-variable (`localVars()`) positions, both out-of-bound and
      in-bound cases.
- [x] `./gradlew :framework:test` — zero failures.
- [x] `./gradlew :checker:test` (full suite) — zero failures, zero
      diagnostic changes elsewhere in the corpus.
- [x] `./gradlew :checker:jtregTests` — zero failures.
- [x] CHANGELOG entry updated; `eisop#737` added to Closed issues.

Fixes #737.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

