### PR TITLE
Resolve polymorphic qualifiers on a method reference before type-arg inference

### DIFF
--- a/checker/tests/nullness/java8/methodref/PolyNullInference.java
+++ b/checker/tests/nullness/java8/methodref/PolyNullInference.java
@@ -1,0 +1,61 @@
+// Type-argument inference must resolve a polymorphic qualifier on the compile-time declaration
+// of a method reference, just as it does for the same call written as a lambda.
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
+
+import java.util.stream.Stream;
+
+public class PolyNullInference {
+
+    interface Lib {}
+
+    static @PolyNull Lib polyCast(@PolyNull Object o) {
+        throw new RuntimeException();
+    }
+
+    @PolyNull Lib polyCastBound(@PolyNull Object o) {
+        throw new RuntimeException();
+    }
+
+    void directCall(Object nonNull, @Nullable Object nble) {
+        Lib x = polyCast(nonNull);
+        @Nullable Lib y = polyCast(nble);
+    }
+
+    Stream<Lib> lambda(Stream<Object> s) {
+        return s.map(o -> polyCast(o));
+    }
+
+    Stream<Lib> staticMethodRef(Stream<Object> s) {
+        return s.map(PolyNullInference::polyCast);
+    }
+
+    Stream<Lib> boundMethodRef(Stream<Object> s) {
+        return s.map(this::polyCastBound);
+    }
+
+    Stream<Lib> explicitTypeArgument(Stream<Object> s) {
+        return s.<Lib>map(PolyNullInference::polyCast);
+    }
+
+    Stream<Lib> classCastMethodRef(Stream<Object> s) {
+        return s.map(Lib.class::cast);
+    }
+
+    Stream<@Nullable Lib> nullableStaticMethodRef(Stream<@Nullable Object> s) {
+        return s.map(PolyNullInference::polyCast);
+    }
+
+    // The polymorphic qualifier is instantiated to @Nullable, so the inferred type argument is
+    // @Nullable Lib, which is not a subtype of @NonNull Lib.  The lambda below fails the same way.
+    Stream<Lib> nullableToNonNullMethodRef(Stream<@Nullable Object> s) {
+        // :: error: (type.arguments.not.inferred)
+        return s.map(PolyNullInference::polyCast);
+    }
+
+    Stream<Lib> nullableToNonNullLambda(Stream<@Nullable Object> s) {
+        // :: error: (type.arguments.not.inferred)
+        return s.map(o -> polyCast(o));
+    }
+}

--- a/checker/tests/tainting/MemberReferenceInference.java
+++ b/checker/tests/tainting/MemberReferenceInference.java
@@ -59,4 +59,41 @@ public class MemberReferenceInference {
         // :: error: (type.arguments.not.inferred)
         String canonicalName = annotationClassNames.computeIfAbsent(clazz, PolyClass::getName);
     }
+
+    static class PolyException extends Exception {}
+
+    @FunctionalInterface
+    interface UntaintedThrowingConsumer<E extends Throwable> {
+        void accept(@Untainted String s) throws E;
+    }
+
+    @FunctionalInterface
+    interface TaintedThrowingConsumer<E extends Throwable> {
+        void accept(@Tainted String s) throws E;
+    }
+
+    static void consume(@PolyTainted String s) throws @PolyTainted PolyException {}
+
+    static <E extends Throwable> E runUntainted(UntaintedThrowingConsumer<E> job) throws E {
+        throw new AssertionError();
+    }
+
+    static <E extends Throwable> E runTainted(TaintedThrowingConsumer<E> job) throws E {
+        throw new AssertionError();
+    }
+
+    // The exception type variable E is inferred from a checked-exception constraint, which is
+    // built from the thrown types of the method reference's compile-time declaration. @PolyTainted
+    // on that thrown type resolves against the function type's @Untainted parameter to @Untainted,
+    // so E is @Untainted PolyException.
+    void polyThrows() throws PolyException {
+        @Untainted PolyException e = runUntainted(MemberReferenceInference::consume);
+    }
+
+    // Same shape, but the function type's parameter is @Tainted, so @PolyTainted resolves to
+    // @Tainted, which does not satisfy the @Untainted target of the assignment.
+    void polyThrowsMismatch() throws PolyException {
+        // :: error: (assignment.type.incompatible) :: error: (type.arguments.not.inferred)
+        @Untainted PolyException e = runTainted(MemberReferenceInference::consume);
+    }
 }

--- a/checker/tests/tainting/MemberReferenceInference.java
+++ b/checker/tests/tainting/MemberReferenceInference.java
@@ -1,3 +1,4 @@
+import org.checkerframework.checker.tainting.qual.PolyTainted;
 import org.checkerframework.checker.tainting.qual.Tainted;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
