### PR TITLE
Thread inferred-vs-written flag through TypeVariableSubstitutor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -335,14 +335,15 @@ Other improvements and bug fixes:
   substituted were inferred by the type checker, as opposed to written
   explicitly by the programmer at the call site. The existing two-argument
   `substitute(Map, AnnotatedTypeMirror)` is unchanged and continues to default
-  to `false`. The corresponding extension point,
-  `substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable)`, now
-  always takes this flag as a third parameter; the two-argument overload has
-  been removed rather than kept alongside it, so a checker cannot accidentally
-  override one and not the other and be surprised that only one of its
-  overrides ever runs. This lets a checker distinguish inferred from written
-  type arguments during substitution without a hand-rolled instance field
-  that must be manually saved and restored around reentrant
+  to `false`; both `substitute(...)` overloads are now `final`, since they are
+  convenience entry points, not extension points. The corresponding extension
+  point, `substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable)`,
+  now always takes this flag as a third parameter; the two-argument overload
+  has been removed rather than kept alongside it, so a checker cannot
+  accidentally override one and not the other and be surprised that only one
+  of its overrides ever runs. This lets a checker distinguish inferred from
+  written type arguments during substitution without a hand-rolled instance
+  field that must be manually saved and restored around reentrant
   `methodFromUse`/`constructorFromUse` calls, as the JSpecify reference
   checker previously had to do.
 - Fixed a latent aliasing bug in `AnnotatedTypeCopier` for executable types.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -330,6 +330,16 @@ Performance optimizations:
 Other improvements and bug fixes:
 - `TreeUtils` has a new `inferredTypeArguments(ExpressionTree)` method to
   recover Java type variables inferred by javac.
