### PR TITLE
BaseTypeVisitor: extract parameter-override compatibility check into an overridable hook

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -161,6 +161,17 @@ Previously the missing qualifier could silently suppress an
 
 **Implementation details:**
 
+`BaseTypeVisitor.OverrideChecker.checkParameters` now delegates its per-parameter
+override compatibility check to a new overridable `isParameterOverrideValid` method,
+instead of inlining the subtype test and type-variable containment fallback. That
+default check is contravariant (the overridden parameter must be a subtype of the
+overriding parameter, the standard override rule in CF's type systems). A checker
+whose type rules require parameter <em>invariance</em> for overrides (both directions
+must be subtypes, as in JSpecify's override rules) can now override just this method
+to change the directionality, rather than duplicating the entire ~35-line
+`checkParameters` and `checkParametersMsg` loop-and-error-reporting logic. No
+behavior change for CF's own (contravariant) checkers.
+
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the
 implicit `Outer<XXX>` enclosing `Super` in `class Sub extends Super`, or the

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -4989,16 +4989,40 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             for (int i = 0; i < overriderParams.size(); ++i) {
                 AnnotatedTypeMirror capturedParam =
                         atypeFactory.applyCaptureConversion(overriddenParams.get(i));
-                boolean success = typeHierarchy.isSubtype(capturedParam, overriderParams.get(i));
-                if (!success) {
-                    success =
-                            testTypevarContainment(overriddenParams.get(i), overriderParams.get(i));
-                }
-
+                boolean success =
+                        isParameterOverrideValid(
+                                capturedParam, overriddenParams.get(i), overriderParams.get(i));
                 checkParametersMsg(success, i, overriderParams, overriddenParams);
                 result &= success;
             }
             return result;
+        }
+
+        /**
+         * Returns true if {@code overriderParam} is an acceptable override of {@code
+         * overriddenParam} (after {@code capturedOverriddenParam}, the capture-converted form of
+         * {@code overriddenParam}, has been computed).
+         *
+         * <p>The default implementation requires contravariance: {@code capturedOverriddenParam}
+         * must be a subtype of {@code overriderParam} (or pass the type-variable containment
+         * fallback). A checker that requires parameter <em>invariance</em> for overrides (both
+         * directions must be subtypes) should override this method to also require {@code
+         * typeHierarchy.isSubtype(overriderParam, capturedOverriddenParam)}.
+         *
+         * @param capturedOverriddenParam the capture-converted overridden parameter type
+         * @param overriddenParam the (uncaptured) overridden parameter type, used by the
+         *     type-variable containment fallback
+         * @param overriderParam the overriding parameter type
+         * @return true if the override is compatible for this parameter
+         */
+        protected boolean isParameterOverrideValid(
+                AnnotatedTypeMirror capturedOverriddenParam,
+                AnnotatedTypeMirror overriddenParam,
+                AnnotatedTypeMirror overriderParam) {
+            if (typeHierarchy.isSubtype(capturedOverriddenParam, overriderParam)) {
+                return true;
+            }
+            return testTypevarContainment(overriddenParam, overriderParam);
         }
 
         private void checkParametersMsg(

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -5004,10 +5004,16 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * {@code overriddenParam}, has been computed).
          *
          * <p>The default implementation requires contravariance: {@code capturedOverriddenParam}
-         * must be a subtype of {@code overriderParam} (or pass the type-variable containment
-         * fallback). A checker that requires parameter <em>invariance</em> for overrides (both
-         * directions must be subtypes) should override this method to also require {@code
-         * typeHierarchy.isSubtype(overriderParam, capturedOverriddenParam)}.
+         * must be a subtype of {@code overriderParam}, or -- as a fallback for corresponding type
+         * variables declared by the overriding and overridden methods themselves, where a direct
+         * subtype check can fail even though the override is valid -- {@code overriddenParam} must
+         * be {@linkplain #testTypevarContainment(AnnotatedTypeMirror, AnnotatedTypeMirror)
+         * contained by} {@code overriderParam}. A checker that requires parameter
+         * <em>invariance</em> for overrides (both directions must be subtypes) should override this
+         * method to also require the reverse: {@code typeHierarchy.isSubtype(overriderParam,
+         * capturedOverriddenParam)}, falling back to {@code testTypevarContainment(overriderParam,
+         * overriddenParam)} for the same reason the default implementation does in the forward
+         * direction.
          *
          * @param capturedOverriddenParam the capture-converted overridden parameter type
          * @param overriddenParam the (uncaptured) overridden parameter type, used by the

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -5025,6 +5025,17 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             return testTypevarContainment(overriddenParam, overriderParam);
         }
 
+        /**
+         * Prints a debugging message (if {@code showchecks} is set) and, if {@code success} is
+         * false, reports an {@code override.param.invalid} or {@code methodref.param.invalid} error
+         * for the parameter at {@code index}.
+         *
+         * @param success whether the parameter at {@code index} is a valid override
+         * @param index the index, into {@code overriderParams} and {@code overriddenParams}, of the
+         *     parameter to report on
+         * @param overriderParams the parameter types of the overriding method
+         * @param overriddenParams the parameter types of the overridden method
+         */
         private void checkParametersMsg(
                 boolean success,
                 int index,


### PR DESCRIPTION
## Summary

`OverrideChecker.checkParameters()` implements override-checking's standard contravariant rule for parameter types (a loop that applies capture conversion, tests subtype compatibility with a type-variable-containment fallback, and reports errors via `checkParametersMsg`). A downstream checker (JSpecify's reference checker) needs parameter *invariance* for overrides (both directions must be subtypes: a parameter may be neither widened nor narrowed), but `checkParameters()`/`checkParametersMsg()` are `private`, so it currently has to override the entire ~35-line method and reimplement the traversal, tree-lookup, and error-reporting by hand just to swap the directionality of one `isSubtype` call — duplicating logic that has to be kept in sync with any future change to `override.param.invalid`'s message format.

Extract the per-parameter compatibility decision into a new `protected isParameterOverrideValid(capturedOverriddenParam, overriddenParam, overriderParam)` method with Javadoc explaining why a checker with different override rules would override it, and call it from `checkParameters()` instead of the inline check. Pure refactor: default behavior is unchanged. `checkParameters()`/`checkParametersMsg()` stay `private`, per the same reasoning as #1941: widening them to `protected` would be an extension point with no demonstrated need, since the new hook already covers the actual use case.

**Verified the hook design against the real, currently-committed consumer code**, not just the task brief's description: `jspecify-reference-checker`'s `InvariantParameterOverrideChecker` (`NullSpecVisitor.java`) can't use this hook yet (it predates this PR), so it still reimplements the whole loop today. Comparing that real implementation against this hook's signature confirms the fit: `capturedOverriddenParam` is already capture-converted for the hook, which the existing code redoes itself; and the `isMethodReference` guard their comment requires ("Skipped for method references: JSpecify's invariance rule is about a method's own declared parameter types, and a method reference has none of its own to compare") is still reachable from inside an override of the new hook, since `isMethodReference` is an inherited field on `OverrideChecker`. No design change needed.

No new test checker added: the demonstrated need is the existing downstream override this hook would replace, not a hypothetical one.

## Test plan

- [x] `./gradlew spotlessCheck` — clean
- [x] `./gradlew javadocDoclintAll` / `requireJavadoc` — the two warnings reported near this change (`checkParameters`, `checkParametersMsg`) are pre-existing on master, for private methods this PR doesn't modify (only relocates relative to the new method)
- [x] `./gradlew :framework:test --tests "*H1H2*"` and `:checker:test --tests "*Override*" --tests "*Nullness*"` — all green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>