@@ -32,5 +33,30 @@ public class MemberReferenceInference {
             MyClass<? extends String> clazz,
             Map<MyClass<? extends String>, String> annotationClassNames) {
         String canonicalName = annotationClassNames.computeIfAbsent(clazz, MyClass::getName);
+    }
+
+    interface PolyClass<Q> {
+        @PolyTainted String getName(@PolyTainted PolyClass<Q> this);
+    }
+
+    // The unbound method reference PolyClass::getName is, like MyClass::getName above, the
+    // top-level poly expression for which type-argument inference runs (not a nested argument to
+    // an enclosing generic call), so this exercises
+    // InvocationTypeInference.infer(MemberReferenceTree)
+    // rather than Expression.reduceMethodRef. @PolyTainted resolves against clazz's @Untainted
+    // receiver type to @Untainted, matching the map's @Untainted value type.
+    void polyMethod(
+            @Untainted PolyClass<? extends String> clazz,
+            Map<@Untainted PolyClass<? extends String>, @Untainted String> annotationClassNames) {
+        String canonicalName = annotationClassNames.computeIfAbsent(clazz, PolyClass::getName);
+    }
+
+    // Same shape, but the receiver's declared type carries no qualifier, so @PolyTainted resolves
+    // to the default, @Tainted, which does not satisfy the map's @Untainted value type.
+    void polyMethodMismatch(
+            PolyClass<? extends String> clazz,
+            Map<PolyClass<? extends String>, @Untainted String> annotationClassNames) {
+        // :: error: (type.arguments.not.inferred)
+        String canonicalName = annotationClassNames.computeIfAbsent(clazz, PolyClass::getName);
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -159,6 +159,18 @@ so the captured type variable's upper bound is no longer computed too low.
 Previously the missing qualifier could silently suppress an
 `assignment.type.incompatible` error.
 
+Type-argument inference now resolves the polymorphic qualifiers of a method
+reference's compile-time declaration against the parameter types of the target
+function type, before it builds the inference constraints. Previously a
+polymorphic qualifier reached the solver as if it were a concrete qualifier, so
+a call whose type argument is inferred, such as `s.map(obj::polyMethod)`,
+reported a spurious `type.arguments.not.inferred` ("unsatisfiable constraint:
+`@PolyNull Lib <: @NonNull Lib`"), even though the same call written as a lambda
+(`s.map(o -> obj.polyMethod(o))`) or with an explicit type argument
+(`s.<Lib>map(obj::polyMethod)`) was accepted. This is the resolution that the
+method reference's override check already performed, but only after inference
+had finished.
+
 **Implementation details:**
 
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -169,7 +169,10 @@ reported a spurious `type.arguments.not.inferred` ("unsatisfiable constraint:
 (`s.map(o -> obj.polyMethod(o))`) or with an explicit type argument
 (`s.<Lib>map(obj::polyMethod)`) was accepted. This is the resolution that the
 method reference's override check already performed, but only after inference
-had finished.
+had finished. The same resolution now also applies when the method reference
+itself, rather than an enclosing invocation, is the expression whose type
+arguments are being inferred, such as an unbound reference passed to
+`Map.computeIfAbsent`.
 
 **Implementation details:**
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -172,7 +172,9 @@ method reference's override check already performed, but only after inference
 had finished. The same resolution now also applies when the method reference
 itself, rather than an enclosing invocation, is the expression whose type
 arguments are being inferred, such as an unbound reference passed to
-`Map.computeIfAbsent`.
+`Map.computeIfAbsent`, and when the compile-time declaration is used to build a
+checked-exception constraint, which infers the exception type argument of a
+functional interface whose method declares a generic `throws` clause.
 
 **Implementation details:**
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
@@ -203,7 +203,7 @@ public class InvocationTypeInference {
         }
 
         InvocationType compileTimeDecl =
-                context.inferenceTypeFactory.compileTimeDeclarationType(invocation);
+                context.inferenceTypeFactory.compileTimeDeclarationType(invocation, target);
         Theta map =
                 context.inferenceTypeFactory.createThetaForMethodReference(
                         invocation, compileTimeDecl, context);

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Expression.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Expression.java
@@ -196,7 +196,7 @@ public class Expression extends TypeConstraint {
         MemberReferenceTree memRef = (MemberReferenceTree) expression;
         if (TreeUtils.isExactMethodReference(memRef)) {
             InvocationType typeOfPoAppMethod =
-                    context.inferenceTypeFactory.compileTimeDeclarationType(memRef);
+                    context.inferenceTypeFactory.compileTimeDeclarationType(memRef, T);
 
             ConstraintSet constraintSet = new ConstraintSet();
             List<AbstractType> ps = T.getFunctionTypeParameterTypes();
@@ -238,7 +238,7 @@ public class Expression extends TypeConstraint {
 
         // Compile-time declaration of the member reference expression
         InvocationType compileTimeDecl =
-                context.inferenceTypeFactory.compileTimeDeclarationType(memRef);
+                context.inferenceTypeFactory.compileTimeDeclarationType(memRef, T);
         if (compileTimeDecl.isVoid()) {
             return ConstraintSet.TRUE;
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -32,6 +32,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVari
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
 import org.checkerframework.framework.type.TypeVariableSubstitutor;
+import org.checkerframework.framework.type.poly.QualifierPolymorphism;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.typeinference8.constraint.ConstraintSet;
 import org.checkerframework.framework.util.typeinference8.constraint.TypeConstraint;
@@ -783,6 +784,20 @@ public class InferenceFactory {
      * @return the compile-time declaration of the method reference
      */
     public InvocationType compileTimeDeclarationType(MemberReferenceTree memRef) {
+        return compileTimeDeclarationType(memRef, null);
+    }
+
+    /**
+     * Same as {@link #compileTimeDeclarationType(MemberReferenceTree)}, but the polymorphic
+     * qualifiers of the compile-time declaration are resolved against the function type of {@code
+     * target}, the target type of the method reference.
+     *
+     * @param memRef method reference tree
+     * @param target the target type of {@code memRef}, or null if it is not known
+     * @return the compile-time declaration of the method reference
+     */
+    public InvocationType compileTimeDeclarationType(
+            MemberReferenceTree memRef, @Nullable AbstractType target) {
         // The tree before :: is an expression or type use.
         final ExpressionTree preColonTree = memRef.getQualifierExpression();
         final MemberReferenceKind memRefKind = MemberReferenceKind.getMemberReferenceKind(memRef);
@@ -827,8 +842,53 @@ public class InferenceFactory {
                                 memRef, compileTimeDeclaration, enclosingType)
                         .executableType;
 
+        if (target != null) {
+            resolvePolyQualifiers(compileTimeType, target);
+        }
+
         return new InvocationType(
                 compileTimeType, compileTimeType.getUnderlyingType(), memRef, context);
+    }
+
+    /**
+     * Resolves the polymorphic qualifiers of {@code compileTimeType}, the type of the compile-time
+     * declaration of a method reference, using the parameter types of the function type of {@code
+     * target}, the target type of that method reference. {@code compileTimeType} is side-effected.
+     *
+     * <p>This is the same resolution that {@code BaseTypeVisitor.checkMethodReferenceAsOverride}
+     * performs on the method reference after inference. Performing it before the inference
+     * constraints are built keeps a polymorphic qualifier from reaching the solver as a concrete
+     * qualifier, which would make an otherwise-satisfiable inference problem unsatisfiable.
+     *
+     * <p>Resolution is skipped unless every parameter type of the function type is a proper type:
+     * an inference variable does not yet have a qualifier with which to instantiate a polymorphic
+     * qualifier.
+     *
+     * @param compileTimeType the type of the compile-time declaration of a method reference; it is
+     *     side-effected
+     * @param target the target type of the method reference
+     */
+    private void resolvePolyQualifiers(
+            AnnotatedExecutableType compileTimeType, AbstractType target) {
+        if (!(typeFactory instanceof GenericAnnotatedTypeFactory)) {
+            return;
+        }
+        QualifierPolymorphism poly =
+                ((GenericAnnotatedTypeFactory<?, ?, ?, ?>) typeFactory).getQualifierPolymorphism();
+        if (!poly.hasPolymorphicQualifiers(compileTimeType)) {
+            return;
+        }
+        List<AbstractType> functionTypeParams = target.getFunctionTypeParameterTypes();
+        if (functionTypeParams == null) {
+            // The target type is not a functional interface type.
+            return;
+        }
+        for (AbstractType param : functionTypeParams) {
+            if (!param.isProper()) {
+                return;
+            }
+        }
+        poly.resolve(target.getFunctionType().first, compileTimeType);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -1125,7 +1125,7 @@ public class InferenceFactory {
                     TypesUtils.findFunctionType(TreeUtils.typeOf(expression), context.env)
                             .getThrownTypes();
             thrownTypes =
-                    compileTimeDeclarationType((MemberReferenceTree) expression)
+                    compileTimeDeclarationType((MemberReferenceTree) expression, targetType)
                             .getAnnotatedType()
                             .getThrownTypes();
             if (thrownTypes.size() != thrownTypeMirrors.size()) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -783,7 +783,7 @@ public class InferenceFactory {
      * @param memRef method reference tree
      * @return the compile-time declaration of the method reference
      */
-    public InvocationType compileTimeDeclarationType(MemberReferenceTree memRef) {
+    public final InvocationType compileTimeDeclarationType(MemberReferenceTree memRef) {
         return compileTimeDeclarationType(memRef, null);
     }
 
@@ -796,7 +796,7 @@ public class InferenceFactory {
      * @param target the target type of {@code memRef}, or null if it is not known
      * @return the compile-time declaration of the method reference
      */
-    public InvocationType compileTimeDeclarationType(
+    public final InvocationType compileTimeDeclarationType(
             MemberReferenceTree memRef, @Nullable AbstractType target) {
         // The tree before :: is an expression or type use.
         final ExpressionTree preColonTree = memRef.getQualifierExpression();


### PR DESCRIPTION
## Summary

For a call whose type argument is inferred, such as `s.map(obj::polyMethod)`, the compile-time declaration of the method reference reached the inference solver with its polymorphic qualifier intact, so the solver treated `@PolyNull` as a concrete qualifier and reported a spurious `type.arguments.not.inferred` ("unsatisfiable constraint: `@PolyNull Lib <: @NonNull Lib`"). The same call written as a lambda (`s.map(o -> obj.polyMethod(o))`) or with an explicit type argument (`s.<Lib>map(obj::polyMethod)`) was accepted, because a nested method invocation has its polymorphic qualifiers resolved in `methodFromUsePreSubstitution` and an explicit type argument skips inference. A method reference's qualifiers were resolved only later, by `BaseTypeVisitor.checkMethodReferenceAsOverride`, which runs after inference.

Four commits:

1. **`InferenceFactory.compileTimeDeclarationType` now takes the target type of the method reference** and applies `QualifierPolymorphism.resolve(functionType, memberReference)` — the same resolution the override check performs — to the compile-time declaration before `Expression.reduceMethodRef` builds any constraint from it. Resolution is skipped unless every parameter type of the target function type is a proper type. New regression test: `checker/tests/nullness/java8/methodref/PolyNullInference.java`.
2. **Closes a gap the first commit's own message flagged as known and deliberately left open**: `InvocationTypeInference.infer(MemberReferenceTree)` — the entry point used when the method reference itself, rather than an enclosing invocation, is the top-level poly expression under inference (e.g. an unbound reference passed to `Map.computeIfAbsent`) — still called the one-argument overload, even though that method already computes the target type locally. Verified live and reproduced a genuine false positive before fixing it.
3. **Marks both `compileTimeDeclarationType` overloads `final`**: no code in this repo or in the one downstream consumer (JSpecify reference checker) subclasses `InferenceFactory`, and unlike `TypeVariableSubstitutor` it has no established factory-method pattern for installing a subclass, so there's no reason to leave open the possibility of a future subclass overriding only one of two arities and having the other silently bypass it.
4. **Closes the third and last call site of the one-argument overload**: `InferenceFactory.getCheckedExceptionConstraints` builds a checked-exception constraint (JLS 18.2.5) from the thrown types of a method reference's compile-time declaration, reached from `InvocationTypeInference.createC` — a second, independent route to the same compile-time declaration, alongside the `Expression` constraint route fixed in commit 1. A polymorphic qualifier on a `throws` clause type reached the solver unresolved, so inferring the exception type argument of a functional interface with a generic `throws` clause could report a spurious `type.arguments.not.inferred` plus a follow-on `assignment.type.incompatible`. This was the "known remaining gap" flagged in this PR's earlier description — that description's own framing turned out to be imprecise (the 2-arg `InvocationTypeInference.infer(ExpressionTree, AnnotatedExecutableType)` doesn't call `compileTimeDeclarationType` at all; the real gap was reached indirectly through it, via the checked-exception-constraint route), corrected here after a fresh investigation with its own verified repro.

Every commit follows the same discipline: confirm the candidate call site is actually live (temporary instrumentation against the existing test corpus, reverted before committing), construct a minimal repro, verify a genuine before/after behavior difference (not just a message change) by reverting the fix and re-testing, then add the repro as a permanent regression test.

## Test plan

- [x] Reproduced each bug standalone before fixing (temporary instrumentation/scratch files, reverted before each commit)
- [x] `./gradlew spotlessCheck` — clean
- [x] `./gradlew javadocDoclintAll` / `requireJavadoc` — nothing reported for any touched file
- [x] `./gradlew :framework:test` — all green
- [x] `./gradlew :checker:test` — **full suite, all checkers** (not just Nullness/Tainting) — all green, independently re-verified after each commit
- [x] Existing `checker/tests/tainting/MemberReferenceInference.java` and `checker/tests/nullness/java8/methodref/PolyNullInference.java` expectations unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>