### PR TITLE
Skip private methods in text parser's fake override resolution

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -2324,6 +2324,12 @@ public class AnnotationFileParser {
                 continue;
             }
             ExecutableElement candidate = (ExecutableElement) elt;
+            // Skip private methods: they cannot be overridden, so they cannot be fake override
+            // targets. This mirrors BinaryStubWriter.processCallable, which never writes private
+            // methods.
+            if (candidate.getModifiers().contains(javax.lang.model.element.Modifier.PRIVATE)) {
+                continue;
+            }
             if (!InternalUtils.sameName(
                     candidate.getSimpleName(), methodDecl.getName().getIdentifier())) {
                 continue;

--- a/framework/src/main/java/org/checkerframework/framework/stub/BinaryStubReader.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/BinaryStubReader.java
@@ -38,6 +38,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
@@ -966,7 +967,14 @@ public class BinaryStubReader {
             AnnotationFileElementTypes elementTypes,
             boolean typevarLenient) {
         if (!typevarLenient) {
-            return elementTypes.methodSigIndex(typeElt).get(sig);
+            ExecutableElement ee = elementTypes.methodSigIndex(typeElt).get(sig);
+            // Skip private methods: they cannot be overridden, so they cannot be fake override
+            // targets. This mirrors AnnotationFileParser.declaredMethodMatching and
+            // BinaryStubWriter.processCallable, which never writes private methods.
+            if (ee != null && ee.getModifiers().contains(Modifier.PRIVATE)) {
+                return null;
+            }
+            return ee;
         }
         int paren = sig.indexOf('(');
         if (paren == -1 || !sig.endsWith(")")) {
@@ -977,6 +985,11 @@ public class BinaryStubReader {
         String[] sigParams = paramList.isEmpty() ? new String[0] : paramList.split(",", -1);
         ExecutableElement match = null;
         for (ExecutableElement candidate : ElementFilter.methodsIn(typeElt.getEnclosedElements())) {
+            // Skip private methods: they cannot be overridden, so they cannot be fake override
+            // targets.
+            if (candidate.getModifiers().contains(Modifier.PRIVATE)) {
+                continue;
+            }
             if (!InternalUtils.sameName(candidate.getSimpleName(), name)) {
                 continue;
             }


### PR DESCRIPTION
The text parser's \`declaredMethodMatching\` was matching private methods in supertypes as potential fake override targets. The binary writer (\`BinaryStubWriter.processCallable\`) skips private methods entirely, so they never appear in binary stubs. This mismatch caused \`binaryStubDiffTest\` failures for private methods like \`MatchResult.groupNumber\` and several methods in \`ObjectInputFilter.Config\`/\`Config.Global\`.

This adds a check to skip private candidates in \`declaredMethodMatching\`, mirroring the binary writer's behavior.

**Tested:**
- \`NullnessBinaryStubDiffTest\` in checker-framework: 1652 top-level classes, 0 mismatches
- \`binaryStubDiffTest\` in jspecify-reference-checker: 791 top-level classes, 0 mismatches