### PR TITLE
BaseTypeValidator: extract wildcard-bound-equality comparison into an overridable hook

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -161,6 +161,16 @@ Previously the missing qualifier could silently suppress an
 
 **Implementation details:**
 
+`BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
+JDK-8054309 collapsed-wildcard-bound comparison to a new overridable
+`areCollapsedWildcardBoundsEqual` method, instead of inlining a bidirectional
+`isSubtypeShallowEffective` check. That bidirectional check only means "same
+qualifier" in an antisymmetric qualifier hierarchy; a checker whose hierarchy
+is not antisymmetric (e.g. an "unspecified" qualifier that is deliberately a
+mutual subtype of everything) needs a different equality test and previously
+had to override the entire ~40-line method to get one. No behavior change for
+CF's own (antisymmetric) checkers.
+
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the
 implicit `Outer<XXX>` enclosing `Super` in `class Sub extends Super`, or the

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -902,14 +902,8 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 // For example, Set<@1 ? super @2 Object> will collapse into Set<@2 Object>.
                 // So, issue a warning if the annotations on the extends bound are not the
                 // same as the annotations on the super bound.
-                if (!(atypeFactory
-                                .getTypeHierarchy()
-                                .isSubtypeShallowEffective(
-                                        wildcard.getSuperBound(), wildcard.getExtendsBound())
-                        && atypeFactory
-                                .getTypeHierarchy()
-                                .isSubtypeShallowEffective(
-                                        wildcard.getExtendsBound(), wildcard.getSuperBound()))) {
+                if (!areCollapsedWildcardBoundsEqual(
+                        wildcard.getExtendsBound(), wildcard.getSuperBound())) {
                     checker.reportError(
                             tree.getTypeArguments().get(i),
                             "type.invalid.super.wildcard",
@@ -918,6 +912,35 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 }
             }
         }
+    }
+
+    /**
+     * Returns true if, for the purposes of the JDK-8054309 collapsed-wildcard check in {@link
+     * #checkExplicitSuperBoundWildcards}, {@code extendsBound} and {@code superBound} count as the
+     * same bound.
+     *
+     * <p>The default implementation tests this via a bidirectional {@code
+     * isSubtypeShallowEffective} check, i.e. "each is a subtype of the other". That is a correct
+     * test for "same qualifier" only in an antisymmetric qualifier hierarchy, which is the case for
+     * all of CF's own type systems.
+     *
+     * <p>A checker whose qualifier hierarchy is not antisymmetric -- for example, one with an
+     * "unspecified" qualifier that is (by design) mutually a subtype of every other qualifier, so
+     * that it is compatible in both directions during subtype checks -- must override this method
+     * to compare the bounds directly (e.g. by comparing their effective annotation sets for
+     * equality) rather than relying on mutual subtyping, since mutual subtyping no longer implies
+     * equality in such a hierarchy.
+     *
+     * @param extendsBound the extends bound of the wildcard
+     * @param superBound the super bound of the wildcard
+     * @return true if the two bounds should be treated as equal for this check
+     */
+    protected boolean areCollapsedWildcardBoundsEqual(
+            AnnotatedTypeMirror extendsBound, AnnotatedTypeMirror superBound) {
+        return atypeFactory.getTypeHierarchy().isSubtypeShallowEffective(superBound, extendsBound)
+                && atypeFactory
+                        .getTypeHierarchy()
+                        .isSubtypeShallowEffective(extendsBound, superBound);
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -28,6 +28,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVari
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.AnnotatedTypeParameterBounds;
 import org.checkerframework.framework.type.QualifierHierarchy;
+import org.checkerframework.framework.type.TypeHierarchy;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.type.visitor.SimpleAnnotatedTypeScanner;
 import org.checkerframework.framework.util.AnnotatedTypes;
@@ -937,10 +938,9 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
      */
     protected boolean areCollapsedWildcardBoundsEqual(
             AnnotatedTypeMirror extendsBound, AnnotatedTypeMirror superBound) {
-        return atypeFactory.getTypeHierarchy().isSubtypeShallowEffective(superBound, extendsBound)
-                && atypeFactory
-                        .getTypeHierarchy()
-                        .isSubtypeShallowEffective(extendsBound, superBound);
+        TypeHierarchy typeHierarchy = atypeFactory.getTypeHierarchy();
+        return typeHierarchy.isSubtypeShallowEffective(superBound, extendsBound)
+                && typeHierarchy.isSubtypeShallowEffective(extendsBound, superBound);
     }
 
     @Override


### PR DESCRIPTION
## Summary

`BaseTypeValidator.checkExplicitSuperBoundWildcards` implements the JDK-8054309 special case (a wildcard's super bound collapsing with the type parameter's extends bound when javac reuses the bound instead of creating a fresh captured type variable) by testing "same qualifier" via a bidirectional `isSubtypeShallowEffective` check. That test only means "same" in an antisymmetric qualifier hierarchy — a checker with a deliberately non-antisymmetric hierarchy (e.g. an "unspecified" qualifier that is a mutual subtype of every other qualifier, so it's compatible in both directions during ordinary subtype checks) needs a different test, but currently has to override the entire ~40-line method just to swap out the final ~10-line comparison, duplicating tree-navigation and error-reporting logic that has to be kept in sync by hand with any future change to this method.

Extract the comparison into a new `protected areCollapsedWildcardBoundsEqual(AnnotatedTypeMirror, AnnotatedTypeMirror)` method with Javadoc explaining the antisymmetric-hierarchy assumption and why a subclass would override it, and call it from `checkExplicitSuperBoundWildcards` instead of the inline double-check. Pure refactor: default behavior for this repo's own (antisymmetric) checkers is unchanged.

**"Generalize the finding" check**: before opening this, I grepped the framework for other bidirectional-subtype-as-equality patterns that might have the same antisymmetric-hierarchy assumption worth extracting the same way. Found three other candidates syntactically (`JavaExpressionParseUtil` comparison-operator applicability, `DefaultTypeHierarchy` wildcard containment, `BaseTypeVisitor.testTypevarContainment`) — none are actually the same pattern: they test comparability or JLS containment (`inner` lies within `[outer.lower, outer.upper]`), not equality, so mutual subtyping is the correct relation for them regardless of antisymmetry. No sibling fix needed.

No new test checker added: the demonstrated need is the existing downstream override this hook replaces (a checker with a non-antisymmetric qualifier hierarchy), not a hypothetical one, so inventing an in-repo non-antisymmetric test checker just to exercise the hook would be speculative per this repo's conventions.

## Test plan

- [x] `./gradlew spotlessCheck` — clean
- [x] `./gradlew javadocDoclintAll` / `requireJavadoc` — the few warnings reported for `BaseTypeValidator.java` are pre-existing, at lines 299/313/364, unrelated to this change (which touches ~902-948)
- [x] `./gradlew :framework:test` — all green
- [x] `./gradlew :checker:test` — full suite, all checkers — all green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>