+- `TypeVariableSubstitutor` has a new `substitute(Map, AnnotatedTypeMirror,
+  boolean)` overload and a corresponding new `substituteTypeVariable(argument,
+  use, boolean)` overload that also indicate whether the type argument being
+  substituted was inferred by the type checker, as opposed to written
+  explicitly by the programmer at the call site. The existing two-argument
+  overloads are unchanged and continue to default to `false`. This lets a
+  checker distinguish inferred from written type arguments during
+  substitution without a hand-rolled instance field that must be manually
+  saved and restored around reentrant `methodFromUse`/`constructorFromUse`
+  calls, as the JSpecify reference checker previously had to do.
 - Fixed a latent aliasing bug in `AnnotatedTypeCopier` for executable types.
 - Fixed an `IndexOutOfBoundsException` for lambdas in varargs.
 - Fixed `BinaryOperation.hashCode()` to agree with `equals()` for commutative

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -331,15 +331,20 @@ Other improvements and bug fixes:
 - `TreeUtils` has a new `inferredTypeArguments(ExpressionTree)` method to
   recover Java type variables inferred by javac.
 - `TypeVariableSubstitutor` has a new `substitute(Map, AnnotatedTypeMirror,
-  boolean)` overload and a corresponding new `substituteTypeVariable(argument,
-  use, boolean)` overload that also indicate whether the type argument being
-  substituted was inferred by the type checker, as opposed to written
+  boolean)` overload that also indicates whether the type arguments being
+  substituted were inferred by the type checker, as opposed to written
   explicitly by the programmer at the call site. The existing two-argument
-  overloads are unchanged and continue to default to `false`. This lets a
-  checker distinguish inferred from written type arguments during
-  substitution without a hand-rolled instance field that must be manually
-  saved and restored around reentrant `methodFromUse`/`constructorFromUse`
-  calls, as the JSpecify reference checker previously had to do.
+  `substitute(Map, AnnotatedTypeMirror)` is unchanged and continues to default
+  to `false`. The corresponding extension point,
+  `substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable)`, now
+  always takes this flag as a third parameter; the two-argument overload has
+  been removed rather than kept alongside it, so a checker cannot accidentally
+  override one and not the other and be surprised that only one of its
+  overrides ever runs. This lets a checker distinguish inferred from written
+  type arguments during substitution without a hand-rolled instance field
+  that must be manually saved and restored around reentrant
+  `methodFromUse`/`constructorFromUse` calls, as the JSpecify reference
+  checker previously had to do.
 - Fixed a latent aliasing bug in `AnnotatedTypeCopier` for executable types.
 - Fixed an `IndexOutOfBoundsException` for lambdas in varargs.
 - Fixed `BinaryOperation.hashCode()` to agree with `equals()` for commutative

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3043,7 +3043,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             }
             methodType =
                     (AnnotatedExecutableType)
-                            typeVarSubstitutor.substitute(typeParamToTypeArg, methodType);
+                            typeVarSubstitutor.substitute(
+                                    typeParamToTypeArg,
+                                    methodType,
+                                    typeArguments.typeArgumentsInferred);
         }
 
         if (typeArguments.inferenceCrash && tree instanceof MethodInvocationTree) {
@@ -3732,7 +3735,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                             con.getTypeVariables());
         }
 
-        con = (AnnotatedExecutableType) typeVarSubstitutor.substitute(typeParamToTypeArg, con);
+        con =
+                (AnnotatedExecutableType)
+                        typeVarSubstitutor.substitute(
+                                typeParamToTypeArg, con, typeArguments.typeArgumentsInferred);
 
         stubTypes.injectRecordComponentType(types, ctor, con);
 

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -34,7 +34,27 @@ public class TypeVariableSubstitutor {
     public AnnotatedTypeMirror substitute(
             Map<TypeVariable, AnnotatedTypeMirror> typeVarToTypeArgument,
             AnnotatedTypeMirror type) {
-        return new Visitor(typeVarToTypeArgument, true).visit(type);
+        return substitute(typeVarToTypeArgument, type, false);
+    }
+
+    /**
+     * Given a mapping from type variable to its type argument, replace each instance of a type
+     * variable with a copy of type argument.
+     *
+     * @see #substituteTypeVariable(AnnotatedTypeMirror,
+     *     org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable, boolean)
+     * @param typeVarToTypeArgument a mapping from type variable to its type argument
+     * @param type the type to substitute
+     * @param typeArgumentsInferred whether the type arguments in {@code typeVarToTypeArgument} were
+     *     inferred by the type checker, as opposed to written explicitly by the programmer at the
+     *     call site
+     * @return a copy of type with its type variables substituted
+     */
+    public AnnotatedTypeMirror substitute(
+            Map<TypeVariable, AnnotatedTypeMirror> typeVarToTypeArgument,
+            AnnotatedTypeMirror type,
+            boolean typeArgumentsInferred) {
+        return new Visitor(typeVarToTypeArgument, true, typeArgumentsInferred).visit(type);
     }
 
     /**
@@ -76,6 +96,27 @@ public class TypeVariableSubstitutor {
     }
 
     /**
+     * As {@link #substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable)}, but also
+     * indicates whether {@code argument} is a type argument that the type checker inferred (true),
+     * as opposed to one the programmer wrote explicitly at the call site (false).
+     *
+     * <p>The default implementation ignores {@code argumentIsInferred} and delegates to {@link
+     * #substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable)}, so existing overrides
+     * of that method are unaffected. A checker that needs to treat inferred and written type
+     * arguments differently during substitution should override this method instead.
+     *
+     * @param argument the argument to declaration (this will be a value in typeParamToArg)
+     * @param use the use that is being replaced
+     * @param argumentIsInferred whether {@code argument} was inferred by the type checker rather
+     *     than written explicitly by the programmer
+     * @return a deep copy of argument with the appropriate annotations applied
+     */
+    protected AnnotatedTypeMirror substituteTypeVariable(
+            AnnotatedTypeMirror argument, AnnotatedTypeVariable use, boolean argumentIsInferred) {
+        return substituteTypeVariable(argument, use);
+    }
+
+    /**
      * Visitor that makes the substitution. This is an inner class so that its methods cannot be
      * called by clients of {@link TypeVariableSubstitutor}.
      */
@@ -103,6 +144,12 @@ public class TypeVariableSubstitutor {
         private final boolean copyArgument;
 
         /**
+         * Whether the type arguments in {@code elementToArgMap} were inferred by the type checker,
+         * as opposed to written explicitly by the programmer at the call site.
+         */
+        private final boolean typeArgumentsInferred;
+
+        /**
          * Creates the Visitor.
          *
          * @param typeParamToArg mapping from TypeVariable to the AnnotatedTypeMirror that will
@@ -111,6 +158,23 @@ public class TypeVariableSubstitutor {
          */
         public Visitor(
                 Map<TypeVariable, AnnotatedTypeMirror> typeParamToArg, boolean copyArgument) {
+            this(typeParamToArg, copyArgument, false);
+        }
+
+        /**
+         * Creates the Visitor.
+         *
+         * @param typeParamToArg mapping from TypeVariable to the AnnotatedTypeMirror that will
+         *     replace it
+         * @param copyArgument whether or not a copy of type argument should be substituted
+         * @param typeArgumentsInferred whether the type arguments in {@code typeParamToArg} were
+         *     inferred by the type checker, as opposed to written explicitly by the programmer at
+         *     the call site
+         */
+        public Visitor(
+                Map<TypeVariable, AnnotatedTypeMirror> typeParamToArg,
+                boolean copyArgument,
+                boolean typeArgumentsInferred) {
             int size = typeParamToArg.size();
             elementToArgMap = new HashMap<>(size);
             typeVars = new ArrayList<>(size);
@@ -125,6 +189,7 @@ public class TypeVariableSubstitutor {
                 typeMirrors.add(paramToArg.getValue().getUnderlyingType());
             }
             this.copyArgument = copyArgument;
+            this.typeArgumentsInferred = typeArgumentsInferred;
         }
 
         @Override
@@ -168,7 +233,7 @@ public class TypeVariableSubstitutor {
                 AnnotatedTypeMirror argument = elementToArgMap.get(typeVarElem);
                 if (argument != null) {
                     if (copyArgument) {
-                        return substituteTypeVariable(argument, original);
+                        return substituteTypeVariable(argument, original, typeArgumentsInferred);
                     } else {
                         return argument;
                     }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -25,13 +25,19 @@ public class TypeVariableSubstitutor {
      * Given a mapping from type variable to its type argument, replace each instance of a type
      * variable with a copy of type argument.
      *
+     * <p>This method is {@code final}: it is a convenience entry point, not an extension point. A
+     * checker that wants to customize substitution should override {@link
+     * #substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable, boolean)} instead
+     * (installed via {@code AnnotatedTypeFactory#createTypeVariableSubstitutor}), so there is
+     * exactly one override point rather than two arities that could be overridden inconsistently.
+     *
      * @see #substituteTypeVariable(AnnotatedTypeMirror,
      *     org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable, boolean)
      * @param typeVarToTypeArgument a mapping from type variable to its type argument
      * @param type the type to substitute
      * @return a copy of type with its type variables substituted
      */
-    public AnnotatedTypeMirror substitute(
+    public final AnnotatedTypeMirror substitute(
             Map<TypeVariable, AnnotatedTypeMirror> typeVarToTypeArgument,
             AnnotatedTypeMirror type) {
         return substitute(typeVarToTypeArgument, type, false);
@@ -40,6 +46,8 @@ public class TypeVariableSubstitutor {
     /**
      * Given a mapping from type variable to its type argument, replace each instance of a type
      * variable with a copy of type argument.
+     *
+     * <p>This method is {@code final}; see {@link #substitute(Map, AnnotatedTypeMirror)}.
      *
      * @see #substituteTypeVariable(AnnotatedTypeMirror,
      *     org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable, boolean)
@@ -50,7 +58,7 @@ public class TypeVariableSubstitutor {
      *     call site
      * @return a copy of type with its type variables substituted
      */
-    public AnnotatedTypeMirror substitute(
+    public final AnnotatedTypeMirror substitute(
             Map<TypeVariable, AnnotatedTypeMirror> typeVarToTypeArgument,
             AnnotatedTypeMirror type,
             boolean typeArgumentsInferred) {

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -26,7 +26,7 @@ public class TypeVariableSubstitutor {
      * variable with a copy of type argument.
      *
      * @see #substituteTypeVariable(AnnotatedTypeMirror,
-     *     org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable)
+     *     org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable, boolean)
      * @param typeVarToTypeArgument a mapping from type variable to its type argument
      * @param type the type to substitute
      * @return a copy of type with its type variables substituted
@@ -62,7 +62,7 @@ public class TypeVariableSubstitutor {
      * variable with the given type argument.
      *
      * @see #substituteTypeVariable(AnnotatedTypeMirror,
-     *     org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable)
+     *     org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable, boolean)
      * @param typeVarToTypeArgument a mapping from type variable to its type argument
      * @param type the type to substitute
      * @return a copy of type with its type variables substituted
@@ -84,36 +84,18 @@ public class TypeVariableSubstitutor {
      *
      * @param argument the argument to declaration (this will be a value in typeParamToArg)
      * @param use the use that is being replaced
+     * @param argumentIsInferred whether {@code argument} is a type argument that the type checker
+     *     inferred (true), as opposed to one the programmer wrote explicitly at the call site
+     *     (false)
      * @return a deep copy of argument with the appropriate annotations applied
      */
     protected AnnotatedTypeMirror substituteTypeVariable(
-            AnnotatedTypeMirror argument, AnnotatedTypeVariable use) {
+            AnnotatedTypeMirror argument, AnnotatedTypeVariable use, boolean argumentIsInferred) {
         AnnotatedTypeMirror substitute = argument.deepCopy(true);
         if (!use.getAnnotationsField().isEmpty()) {
             substitute.replaceAnnotations(use.getAnnotationsField());
         }
         return substitute;
-    }
-
-    /**
-     * As {@link #substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable)}, but also
-     * indicates whether {@code argument} is a type argument that the type checker inferred (true),
-     * as opposed to one the programmer wrote explicitly at the call site (false).
-     *
-     * <p>The default implementation ignores {@code argumentIsInferred} and delegates to {@link
-     * #substituteTypeVariable(AnnotatedTypeMirror, AnnotatedTypeVariable)}, so existing overrides
-     * of that method are unaffected. A checker that needs to treat inferred and written type
-     * arguments differently during substitution should override this method instead.
-     *
-     * @param argument the argument to declaration (this will be a value in typeParamToArg)
-     * @param use the use that is being replaced
-     * @param argumentIsInferred whether {@code argument} was inferred by the type checker rather
-     *     than written explicitly by the programmer
-     * @return a deep copy of argument with the appropriate annotations applied
-     */
-    protected AnnotatedTypeMirror substituteTypeVariable(
-            AnnotatedTypeMirror argument, AnnotatedTypeVariable use, boolean argumentIsInferred) {
-        return substituteTypeVariable(argument, use);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -78,7 +78,7 @@ public class TypeVariableSubstitutor {
     public AnnotatedTypeMirror substituteWithoutCopyingTypeArguments(
             Map<TypeVariable, AnnotatedTypeMirror> typeVarToTypeArgument,
             AnnotatedTypeMirror type) {
-        return new Visitor(typeVarToTypeArgument, false).visit(type);
+        return new Visitor(typeVarToTypeArgument, false, false).visit(type);
     }
 
     /**
@@ -138,18 +138,6 @@ public class TypeVariableSubstitutor {
          * as opposed to written explicitly by the programmer at the call site.
          */
         private final boolean typeArgumentsInferred;
-
-        /**
-         * Creates the Visitor.
-         *
-         * @param typeParamToArg mapping from TypeVariable to the AnnotatedTypeMirror that will
-         *     replace it
-         * @param copyArgument whether or not a copy of type argument should be substituted
-         */
-        public Visitor(
-                Map<TypeVariable, AnnotatedTypeMirror> typeParamToArg, boolean copyArgument) {
-            this(typeParamToArg, copyArgument, false);
-        }
 
         /**
          * Creates the Visitor.

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -714,7 +714,7 @@ public class AnnotatedTypes {
      * ExpressionTree, ExecutableElement, AnnotatedExecutableType, boolean)}.
      */
     private static final TypeArguments emptyFalsePair =
-            new TypeArguments(Collections.emptyMap(), false, false);
+            new TypeArguments(Collections.emptyMap(), false, false, false);
 
     /**
      * Given a method or constructor invocation, return a mapping of the type variables to their
@@ -762,7 +762,8 @@ public class AnnotatedTypes {
                 return new TypeArguments(
                         inferenceResult.getTypeArgumentsForExpression(expr),
                         inferenceResult.isUncheckedConversion(),
-                        inferenceResult.needsDefaultedReturnType());
+                        inferenceResult.needsDefaultedReturnType(),
+                        true);
             }
             targs = memRef.getTypeArguments();
             if (memRef.getTypeArguments() == null) {
@@ -798,7 +799,7 @@ public class AnnotatedTypes {
                 // already should be a declaration.
                 typeArguments.put(typeVar.getUnderlyingType(), typeArg);
             }
-            return new TypeArguments(typeArguments, false, false);
+            return new TypeArguments(typeArguments, false, false, false);
         } else {
             if (inferTypeArgs) {
                 InferenceResult inferenceResult =
@@ -808,7 +809,8 @@ public class AnnotatedTypes {
                 return new TypeArguments(
                         inferenceResult.getTypeArgumentsForExpression(expr),
                         inferenceResult.isUncheckedConversion(),
-                        inferenceResult.needsDefaultedReturnType());
+                        inferenceResult.needsDefaultedReturnType(),
+                        true);
             } else {
                 return emptyFalsePair;
             }
@@ -830,19 +832,29 @@ public class AnnotatedTypes {
         public final boolean inferenceCrash;
 
         /**
+         * Whether {@link #typeArguments} were inferred by the type checker, as opposed to written
+         * explicitly by the programmer at the call site.
+         */
+        public final boolean typeArgumentsInferred;
+
+        /**
          * Creates a {@link TypeArguments} object.
          *
          * @param typeArguments a mapping from {@link TypeVariable} to its annotated type argument
          * @param uncheckedConversion whether unchecked conversion was needed for inference
          * @param inferenceCrash whether type argument inference crashed
+         * @param typeArgumentsInferred whether {@code typeArguments} were inferred by the type
+         *     checker, as opposed to written explicitly by the programmer at the call site
          */
         public TypeArguments(
                 Map<TypeVariable, AnnotatedTypeMirror> typeArguments,
                 boolean uncheckedConversion,
-                boolean inferenceCrash) {
+                boolean inferenceCrash,
+                boolean typeArgumentsInferred) {
             this.typeArguments = typeArguments;
             this.uncheckedConversion = uncheckedConversion;
             this.inferenceCrash = inferenceCrash;
+            this.typeArgumentsInferred = typeArgumentsInferred;
         }
     }
 


### PR DESCRIPTION
## Summary
- `AnnotatedTypes.findTypeArguments` already knows, for each method/constructor/method-reference invocation, whether its type arguments were inferred or written explicitly, but that fact was dropped before reaching `TypeVariableSubstitutor.substituteTypeVariable`.
- A downstream checker (the JSpecify reference checker) needs this distinction during substitution and previously reconstructed it with a hand-maintained instance field that had to be manually saved/restored around reentrant `methodFromUse`/`constructorFromUse` calls — a latent reentrancy bug source.
- Add a `typeArgumentsInferred` field to `AnnotatedTypes.TypeArguments`, and thread it through a new three-argument `TypeVariableSubstitutor.substitute(...)` overload into `substituteTypeVariable(argument, use, argumentIsInferred)`.
- `substituteTypeVariable(...)` is the class's actual `protected` extension point (installed indirectly via `AnnotatedTypeFactory#createTypeVariableSubstitutor`). The first commit initially added a three-arg overload alongside the existing two-arg one, with the three-arg default delegating to the two-arg method — but that leaves two overridable arities of the same hook, so a checker could override both by accident (e.g. mid-migration) and have one silently never fire, since the Visitor always calls the three-arg method and it doesn't call back into the two-arg one. The second commit collapses these into a single three-argument `substituteTypeVariable`, removing the two-argument overload entirely.
- `substitute(...)`, by contrast, is a plain public entry point nobody subclasses to override — it just drives the traversal. It keeps both arities, but the third commit marks both `final`, closing off the same class of accidental-partial-override footgun proactively (nothing currently overrides it, so this is free).
- The fourth commit collapses the internal `Visitor` helper's two constructors into one: constructors aren't virtually dispatched so this isn't the same ambiguity risk, but the two-argument constructor had exactly one caller and no subclass of `Visitor` exists anywhere, so it was unnecessary duplication.
- No code in this repo overrides `substitute`/`substituteTypeVariable`/`Visitor`, and the one known downstream consumer (JSpecify reference checker) already migrated to override only the three-arg `substituteTypeVariable`.

## Test plan
- [x] `./gradlew spotlessCheck` — clean
- [x] `./gradlew :framework:compileJava` / `:checker:compileJava` — no in-repo caller/subclass affected by any of the removed overloads or the new `final`
- [x] `./gradlew javadocDoclintAll` / `requireJavadoc` — nothing reported for the changed file
- [x] `./gradlew :framework:test` — all green
- [x] `./gradlew :checker:test --tests "*Nullness*" --tests "*Tainting*" --tests "*Override*"` — all green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>