### PR TITLE
Fix qualifier defaults scope shadowing

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -790,14 +790,11 @@ public class QualifierDefaults {
             qualifiers = parentDefaults;
         } else {
             // A default for a given (location, hierarchy) at a nearer scope shadows a default for
-            // the
-            // same (location, hierarchy) at an enclosing scope: only inherit an enclosing-scope
-            // default
-            // whose (location, hierarchy) the nearer scope does not itself set. Without this, both
-            // defaults
-            // would coexist in the (location, annotation)-ordered TreeSet and the winner between
-            // them
-            // would be decided by annotation ordering rather than by scope distance.
+            // the same (location, hierarchy) at an enclosing scope: only inherit an enclosing-scope
+            // default whose (location, hierarchy) the nearer scope does not itself set. Without
+            // this, both defaults would coexist in the (location, annotation)-ordered TreeSet and
+            // the winner between them would be decided by annotation ordering rather than by scope
+            // distance.
             QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
             List<Default> nearerDefaults = new ArrayList<>(qualifiers);
             for (Default d : parentDefaults) {

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -41,6 +41,7 @@ import org.plumelib.util.StringsPlume;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
@@ -789,8 +790,22 @@ public class QualifierDefaults {
         if (qualifiers == null || qualifiers.isEmpty()) {
             qualifiers = parentDefaults;
         } else {
-            // TODO(cpovirk): What should happen with conflicts?
-            qualifiers.addAll(parentDefaults);
+            // A default for a given location at a nearer scope shadows a default for the same
+            // location at an enclosing scope: only inherit an enclosing-scope default whose
+            // location the nearer scope does not itself set. Without this, both defaults would
+            // coexist in the (location, annotation)-ordered TreeSet and the winner between them
+            // would be decided by annotation ordering rather than by scope distance -- so an
+            // enclosing scope could override a nearer one (e.g. a nested @NullUnmarked failing to
+            // override an enclosing @NullMarked for a wildcard's implicit upper bound).
+            Set<TypeUseLocation> nearerLocations = EnumSet.noneOf(TypeUseLocation.class);
+            for (Default d : qualifiers) {
+                nearerLocations.add(d.location);
+            }
+            for (Default d : parentDefaults) {
+                if (!nearerLocations.contains(d.location)) {
+                    qualifiers.add(d);
+                }
+            }
         }
 
         if (!qualifiers.isEmpty()) {

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -38,6 +38,7 @@ import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
 import org.plumelib.util.StringsPlume;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -38,7 +38,6 @@ import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
 import org.plumelib.util.StringsPlume;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -796,7 +795,7 @@ public class QualifierDefaults {
             // the winner between them would be decided by annotation ordering rather than by scope
             // distance.
             QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
-            List<Default> nearerDefaults = new ArrayList<>(qualifiers);
+            Default[] nearerDefaults = qualifiers.toArray(new Default[qualifiers.size()]);
             for (Default d : parentDefaults) {
                 boolean shadowed = false;
                 AnnotationMirror parentTop = qualHierarchy.getTopAnnotation(d.anno);

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -796,11 +796,10 @@ public class QualifierDefaults {
             // the winner between them would be decided by annotation ordering rather than by scope
             // distance.
             QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
-            Default[] nearerDefaults = qualifiers.toArray(new Default[qualifiers.size()]);
             for (Default d : parentDefaults) {
                 boolean shadowed = false;
                 AnnotationMirror parentTop = qualHierarchy.getTopAnnotation(d.anno);
-                for (Default nearer : nearerDefaults) {
+                for (Default nearer : qualifiers) {
                     if (nearer.location == d.location) {
                         AnnotationMirror nearerTop = qualHierarchy.getTopAnnotation(nearer.anno);
                         if (AnnotationUtils.areSame(parentTop, nearerTop)) {

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -41,7 +41,6 @@ import org.plumelib.util.StringsPlume;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
@@ -790,19 +789,30 @@ public class QualifierDefaults {
         if (qualifiers == null || qualifiers.isEmpty()) {
             qualifiers = parentDefaults;
         } else {
-            // A default for a given location at a nearer scope shadows a default for the same
-            // location at an enclosing scope: only inherit an enclosing-scope default whose
-            // location the nearer scope does not itself set. Without this, both defaults would
-            // coexist in the (location, annotation)-ordered TreeSet and the winner between them
-            // would be decided by annotation ordering rather than by scope distance -- so an
-            // enclosing scope could override a nearer one (e.g. a nested @NullUnmarked failing to
-            // override an enclosing @NullMarked for a wildcard's implicit upper bound).
-            Set<TypeUseLocation> nearerLocations = EnumSet.noneOf(TypeUseLocation.class);
-            for (Default d : qualifiers) {
-                nearerLocations.add(d.location);
-            }
+            // A default for a given (location, hierarchy) at a nearer scope shadows a default for
+            // the
+            // same (location, hierarchy) at an enclosing scope: only inherit an enclosing-scope
+            // default
+            // whose (location, hierarchy) the nearer scope does not itself set. Without this, both
+            // defaults
+            // would coexist in the (location, annotation)-ordered TreeSet and the winner between
+            // them
+            // would be decided by annotation ordering rather than by scope distance.
+            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
+            List<Default> nearerDefaults = new ArrayList<>(qualifiers);
             for (Default d : parentDefaults) {
-                if (!nearerLocations.contains(d.location)) {
+                boolean shadowed = false;
+                AnnotationMirror parentTop = qualHierarchy.getTopAnnotation(d.anno);
+                for (Default nearer : nearerDefaults) {
+                    if (nearer.location == d.location) {
+                        AnnotationMirror nearerTop = qualHierarchy.getTopAnnotation(nearer.anno);
+                        if (AnnotationUtils.areSame(parentTop, nearerTop)) {
+                            shadowed = true;
+                            break;
+                        }
+                    }
+                }
+                if (!shadowed) {
                     qualifiers.add(d);
                 }
             }

--- a/framework/tests/defaulting/upperbound/ScopeShadowing.java
+++ b/framework/tests/defaulting/upperbound/ScopeShadowing.java
@@ -1,0 +1,17 @@
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;
+import org.checkerframework.framework.testchecker.defaulting.UpperBoundQual.UbExplicit;
+import org.checkerframework.framework.testchecker.defaulting.UpperBoundQual.UbImplicit;
+
+@DefaultQualifier(value = UbExplicit.class, locations = TypeUseLocation.RETURN)
+public class ScopeShadowing {
+
+    @DefaultQualifier(value = UbImplicit.class, locations = TypeUseLocation.RETURN)
+    public Object testShadowing() {
+        return null;
+    }
+
+    public void test() {
+        @UbImplicit Object result = testShadowing();
+    }
+}

--- a/framework/tests/h1h2checker/ScopeShadowing.java
+++ b/framework/tests/h1h2checker/ScopeShadowing.java
@@ -1,0 +1,25 @@
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;
+import org.checkerframework.framework.testchecker.h1h2checker.quals.H1S1;
+import org.checkerframework.framework.testchecker.h1h2checker.quals.H2S1;
+
+@DefaultQualifier(value = H1S1.class, locations = TypeUseLocation.RETURN)
+public class ScopeShadowing {
+
+    // The enclosing scope sets the default for the H1 hierarchy to @H1S1.
+    // The nearer scope (this method) sets the default for the H2 hierarchy to @H2S1.
+    // Under the buggy shadowing logic, the nearer @H2S1 would shadow the enclosing @H1S1
+    // simply because they both share the location TypeUseLocation.RETURN, which meant
+    // that the H1 hierarchy would fallback to its standard default (H1Top) instead of H1S1.
+    @DefaultQualifier(value = H2S1.class, locations = TypeUseLocation.RETURN)
+    public Object testMultiHierarchyShadowing() {
+        return null;
+    }
+
+    public void test() {
+        // testMultiHierarchyShadowing() should return @H1S1 @H2S1 Object.
+        // Assigning it to a variable explicitly typed as @H1S1 @H2S1 Object should be valid.
+        // Under the bug, the return type would be @H1Top @H2S1 Object, causing an assignment error.
+        @H1S1 @H2S1 Object result = testMultiHierarchyShadowing();
+    }
+}


### PR DESCRIPTION
Defaults from a nearer scope should shadow defaults from an enclosing scope for the same location. Fixes an issue where enclosing scopes incorrectly override nearer scopes depending on annotation alphabetical order.

Started by Claude and expanded and tested with Antigravity.