### PR TITLE
Summarize intersection bounds uniformly, whether explicit or defaulted

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -124,32 +124,22 @@ When the bounds of an intersection type (for example, the bound
 `<T extends @NonNull Object & @Nullable Serializable>`) carry conflicting
 qualifiers in the same hierarchy, the intersection's qualifier for that
 hierarchy is the qualifier of the first bound in source order, and every other
-explicit bound qualifier gets an `explicit.annotation.ignored` warning. That
-summary is then written back onto every bound (homogenization), so all bounds of
-the intersection carry the same qualifier per hierarchy. Homogenization is sound
-for value-property qualifiers and can be strictly more precise than keeping each
-bound's own qualifier, because a hierarchy that only one bound constrains is
-propagated to the others rather than defaulted away.
-First-bound-wins holds uniformly whether the first bound is annotated explicitly
-or by defaulting: for `<T extends Object & @Nullable Serializable>` the first
-bound `Object` defaults to `@NonNull` (because the `extends` clause is written),
-so the summary is `@NonNull` and the second bound's `@Nullable` is ignored,
-exactly as if the first bound had been written `@NonNull Object`. This result is
-deterministic for a given compilation, but it depends on the source order of the
-bounds. A checker that wants an order-independent summary can override
+bound's differing qualifier gets an `explicit.annotation.ignored` warning if
+it was written explicitly. That summary is then written back onto every bound
+(homogenization), so all bounds of the intersection carry the same qualifier
+per hierarchy. Homogenization is sound for value-property qualifiers and can
+be strictly more precise than keeping each bound's own qualifier, because a
+hierarchy that only one bound constrains is propagated to the others rather
+than defaulted away. First-bound-wins holds uniformly no matter how the first
+bound's qualifier arose: written explicitly, filled by an ordinary location
+default, or filled by a type-based default such as `@DefaultQualifierForUse`.
+This result is deterministic for a given compilation, but it depends on the
+source order of the bounds. A checker that wants an order-independent
+summary can override
 `AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` to
-return, for example, the greatest lower bound.
-
-Correction to the previous paragraph: first-bound-wins now holds uniformly
-whether the first bound's qualifier comes from an explicit annotation, a
-location default, or a type-based default (e.g. `@DefaultQualifierForUse`),
-and the combining hook is now consulted uniformly too, in every hierarchy
-that any bound constrains, explicitly or by defaulting &mdash; both were true
-only for two explicitly annotated bounds when this paragraph was first
-written. See the "Implementation details" entry below for what changed and
-why the `<T extends Object & @Nullable Serializable>` example above was
-previously handled inconsistently with an equivalent example whose bound
-default is type-based rather than location-based.
+return, for example, the greatest lower bound; the hook is consulted whenever
+any two bounds' qualifiers conflict in a hierarchy, whether either qualifier
+is written or defaulted.
 
 Added a new lint option, `-Alint=monotonicNonNullOnStatic`, under which the
 Nullness Checker issues a `monotonic.on.static` warning when `@MonotonicNonNull`
@@ -189,79 +179,31 @@ functional interface whose method declares a generic `throws` clause.
 
 **Implementation details:**
 
-Corrects an inaccuracy in #1875, which introduced
-`AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy` and
-claimed that first-bound-wins "holds uniformly whether the first bound is
-annotated explicitly or by defaulting" and that overriding the hook gives an
-order-independent summary. Neither was true: the hook was consulted only when
-two bounds were both explicitly annotated in a hierarchy, so overriding it had
-no effect whenever one side's qualifier came from defaulting, including
-#1875's own `<T extends Object & @Nullable Serializable>` motivating example.
-That gap is now closed for a type variable's own intersection upper bound
-(not for an intersection cast target; see below).
-
-The fix is in `QualifierDefaults`, not in `AnnotatedIntersectionType`.
-`AnnotatedIntersectionType` now has a single summarizing method,
-`summarizeBounds`, which reads each bound's qualifier via
-`getAnnotationInHierarchy` and folds the combining hook over them &mdash;
-uniformly, whether a bound's qualifier is explicit or defaulted, since this
-method does not care which. What differs between its callers is only *when*
-in the pipeline they call it, which determines what `getAnnotationInHierarchy`
-finds: `QualifierDefaults` now handles a type variable's own intersection
-upper bound specially, letting each bound be defaulted independently first
-(in its own right, so a type-based default such as `@DefaultQualifierForUse`
-applies correctly) and only then calling `summarizeBounds`, so the combining
-hook sees every bound's real qualifier. `AbstractViewpointAdapter` calls it
-on already fully-defaulted bound copies, for the same reason. An intersection
-cast target's construction calls it before any defaulting has run, so only
-bounds' explicit annotations are found; a hierarchy no bound constrains
-explicitly is simply left out of the summary, because a cast target's
+`AnnotatedIntersectionType.summarizeBounds` computes the summary described
+above, reading each bound's qualifier &mdash; explicit or defaulted,
+uniformly &mdash; and folding
+`AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` over
+conflicts. For a type variable's own intersection upper bound,
+`QualifierDefaults` lets each bound be defaulted independently before
+calling it, so the combining hook sees every bound's real qualifier
+regardless of whether it came from a location default or a type-based one
+such as `@DefaultQualifierForUse`. For an intersection cast target, whose
 remaining hierarchies are instead filled from the cast operand by
-`PropagationTreeAnnotator#visitTypeCast`, a mechanism `QualifierDefaults`
-does not participate in.
-(There used to be two methods here, `copyIntersectionBoundAnnotations` and
-`summarizeDefaultedBounds`, differing only in which of `getAnnotationsField`
-or `getAnnotationInHierarchy` they read bounds through &mdash; a distinction
-that stopped mattering once every caller either ran after defaulting or
-plainly needed the explicit-only behavior on its own terms, not because the
-two methods computed anything different. They are merged into the one
-method described above.)
-
-This also fixes a latent inaccuracy in #1875 that was independent of the
-combining hook: even under the default (first-bound-wins) hook, an
-intersection whose first bound relies on a type-based default now correctly
-summarizes to that default, rather than to the intersection's own location
-default as before. This is a user-visible behavior change; see
-`framework/tests/lubglb/IntersectionBoundDefaulting.java`'s `callTypeBased`
-test.
+`PropagationTreeAnnotator#visitTypeCast`, it is called before defaulting and
+sees only explicit annotations.
 
 Added `IntersectionGlbChecker`/`IntersectionGlbAnnotatedTypeFactory`, a test
-checker that overrides `combineIntersectionBoundAnnotationsInHierarchy` to
-compute the greatest lower bound, and extended
-`framework/tests/intersectionglb/IntersectionBoundCombining.java` to test it,
-including bare-first-bound and bare-later-bound cases (the latter with a
-type-based default) and an F-bounded intersection regression test (see
-below). This also demonstrates that a checker whose qualifier semantics are
-per-component (e.g. JSpecify, where `@Nullable Object & Lib` is
-null-exclusive because it IS-A the non-null `Lib`) can reach for a
-GLB-combine override rather than a separate per-bound API: for any target, if
-some bound's own qualifier is a subtype of it, the greatest lower bound of
-the bounds' qualifiers is a subtype of it too, so `getBounds()` with a
-GLB-combine override answers the per-component question on its own.
-
-An earlier version of this fix computed a bare bound's own default via a
-synthetic, standalone defaulting call issued from inside
-`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` during type
-construction, rather than changing where in the pipeline the summary is
-computed. That version was reverted before landing: the synthetic call could
-re-enter type construction for the same element and crash with
-`StackOverflowError` on an F-bounded type parameter such as `<T extends
-Recursive<T> & @Q Cloneable>`, for every checker, not just one overriding the
-hook, and was not issued at the bound's real defaulting location, so it could
-compute the wrong default even where it didn't crash. The current fix avoids
-both problems by letting each bound go through the ordinary, correctly
-located defaulting pass in its own right, instead of predicting what that
-pass would compute from inside type construction.
+checker that overrides the combining hook to compute the greatest lower
+bound, and extended `IntersectionBoundCombining.java` and
+`IntersectionBoundDefaulting.java` (in `framework/tests/intersectionglb/`
+and `framework/tests/lubglb/`) to test it: bare bounds with location-based
+and type-based defaults, order independence across 3+ bounds, and F-bounded
+self-reference. A checker whose qualifier semantics are per-component (e.g.
+JSpecify, where `@Nullable Object & Lib` is null-exclusive because it IS-A
+the non-null `Lib`) can reach for a GLB-combine override rather than a
+separate per-bound API: for any target, if some bound's own qualifier is a
+subtype of it, the greatest lower bound of the bounds' qualifiers is a
+subtype of it too.
 
 `BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
 JDK-8054309 collapsed-wildcard-bound comparison to a new overridable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -194,11 +194,12 @@ sees only explicit annotations.
 
 Added `IntersectionGlbChecker`/`IntersectionGlbAnnotatedTypeFactory`, a test
 checker that overrides the combining hook to compute the greatest lower
-bound, and extended `IntersectionBoundCombining.java` and
-`IntersectionBoundDefaulting.java` (in `framework/tests/intersectionglb/`
-and `framework/tests/lubglb/`) to test it: bare bounds with location-based
-and type-based defaults, order independence across 3+ bounds, and F-bounded
-self-reference. A checker whose qualifier semantics are per-component (e.g.
+bound, and extended two test files to test it &mdash;
+`framework/tests/intersectionglb/IntersectionBoundCombining.java` and
+`framework/tests/lubglb/IntersectionBoundDefaulting.java` &mdash; with bare
+bounds under location-based and type-based defaults, order independence
+across 3+ bounds, and F-bounded self-reference. A checker whose qualifier
+semantics are per-component (e.g.
 JSpecify, where `@Nullable Object & Lib` is null-exclusive because it IS-A
 the non-null `Lib`) can reach for a GLB-combine override rather than a
 separate per-bound API: for any target, if some bound's own qualifier is a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,7 +138,9 @@ exactly as if the first bound had been written `@NonNull Object`. This result is
 deterministic for a given compilation, but it depends on the source order of the
 bounds. A checker that wants an order-independent summary can override
 `AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` to return,
-for example, the greatest lower bound.
+for example, the greatest lower bound. That hook is consulted in every hierarchy
+that some bound constrains explicitly, whether the other bounds' qualifiers in
+that hierarchy are written on them or are their own defaults.
 
 Added a new lint option, `-Alint=monotonicNonNullOnStatic`, under which the
 Nullness Checker issues a `monotonic.on.static` warning when `@MonotonicNonNull`
@@ -177,6 +179,30 @@ checked-exception constraint, which infers the exception type argument of a
 functional interface whose method declares a generic `throws` clause.
 
 **Implementation details:**
+
+`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` now lets a bound
+left bare in a hierarchy that another bound constrains explicitly contribute
+its own default to the summary, passing that default to
+`AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy` exactly
+like a qualifier written on the bound. Previously that hook was called only
+when two bounds were both explicitly annotated in one hierarchy, so a checker
+overriding it had no say wherever one side's qualifier was a bound's default:
+for `<T extends Object & @Nullable Cloneable>` the summary was the first
+bound's default whatever the hook returned, and the hook was not called at
+all. Under the default (first-bound-wins) hook nothing changes, because a
+hierarchy whose summary is still the first bound's own default is deferred to
+the defaulting pass exactly as before.
+
+A checker whose qualifier semantics are per-component (e.g. JSpecify, where
+`@Nullable Object & Lib` is null-exclusive because it IS-A the non-null
+`Lib`) should override `combineIntersectionBoundAnnotationsInHierarchy` to
+compute the greatest lower bound of the two qualifiers, now that a bound's
+own default takes part in combining too. A GLB summary is sound and at least
+as precise as checking each bound's own qualifier individually: for any
+target, if some bound's own qualifier is a subtype of it, the greatest lower
+bound of all the bounds' qualifiers is a subtype of it as well, so
+`getBounds()` alone answers the per-component question; no separate
+per-bound view is needed. See `framework/tests/intersectionglb`.
 
 `BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
 JDK-8054309 collapsed-wildcard-bound comparison to a new overridable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,9 +138,11 @@ exactly as if the first bound had been written `@NonNull Object`. This result is
 deterministic for a given compilation, but it depends on the source order of the
 bounds. A checker that wants an order-independent summary can override
 `AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` to return,
-for example, the greatest lower bound. That hook is consulted in every hierarchy
-that some bound constrains explicitly, whether the other bounds' qualifiers in
-that hierarchy are written on them or are their own defaults.
+for example, the greatest lower bound (see #1943 for a correction to this
+paragraph: at this point the hook was consulted only when two bounds were both
+explicitly annotated in a hierarchy, not when one side's qualifier came from
+defaulting, so overriding it did not yet give an order-independent summary for
+the `<T extends Object & @Nullable Serializable>` example above).
 
 Added a new lint option, `-Alint=monotonicNonNullOnStatic`, under which the
 Nullness Checker issues a `monotonic.on.static` warning when `@MonotonicNonNull`
@@ -192,6 +194,15 @@ bound's default whatever the hook returned, and the hook was not called at
 all. Under the default (first-bound-wins) hook nothing changes, because a
 hierarchy whose summary is still the first bound's own default is deferred to
 the defaulting pass exactly as before.
+
+This corrects an inaccuracy in #1875, which introduced the hook and claimed
+that first-bound-wins "holds uniformly whether the first bound is annotated
+explicitly or by defaulting" and that overriding the hook gives an
+order-independent summary. Both claims held only for two explicitly annotated
+bounds in conflict; whenever one side's qualifier came from defaulting, the
+hook was structurally unreachable, so overriding it had no effect on that
+case, including #1875's own `<T extends Object & @Nullable Serializable>`
+motivating example.
 
 A checker whose qualifier semantics are per-component (e.g. JSpecify, where
 `@Nullable Object & Lib` is null-exclusive because it IS-A the non-null

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -180,8 +180,8 @@ functional interface whose method declares a generic `throws` clause.
 **Implementation details:**
 
 `AnnotatedIntersectionType.summarizeBounds` computes the summary described
-above, reading each bound's qualifier &mdash; explicit or defaulted,
-uniformly &mdash; and folding
+above, reading each bound's qualifier, explicit or defaulted, uniformly,
+and folding
 `AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` over
 conflicts. For a type variable's own intersection upper bound,
 `QualifierDefaults` lets each bound be defaulted independently before
@@ -194,12 +194,12 @@ sees only explicit annotations.
 
 Added `IntersectionGlbChecker`/`IntersectionGlbAnnotatedTypeFactory`, a test
 checker that overrides the combining hook to compute the greatest lower
-bound, and extended two test files to test it &mdash;
+bound, and extended two test files to test it, with bare bounds under
+location-based and type-based defaults, order independence across 3+
+bounds, and F-bounded self-reference:
 `framework/tests/intersectionglb/IntersectionBoundCombining.java` and
-`framework/tests/lubglb/IntersectionBoundDefaulting.java` &mdash; with bare
-bounds under location-based and type-based defaults, order independence
-across 3+ bounds, and F-bounded self-reference. A checker whose qualifier
-semantics are per-component (e.g.
+`framework/tests/lubglb/IntersectionBoundDefaulting.java`. A checker whose
+qualifier semantics are per-component (e.g.
 JSpecify, where `@Nullable Object & Lib` is null-exclusive because it IS-A
 the non-null `Lib`) can reach for a GLB-combine override rather than a
 separate per-bound API: for any target, if some bound's own qualifier is a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -137,15 +137,19 @@ so the summary is `@NonNull` and the second bound's `@Nullable` is ignored,
 exactly as if the first bound had been written `@NonNull Object`. This result is
 deterministic for a given compilation, but it depends on the source order of the
 bounds. A checker that wants an order-independent summary can override
-`AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` to return,
-for example, the greatest lower bound. Correction: the hook is consulted only
-when two bounds are both explicitly annotated in a hierarchy, not when one
-side's qualifier comes from defaulting, so overriding it does not give an
-order-independent summary for the `<T extends Object & @Nullable Serializable>`
-example above &mdash; that case still defers the hierarchy to the ordinary
-defaulting pass, regardless of what the hook returns. This is a known,
-currently open limitation; see
-`AnnotatedIntersectionType#copyIntersectionBoundAnnotations`.
+`AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` to
+return, for example, the greatest lower bound.
+
+Correction to the previous paragraph: first-bound-wins now holds uniformly
+whether the first bound's qualifier comes from an explicit annotation, a
+location default, or a type-based default (e.g. `@DefaultQualifierForUse`),
+and the combining hook is now consulted uniformly too, in every hierarchy
+that any bound constrains, explicitly or by defaulting &mdash; both were true
+only for two explicitly annotated bounds when this paragraph was first
+written. See the "Implementation details" entry below for what changed and
+why the `<T extends Object & @Nullable Serializable>` example above was
+previously handled inconsistently with an equivalent example whose bound
+default is type-based rather than location-based.
 
 Added a new lint option, `-Alint=monotonicNonNullOnStatic`, under which the
 Nullness Checker issues a `monotonic.on.static` warning when `@MonotonicNonNull`
@@ -189,41 +193,73 @@ Corrects an inaccuracy in #1875, which introduced
 `AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy` and
 claimed that first-bound-wins "holds uniformly whether the first bound is
 annotated explicitly or by defaulting" and that overriding the hook gives an
-order-independent summary. Both claims hold only for two explicitly annotated
-bounds in conflict; whenever one side's qualifier comes from defaulting, the
-hook is not called at all, so overriding it currently has no effect on that
-case, including #1875's own `<T extends Object & @Nullable Serializable>`
-motivating example. Making a bare bound's own default take part in combining
-was attempted and reverted (see below); the gap remains open.
+order-independent summary. Neither was true: the hook was consulted only when
+two bounds were both explicitly annotated in a hierarchy, so overriding it had
+no effect whenever one side's qualifier came from defaulting, including
+#1875's own `<T extends Object & @Nullable Serializable>` motivating example.
+That gap is now closed for a type variable's own intersection upper bound
+(not for an intersection cast target; see below).
+
+The fix is in `QualifierDefaults`, not in `AnnotatedIntersectionType`.
+Previously, the summary was computed once, early, during type construction
+(`AnnotatedIntersectionType.copyIntersectionBoundAnnotations`), from the
+bounds' explicit annotations only, since defaulting had not run yet at that
+point in the pipeline; a hierarchy no bound constrained explicitly was left
+for the ordinary defaulting pass to fill using the *intersection's own*
+defaulting location (the type variable's upper bound) &mdash; not, as #1875
+claimed, "the first bound's own default": those coincide only when the first
+bound's own default is itself a location default, not a type-based one such
+as `@DefaultQualifierForUse`. `QualifierDefaults` now handles a type
+variable's own intersection upper bound specially: it lets each bound be
+defaulted independently first (in its own right, so a type-based default
+applies correctly), then summarizes the bounds' real qualifiers &mdash;
+explicit or defaulted, uniformly &mdash; via the new
+`AnnotatedIntersectionType.summarizeDefaultedBounds`, which folds the
+combining hook over them the same way `copyIntersectionBoundAnnotations`
+already did for explicit annotations.
+`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` is accordingly no
+longer called for a type variable's own upper bound (its early,
+explicit-only summary would otherwise homogenize prematurely and pre-empt a
+bare bound's own default, including a location-based one on a later bound
+that a naive fix might not consider); it is still called, unchanged, for an
+intersection cast target and for `AbstractViewpointAdapter`'s already-defaulted
+bound copies, two positions this change does not affect.
+
+This also fixes a latent inaccuracy in #1875 that was independent of the
+combining hook: even under the default (first-bound-wins) hook, an
+intersection whose first bound relies on a type-based default now correctly
+summarizes to that default, rather than to the intersection's own location
+default as before. This is a user-visible behavior change; see
+`framework/tests/lubglb/IntersectionBoundDefaulting.java`'s `callTypeBased`
+test.
 
 Added `IntersectionGlbChecker`/`IntersectionGlbAnnotatedTypeFactory`, a test
 checker that overrides `combineIntersectionBoundAnnotationsInHierarchy` to
-compute the greatest lower bound of two explicitly conflicting bounds, and
-`framework/tests/intersectionglb/IntersectionBoundCombining.java` to test it.
-This demonstrates that a checker whose qualifier semantics are per-component
-(e.g. JSpecify, where `@Nullable Object & Lib` is null-exclusive because it
-IS-A the non-null `Lib`) should reach for a GLB-combine override rather than a
-separate per-bound API: for any target, if some bound's own qualifier is a
-subtype of it, the greatest lower bound of the bounds' qualifiers is a
-subtype of it too, so `getBounds()` with a GLB-combine override already
-answers the per-component question, at least for bounds that are explicitly
-annotated.
+compute the greatest lower bound, and extended
+`framework/tests/intersectionglb/IntersectionBoundCombining.java` to test it,
+including bare-first-bound and bare-later-bound cases (the latter with a
+type-based default) and an F-bounded intersection regression test (see
+below). This also demonstrates that a checker whose qualifier semantics are
+per-component (e.g. JSpecify, where `@Nullable Object & Lib` is
+null-exclusive because it IS-A the non-null `Lib`) can reach for a
+GLB-combine override rather than a separate per-bound API: for any target, if
+some bound's own qualifier is a subtype of it, the greatest lower bound of
+the bounds' qualifiers is a subtype of it too, so `getBounds()` with a
+GLB-combine override answers the per-component question on its own.
 
-An earlier version of this change made
-`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` compute a bare
-bound's own default and feed it into the combining hook, so that a checker
-overriding the hook would have a say even when one side's qualifier came from
-defaulting rather than being written. That version is **reverted**: computing
-the default required a synthetic, standalone defaulting call from inside type
-construction, which (a) can re-enter type construction for the same element
-and crash with `StackOverflowError` on an F-bounded type parameter such as
-`<T extends Recursive<T> & @Q Cloneable>`, for every checker, not just one
-overriding the hook, and (b) is not issued at the bound's real location
-(`UPPER_BOUND`), so it can compute the wrong default. Closing this gap
-correctly needs the summary to be computed from the bounds' real qualifiers
-after the ordinary defaulting pass has run on them, which is a larger,
-separately-scoped change to the type-construction/defaulting pipeline
-ordering, not attempted here.
+An earlier version of this fix computed a bare bound's own default via a
+synthetic, standalone defaulting call issued from inside
+`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` during type
+construction, rather than changing where in the pipeline the summary is
+computed. That version was reverted before landing: the synthetic call could
+re-enter type construction for the same element and crash with
+`StackOverflowError` on an F-bounded type parameter such as `<T extends
+Recursive<T> & @Q Cloneable>`, for every checker, not just one overriding the
+hook, and was not issued at the bound's real defaulting location, so it could
+compute the wrong default even where it didn't crash. The current fix avoids
+both problems by letting each bound go through the ordinary, correctly
+located defaulting pass in its own right, instead of predicting what that
+pass would compute from inside type construction.
 
 `BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
 JDK-8054309 collapsed-wildcard-bound comparison to a new overridable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -201,29 +201,31 @@ That gap is now closed for a type variable's own intersection upper bound
 (not for an intersection cast target; see below).
 
 The fix is in `QualifierDefaults`, not in `AnnotatedIntersectionType`.
-Previously, the summary was computed once, early, during type construction
-(`AnnotatedIntersectionType.copyIntersectionBoundAnnotations`), from the
-bounds' explicit annotations only, since defaulting had not run yet at that
-point in the pipeline; a hierarchy no bound constrained explicitly was left
-for the ordinary defaulting pass to fill using the *intersection's own*
-defaulting location (the type variable's upper bound) &mdash; not, as #1875
-claimed, "the first bound's own default": those coincide only when the first
-bound's own default is itself a location default, not a type-based one such
-as `@DefaultQualifierForUse`. `QualifierDefaults` now handles a type
-variable's own intersection upper bound specially: it lets each bound be
-defaulted independently first (in its own right, so a type-based default
-applies correctly), then summarizes the bounds' real qualifiers &mdash;
-explicit or defaulted, uniformly &mdash; via the new
-`AnnotatedIntersectionType.summarizeDefaultedBounds`, which folds the
-combining hook over them the same way `copyIntersectionBoundAnnotations`
-already did for explicit annotations.
-`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` is accordingly no
-longer called for a type variable's own upper bound (its early,
-explicit-only summary would otherwise homogenize prematurely and pre-empt a
-bare bound's own default, including a location-based one on a later bound
-that a naive fix might not consider); it is still called, unchanged, for an
-intersection cast target and for `AbstractViewpointAdapter`'s already-defaulted
-bound copies, two positions this change does not affect.
+`AnnotatedIntersectionType` now has a single summarizing method,
+`summarizeBounds`, which reads each bound's qualifier via
+`getAnnotationInHierarchy` and folds the combining hook over them &mdash;
+uniformly, whether a bound's qualifier is explicit or defaulted, since this
+method does not care which. What differs between its callers is only *when*
+in the pipeline they call it, which determines what `getAnnotationInHierarchy`
+finds: `QualifierDefaults` now handles a type variable's own intersection
+upper bound specially, letting each bound be defaulted independently first
+(in its own right, so a type-based default such as `@DefaultQualifierForUse`
+applies correctly) and only then calling `summarizeBounds`, so the combining
+hook sees every bound's real qualifier. `AbstractViewpointAdapter` calls it
+on already fully-defaulted bound copies, for the same reason. An intersection
+cast target's construction calls it before any defaulting has run, so only
+bounds' explicit annotations are found; a hierarchy no bound constrains
+explicitly is simply left out of the summary, because a cast target's
+remaining hierarchies are instead filled from the cast operand by
+`PropagationTreeAnnotator#visitTypeCast`, a mechanism `QualifierDefaults`
+does not participate in.
+(There used to be two methods here, `copyIntersectionBoundAnnotations` and
+`summarizeDefaultedBounds`, differing only in which of `getAnnotationsField`
+or `getAnnotationInHierarchy` they read bounds through &mdash; a distinction
+that stopped mattering once every caller either ran after defaulting or
+plainly needed the explicit-only behavior on its own terms, not because the
+two methods computed anything different. They are merged into the one
+method described above.)
 
 This also fixes a latent inaccuracy in #1875 that was independent of the
 combining hook: even under the default (first-bound-wins) hook, an

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,11 +138,14 @@ exactly as if the first bound had been written `@NonNull Object`. This result is
 deterministic for a given compilation, but it depends on the source order of the
 bounds. A checker that wants an order-independent summary can override
 `AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy` to return,
-for example, the greatest lower bound (see #1943 for a correction to this
-paragraph: at this point the hook was consulted only when two bounds were both
-explicitly annotated in a hierarchy, not when one side's qualifier came from
-defaulting, so overriding it did not yet give an order-independent summary for
-the `<T extends Object & @Nullable Serializable>` example above).
+for example, the greatest lower bound. Correction: the hook is consulted only
+when two bounds are both explicitly annotated in a hierarchy, not when one
+side's qualifier comes from defaulting, so overriding it does not give an
+order-independent summary for the `<T extends Object & @Nullable Serializable>`
+example above &mdash; that case still defers the hierarchy to the ordinary
+defaulting pass, regardless of what the hook returns. This is a known,
+currently open limitation; see
+`AnnotatedIntersectionType#copyIntersectionBoundAnnotations`.
 
 Added a new lint option, `-Alint=monotonicNonNullOnStatic`, under which the
 Nullness Checker issues a `monotonic.on.static` warning when `@MonotonicNonNull`
@@ -182,38 +185,45 @@ functional interface whose method declares a generic `throws` clause.
 
 **Implementation details:**
 
-`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` now lets a bound
-left bare in a hierarchy that another bound constrains explicitly contribute
-its own default to the summary, passing that default to
-`AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy` exactly
-like a qualifier written on the bound. Previously that hook was called only
-when two bounds were both explicitly annotated in one hierarchy, so a checker
-overriding it had no say wherever one side's qualifier was a bound's default:
-for `<T extends Object & @Nullable Cloneable>` the summary was the first
-bound's default whatever the hook returned, and the hook was not called at
-all. Under the default (first-bound-wins) hook nothing changes, because a
-hierarchy whose summary is still the first bound's own default is deferred to
-the defaulting pass exactly as before.
-
-This corrects an inaccuracy in #1875, which introduced the hook and claimed
-that first-bound-wins "holds uniformly whether the first bound is annotated
-explicitly or by defaulting" and that overriding the hook gives an
-order-independent summary. Both claims held only for two explicitly annotated
-bounds in conflict; whenever one side's qualifier came from defaulting, the
-hook was structurally unreachable, so overriding it had no effect on that
+Corrects an inaccuracy in #1875, which introduced
+`AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy` and
+claimed that first-bound-wins "holds uniformly whether the first bound is
+annotated explicitly or by defaulting" and that overriding the hook gives an
+order-independent summary. Both claims hold only for two explicitly annotated
+bounds in conflict; whenever one side's qualifier comes from defaulting, the
+hook is not called at all, so overriding it currently has no effect on that
 case, including #1875's own `<T extends Object & @Nullable Serializable>`
-motivating example.
+motivating example. Making a bare bound's own default take part in combining
+was attempted and reverted (see below); the gap remains open.
 
-A checker whose qualifier semantics are per-component (e.g. JSpecify, where
-`@Nullable Object & Lib` is null-exclusive because it IS-A the non-null
-`Lib`) should override `combineIntersectionBoundAnnotationsInHierarchy` to
-compute the greatest lower bound of the two qualifiers, now that a bound's
-own default takes part in combining too. A GLB summary is sound and at least
-as precise as checking each bound's own qualifier individually: for any
-target, if some bound's own qualifier is a subtype of it, the greatest lower
-bound of all the bounds' qualifiers is a subtype of it as well, so
-`getBounds()` alone answers the per-component question; no separate
-per-bound view is needed. See `framework/tests/intersectionglb`.
+Added `IntersectionGlbChecker`/`IntersectionGlbAnnotatedTypeFactory`, a test
+checker that overrides `combineIntersectionBoundAnnotationsInHierarchy` to
+compute the greatest lower bound of two explicitly conflicting bounds, and
+`framework/tests/intersectionglb/IntersectionBoundCombining.java` to test it.
+This demonstrates that a checker whose qualifier semantics are per-component
+(e.g. JSpecify, where `@Nullable Object & Lib` is null-exclusive because it
+IS-A the non-null `Lib`) should reach for a GLB-combine override rather than a
+separate per-bound API: for any target, if some bound's own qualifier is a
+subtype of it, the greatest lower bound of the bounds' qualifiers is a
+subtype of it too, so `getBounds()` with a GLB-combine override already
+answers the per-component question, at least for bounds that are explicitly
+annotated.
+
+An earlier version of this change made
+`AnnotatedIntersectionType.copyIntersectionBoundAnnotations` compute a bare
+bound's own default and feed it into the combining hook, so that a checker
+overriding the hook would have a say even when one side's qualifier came from
+defaulting rather than being written. That version is **reverted**: computing
+the default required a synthetic, standalone defaulting call from inside type
+construction, which (a) can re-enter type construction for the same element
+and crash with `StackOverflowError` on an F-bounded type parameter such as
+`<T extends Recursive<T> & @Q Cloneable>`, for every checker, not just one
+overriding the hook, and (b) is not issued at the bound's real location
+(`UPPER_BOUND`), so it can compute the wrong default. Closing this gap
+correctly needs the summary to be computed from the bounds' real qualifiers
+after the ordinary defaulting pass has run on them, which is a larger,
+separately-scoped change to the type-construction/defaulting pipeline
+ordering, not attempted here.
 
 `BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
 JDK-8054309 collapsed-wildcard-bound comparison to a new overridable

--- a/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
@@ -518,9 +518,11 @@ public abstract class AbstractViewpointAdapter implements ViewpointAdapter {
         }
         // First replace the bounds copied by shallowCopy with the adapted bounds. Then clear the
         // shallow copy's stale primary annotations and recompute them from the adapted bounds.
+        // The adapted bounds are already fully annotated (source's bounds have already been
+        // through construction and defaulting, and adaptBound preserves that).
         intersection.setBounds(adaptedBounds);
         intersection.clearAnnotations();
-        intersection.copyIntersectionBoundAnnotations();
+        intersection.summarizeBounds();
         return intersection;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1658,10 +1658,12 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     /**
      * Combines two conflicting bound annotations of an intersection type, in the same qualifier
-     * hierarchy, into the single annotation that {@link
-     * AnnotatedTypeMirror.AnnotatedIntersectionType#copyIntersectionBoundAnnotations()} uses to
-     * summarize that hierarchy. This method is called only when two bounds carry different
-     * annotations in one hierarchy.
+     * hierarchy, into the single annotation used to summarize that hierarchy. Called by {@link
+     * AnnotatedTypeMirror.AnnotatedIntersectionType#summarizeBounds()}: for a type variable's own
+     * intersection upper bound, after each bound has been independently defaulted, so a bound's
+     * annotation may be explicit or defaulted; for an intersection cast target, before defaulting,
+     * so only explicit annotations are seen. Either way, this method is called only when two bounds
+     * carry different annotations in one hierarchy.
      *
      * <p>By default the annotation of the bound encountered first, in source order, wins
      * (first-bound-wins): the returned summary equals {@code existingAnnotation} and {@code

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -3028,10 +3028,14 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
                     annos.add(summary);
                 }
             }
-            // replaceAnnotations, not addAnnotations: this must not depend on the (currently
-            // true) invariant that any annotation already on the intersection was already
-            // homogenized onto every bound when it was added, and so is guaranteed to be
-            // reproduced by the fold above.
+            // Clear first, then replaceAnnotations rather than addAnnotations: summarizeBounds is a
+            // full recomputation, so a hierarchy with no contributing bound must be dropped from
+            // both the intersection and its homogenized bound copies, not preserved from an earlier
+            // summary.
+            clearAnnotations();
+            for (AnnotatedTypeMirror bound : theBounds) {
+                bound.clearAnnotations();
+            }
             replaceAnnotations(annos);
         }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -3076,6 +3076,13 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * that view to top. Same-hierarchy conflicts remain an accepted, deterministic trade-off:
          * the first bound wins and later explicit qualifiers draw an {@code
          * explicit.annotation.ignored} warning.
+         *
+         * <p>Homogenization is not just a precision optimization: writing the summary only onto the
+         * intersection type's own primary annotation location, and leaving the bounds untouched,
+         * would not be enough. {@link DefaultTypeHierarchy}'s intersection subtyping methods (for
+         * example {@code visitIntersection_Type}) read only {@link #getBounds()}; they never
+         * consult the intersection type's own primary annotation. A hierarchy left un-homogenized
+         * on a bound would therefore not be seen by ordinary subtype checks at all.
          */
         public void copyIntersectionBoundAnnotations() {
             copyIntersectionBoundAnnotations(true, null);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -3050,11 +3050,8 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
             // Clear first, then replaceAnnotations rather than addAnnotations: summarizeBounds is a
             // full recomputation, so a hierarchy with no contributing bound must be dropped from
             // both the intersection and its homogenized bound copies, not preserved from an earlier
-            // summary.
+            // summary. clearAnnotations() also clears every bound (see the override above).
             clearAnnotations();
-            for (AnnotatedTypeMirror bound : theBounds) {
-                bound.clearAnnotations();
-            }
             replaceAnnotations(annos);
         }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2941,19 +2941,6 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *
          * <p>This returns the same types as {@link #directSupertypes()}.
          *
-         * <p>The returned bounds are homogenized: {@link #copyIntersectionBoundAnnotations()}
-         * summarizes the bounds' qualifiers into one qualifier per hierarchy and writes that
-         * summary onto every bound, so a later bound's own qualifier &mdash; explicit or defaulted
-         * &mdash; is not recoverable from this method, only from the summary. The default summary
-         * policy is first-bound-wins; a checker whose qualifier semantics are per-component (for
-         * example JSpecify, where {@code @Nullable Object & Lib} is null-exclusive because it IS-A
-         * the non-null {@code Lib}) overrides {@link
-         * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy} to compute the
-         * greatest lower bound instead: for any target, if some bound is a subtype of it, the
-         * greatest lower bound of all the bounds' qualifiers is too, so a GLB summary is at least
-         * as precise as checking each bound's own qualifier individually, and does not need a
-         * separate per-bound view. See {@code framework/tests/intersectionglb}.
-         *
          * @return the bounds of this, which are also the direct super types of this
          */
         public List<AnnotatedTypeMirror> getBounds() {
@@ -3003,33 +2990,30 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *       example, the greatest lower bound. In {@code @NonNull Object & @Nullable
          *       Serializable} both bounds constrain the nullness hierarchy, so the summary is
          *       {@code @NonNull}. See {@code framework/tests/lubglb/IntersectionBoundOrderA.java}.
-         *   <li><b>The first bound is not explicitly annotated in the hierarchy.</b> Its qualifier
-         *       there is its default. This method runs before defaulting, so rather than summarize
-         *       a later bound's explicit qualifier it leaves the hierarchy out of the summary; the
-         *       normal defaulting pass then fills the intersection's primary annotation in that
-         *       hierarchy. Because the first bound and the whole intersection occupy the same
-         *       defaulting location (the type variable's upper bound), that default is exactly the
-         *       first bound's own default. For example, in {@code Object & @Nullable Serializable}
-         *       the first bound {@code Object} has no explicit nullness qualifier; its default is
-         *       {@code @NonNull} (explicit-upper-bound defaulting, because the {@code extends}
-         *       clause is written), so the summary is {@code @NonNull} and the later bound's
-         *       {@code @Nullable} is ignored&mdash;exactly as if the first bound had been written
-         *       {@code @NonNull Object}. See {@code
+         *   <li><b>The first bound is not explicitly annotated in the hierarchy.</b> This method
+         *       runs before defaulting, so rather than summarize a later bound's explicit qualifier
+         *       it leaves the hierarchy out of the summary; the normal defaulting pass then fills
+         *       <em>the intersection's own</em> primary annotation in that hierarchy&mdash;not the
+         *       first bound's: the node being defaulted is the intersection, which has no class
+         *       element, so a default keyed to the first bound's own class (for example
+         *       {@code @DefaultQualifierForUse}) does not apply to it, while a default keyed to the
+         *       shared defaulting location (the type variable's upper bound) does. The combining
+         *       hook above is never consulted for this case: it is reached only when two bounds are
+         *       both explicitly annotated in a hierarchy, so a checker overriding it has no say
+         *       when a hierarchy is deferred this way, even if another bound is explicitly
+         *       annotated in it. This is a known, currently open limitation. When the first bound's
+         *       own default is itself a location default, filling from the intersection's shared
+         *       location happens to equal it&mdash;for example, in {@code Object & @Nullable
+         *       Serializable} the first bound {@code Object} has no explicit nullness qualifier;
+         *       its default is {@code @NonNull} (explicit-upper-bound defaulting), so the summary
+         *       is {@code @NonNull} and the later bound's {@code @Nullable} is ignored, exactly as
+         *       if the first bound had been written {@code @NonNull Object}. But when the first
+         *       bound's own default instead comes from a type-based default (for example
+         *       {@code @DefaultQualifierForUse}), filling from the intersection's location does
+         *       <em>not</em> reproduce it: the deferred hierarchy gets the intersection's location
+         *       default, not the first bound's own (different) default. See {@code
          *       framework/tests/lubglb/IntersectionBoundDefaulting.java}.
          * </ul>
-         *
-         * <p>The two cases differ only in <em>when</em> the first bound's qualifier is known, not
-         * in which bound wins. That distinction does matter to a checker that overrides the
-         * combining hook, though: the hook decides the first case but, if the hierarchy is simply
-         * deferred, is never consulted about the second. So a bound written bare in a hierarchy
-         * that another bound constrains explicitly contributes its own default to the summary, and
-         * that default is passed to the hook exactly like a written qualifier&mdash;every bound has
-         * a say in every hierarchy some bound constrains. This needs an element to default the bare
-         * bound in; {@link #copyIntersectionBoundAnnotations(Element)} takes one and {@link
-         * #copyIntersectionBoundAnnotations()} does not. Under the default hook nothing changes: it
-         * keeps the first bound's qualifier, so a hierarchy whose summary is still the first
-         * bound's own default is deferred after all, exactly as if the default had never been
-         * computed.
          *
          * <p>The summary is a sound upper bound of the intersection: it is the qualifier of the
          * intersection's first bound, and the intersection is a subtype of that bound. Like any
@@ -3048,9 +3032,10 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * unannotated position by two different, pre-existing rules, and only the former reproduces
          * first-bound-wins when a hierarchy is deferred. A type variable's upper bound has no
          * operand; a hierarchy left out of the summary is filled by ordinary upper-bound
-         * defaulting, and because the first bound and the whole intersection share that defaulting
-         * location the value is exactly the first bound's own default. A cast target, by contrast,
-         * is post-processed by {@code PropagationTreeAnnotator.visitTypeCast}, which fills every
+         * defaulting, using the intersection's own defaulting location&mdash;which reproduces the
+         * first bound's own default only when that default is itself a location default, not a
+         * type-based one (see the second bullet above). A cast target, by contrast, is
+         * post-processed by {@code PropagationTreeAnnotator.visitTypeCast}, which fills every
          * hierarchy the target still lacks from the <em>cast operand's</em> effective qualifier
          * (capped at the type-declaration bound) &mdash; the general rule, applied to every cast,
          * that lets {@code (Object) x} adopt {@code x}'s qualifier. So deferring a hierarchy at a
@@ -3063,7 +3048,7 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * intersection casts specifically, which would make an intersection cast inconsistent with
          * a plain cast to the same erased type; that is a worse divergence than the bound-vs-cast
          * one, so the two paths are kept distinct deliberately. See {@link
-         * #copyIntersectionBoundAnnotations(boolean, Element)}.)
+         * #copyIntersectionBoundAnnotations(boolean)}.)
          *
          * <p>The computed summary is then written back onto every bound, homogenizing them, so all
          * bounds carry the same qualifier per hierarchy. Homogenization is sound for value-property
@@ -3076,34 +3061,9 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * that view to top. Same-hierarchy conflicts remain an accepted, deterministic trade-off:
          * the first bound wins and later explicit qualifiers draw an {@code
          * explicit.annotation.ignored} warning.
-         *
-         * <p>Homogenization is not just a precision optimization: writing the summary only onto the
-         * intersection type's own primary annotation location, and leaving the bounds untouched,
-         * would not be enough. {@link DefaultTypeHierarchy}'s intersection subtyping methods (for
-         * example {@code visitIntersection_Type}) read only {@link #getBounds()}; they never
-         * consult the intersection type's own primary annotation. A hierarchy left un-homogenized
-         * on a bound would therefore not be seen by ordinary subtype checks at all.
          */
         public void copyIntersectionBoundAnnotations() {
-            copyIntersectionBoundAnnotations(true, null);
-        }
-
-        /**
-         * Like {@link #copyIntersectionBoundAnnotations()}, but a bound written bare in a hierarchy
-         * that another bound constrains explicitly contributes its own default, computed in {@code
-         * scope}, to the summary. Its default is passed to {@link
-         * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy} exactly like a
-         * qualifier written on that bound, so a checker that overrides the hook has a say in every
-         * hierarchy some bound constrains, not only in one that two bounds constrain explicitly.
-         *
-         * <p>This changes nothing for a checker that uses the default (first-bound-wins) hook: see
-         * {@link #copyIntersectionBoundAnnotations()}.
-         *
-         * @param scope the element in whose scope a bare bound is defaulted, typically the type
-         *     parameter element whose upper bound this is
-         */
-        public void copyIntersectionBoundAnnotations(Element scope) {
-            copyIntersectionBoundAnnotations(true, scope);
+            copyIntersectionBoundAnnotations(true);
         }
 
         /**
@@ -3114,62 +3074,22 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *     bound's default. Pass true for a type variable's upper bound and false for an
          *     intersection cast target; the class-level discussion of first-bound-wins on {@link
          *     #copyIntersectionBoundAnnotations()} explains why the two positions differ.
-         * @param scope the element in whose scope a bare bound is defaulted so that its default can
-         *     take part in combining, or null not to compute bounds' defaults at all
          */
-        void copyIntersectionBoundAnnotations(
-                boolean deferFirstBoundDefault, @Nullable Element scope) {
-            List<AnnotatedTypeMirror> theBounds = getBounds();
-            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
-
-            // The hierarchies that at least one bound constrains explicitly, each represented by
-            // the first qualifier found in it. Only in these hierarchies is a bare bound's own
-            // default computed: a hierarchy that no bound constrains has nothing to combine that
-            // default with, and computing defaults for it would call the defaulting pass on every
-            // bound of every intersection type.
-            AnnotationMirrorSet explicitlyConstrained = new AnnotationMirrorSet();
-            if (scope != null) {
-                for (AnnotatedTypeMirror bound : theBounds) {
-                    for (AnnotationMirror a : bound.getAnnotationsField()) {
-                        if (qualHierarchy.findAnnotationInSameHierarchy(explicitlyConstrained, a)
-                                == null) {
-                            explicitlyConstrained.add(a);
-                        }
-                    }
-                }
-            }
-
-            // The first bound's own defaults, in the hierarchies it does not constrain explicitly.
-            // A hierarchy in here is one that would be deferred without this method's scope; the
-            // summary computed for it is committed only if combining moved it off this default,
-            // see below.
-            AnnotationMirrorSet firstBoundDefaults = new AnnotationMirrorSet();
-
+        void copyIntersectionBoundAnnotations(boolean deferFirstBoundDefault) {
             AnnotationMirrorSet annos = new AnnotationMirrorSet();
+            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
             boolean firstBound = true;
-            for (AnnotatedTypeMirror bound : theBounds) {
-                AnnotationMirrorSet contributions = bound.getAnnotationsField();
-                if (!explicitlyConstrained.isEmpty()) {
-                    AnnotationMirrorSet defaults =
-                            ownDefaultsInBareHierarchies(bound, explicitlyConstrained, scope);
-                    if (!defaults.isEmpty()) {
-                        contributions = new AnnotationMirrorSet(contributions);
-                        contributions.addAll(defaults);
-                        if (firstBound) {
-                            firstBoundDefaults.addAll(defaults);
-                        }
-                    }
-                }
-                for (AnnotationMirror a : contributions) {
+            for (AnnotatedTypeMirror bound : getBounds()) {
+                for (AnnotationMirror a : bound.getAnnotationsField()) {
                     AnnotationMirror existing =
                             qualHierarchy.findAnnotationInSameHierarchy(annos, a);
                     if (existing == null) {
                         // First-bound-wins: in defer mode only the first bound may introduce a
                         // hierarchy into the summary. A hierarchy that only a later bound
-                        // constrains is left out, so the following defaulting pass fills it with
-                        // the first bound's own default (the first bound and the whole
-                        // intersection share that defaulting location, the type variable's upper
-                        // bound). An intersection cast passes deferFirstBoundDefault false and
+                        // constrains is left out, so the following defaulting pass fills it using
+                        // the intersection's own defaulting location (the type variable's upper
+                        // bound), not the first bound's -- the combining hook is not consulted for
+                        // this case. An intersection cast passes deferFirstBoundDefault false and
                         // summarizes every bound instead, because its unannotated hierarchies are
                         // filled from the cast operand. See the method Javadoc.
                         if (firstBound || !deferFirstBoundDefault) {
@@ -3187,62 +3107,10 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
                 }
                 firstBound = false;
             }
-
-            // In a hierarchy the first bound does not constrain explicitly, keep the summary only
-            // if combining moved it off the first bound's own default. If it did not, remove it
-            // and defer to the following defaulting pass exactly as if the default had never been
-            // computed, so that the behavior of a checker that does not override the combining
-            // hook is unchanged.
-            for (AnnotationMirror aDefault : firstBoundDefaults) {
-                AnnotationMirror summary =
-                        qualHierarchy.findAnnotationInSameHierarchy(annos, aDefault);
-                if (summary != null && AnnotationUtils.areSame(summary, aDefault)) {
-                    annos.remove(summary);
-                }
-            }
-
             // addAnnotations dispatches to the overridden addAnnotation, whose
             // fixupBoundAnnotations copies the primary annotation onto every bound, homogenizing
             // them.
             addAnnotations(annos);
-        }
-
-        /**
-         * Returns {@code bound}'s own default qualifier in each hierarchy that {@code bound} does
-         * not constrain explicitly, out of the given hierarchies. The bound is defaulted on its
-         * own, independently of the other bounds' qualifiers.
-         *
-         * @param bound a bound of this intersection type
-         * @param hierarchies the hierarchies to compute a default in, each represented by an
-         *     annotation in it
-         * @param scope the element in whose scope {@code bound} is defaulted
-         * @return {@code bound}'s own default in each of {@code hierarchies} it does not constrain
-         *     explicitly; empty if it constrains all of them
-         */
-        private AnnotationMirrorSet ownDefaultsInBareHierarchies(
-                AnnotatedTypeMirror bound, AnnotationMirrorSet hierarchies, Element scope) {
-            AnnotationMirrorSet bare = new AnnotationMirrorSet();
-            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
-            AnnotationMirrorSet written = bound.getAnnotationsField();
-            for (AnnotationMirror a : hierarchies) {
-                if (qualHierarchy.findAnnotationInSameHierarchy(written, a) == null) {
-                    bare.add(a);
-                }
-            }
-            if (bare.isEmpty()) {
-                return bare;
-            }
-            AnnotatedTypeMirror defaulted =
-                    createType(bound.getUnderlyingType(), atypeFactory, false);
-            atypeFactory.addComputedTypeAnnotations(scope, defaulted);
-            AnnotationMirrorSet result = new AnnotationMirrorSet();
-            for (AnnotationMirror a : bare) {
-                AnnotationMirror ownDefault = defaulted.getAnnotationInHierarchy(a);
-                if (ownDefault != null) {
-                    result.add(ownDefault);
-                }
-            }
-            return result;
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2941,6 +2941,19 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *
          * <p>This returns the same types as {@link #directSupertypes()}.
          *
+         * <p>The returned bounds are homogenized: {@link #copyIntersectionBoundAnnotations()}
+         * summarizes the bounds' qualifiers into one qualifier per hierarchy and writes that
+         * summary onto every bound, so a later bound's own qualifier &mdash; explicit or defaulted
+         * &mdash; is not recoverable from this method, only from the summary. The default summary
+         * policy is first-bound-wins; a checker whose qualifier semantics are per-component (for
+         * example JSpecify, where {@code @Nullable Object & Lib} is null-exclusive because it IS-A
+         * the non-null {@code Lib}) overrides {@link
+         * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy} to compute the
+         * greatest lower bound instead: for any target, if some bound is a subtype of it, the
+         * greatest lower bound of all the bounds' qualifiers is too, so a GLB summary is at least
+         * as precise as checking each bound's own qualifier individually, and does not need a
+         * separate per-bound view. See {@code framework/tests/intersectionglb}.
+         *
          * @return the bounds of this, which are also the direct super types of this
          */
         public List<AnnotatedTypeMirror> getBounds() {
@@ -3005,6 +3018,19 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *       framework/tests/lubglb/IntersectionBoundDefaulting.java}.
          * </ul>
          *
+         * <p>The two cases differ only in <em>when</em> the first bound's qualifier is known, not
+         * in which bound wins. That distinction does matter to a checker that overrides the
+         * combining hook, though: the hook decides the first case but, if the hierarchy is simply
+         * deferred, is never consulted about the second. So a bound written bare in a hierarchy
+         * that another bound constrains explicitly contributes its own default to the summary, and
+         * that default is passed to the hook exactly like a written qualifier&mdash;every bound has
+         * a say in every hierarchy some bound constrains. This needs an element to default the bare
+         * bound in; {@link #copyIntersectionBoundAnnotations(Element)} takes one and {@link
+         * #copyIntersectionBoundAnnotations()} does not. Under the default hook nothing changes: it
+         * keeps the first bound's qualifier, so a hierarchy whose summary is still the first
+         * bound's own default is deferred after all, exactly as if the default had never been
+         * computed.
+         *
          * <p>The summary is a sound upper bound of the intersection: it is the qualifier of the
          * intersection's first bound, and the intersection is a subtype of that bound. Like any
          * first-bound-wins choice it is source-order dependent but deterministic for a given
@@ -3037,7 +3063,7 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * intersection casts specifically, which would make an intersection cast inconsistent with
          * a plain cast to the same erased type; that is a worse divergence than the bound-vs-cast
          * one, so the two paths are kept distinct deliberately. See {@link
-         * #copyIntersectionBoundAnnotations(boolean)}.)
+         * #copyIntersectionBoundAnnotations(boolean, Element)}.)
          *
          * <p>The computed summary is then written back onto every bound, homogenizing them, so all
          * bounds carry the same qualifier per hierarchy. Homogenization is sound for value-property
@@ -3052,7 +3078,25 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * explicit.annotation.ignored} warning.
          */
         public void copyIntersectionBoundAnnotations() {
-            copyIntersectionBoundAnnotations(true);
+            copyIntersectionBoundAnnotations(true, null);
+        }
+
+        /**
+         * Like {@link #copyIntersectionBoundAnnotations()}, but a bound written bare in a hierarchy
+         * that another bound constrains explicitly contributes its own default, computed in {@code
+         * scope}, to the summary. Its default is passed to {@link
+         * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy} exactly like a
+         * qualifier written on that bound, so a checker that overrides the hook has a say in every
+         * hierarchy some bound constrains, not only in one that two bounds constrain explicitly.
+         *
+         * <p>This changes nothing for a checker that uses the default (first-bound-wins) hook: see
+         * {@link #copyIntersectionBoundAnnotations()}.
+         *
+         * @param scope the element in whose scope a bare bound is defaulted, typically the type
+         *     parameter element whose upper bound this is
+         */
+        public void copyIntersectionBoundAnnotations(Element scope) {
+            copyIntersectionBoundAnnotations(true, scope);
         }
 
         /**
@@ -3063,13 +3107,53 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *     bound's default. Pass true for a type variable's upper bound and false for an
          *     intersection cast target; the class-level discussion of first-bound-wins on {@link
          *     #copyIntersectionBoundAnnotations()} explains why the two positions differ.
+         * @param scope the element in whose scope a bare bound is defaulted so that its default can
+         *     take part in combining, or null not to compute bounds' defaults at all
          */
-        void copyIntersectionBoundAnnotations(boolean deferFirstBoundDefault) {
-            AnnotationMirrorSet annos = new AnnotationMirrorSet();
+        void copyIntersectionBoundAnnotations(
+                boolean deferFirstBoundDefault, @Nullable Element scope) {
+            List<AnnotatedTypeMirror> theBounds = getBounds();
             QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
+
+            // The hierarchies that at least one bound constrains explicitly, each represented by
+            // the first qualifier found in it. Only in these hierarchies is a bare bound's own
+            // default computed: a hierarchy that no bound constrains has nothing to combine that
+            // default with, and computing defaults for it would call the defaulting pass on every
+            // bound of every intersection type.
+            AnnotationMirrorSet explicitlyConstrained = new AnnotationMirrorSet();
+            if (scope != null) {
+                for (AnnotatedTypeMirror bound : theBounds) {
+                    for (AnnotationMirror a : bound.getAnnotationsField()) {
+                        if (qualHierarchy.findAnnotationInSameHierarchy(explicitlyConstrained, a)
+                                == null) {
+                            explicitlyConstrained.add(a);
+                        }
+                    }
+                }
+            }
+
+            // The first bound's own defaults, in the hierarchies it does not constrain explicitly.
+            // A hierarchy in here is one that would be deferred without this method's scope; the
+            // summary computed for it is committed only if combining moved it off this default,
+            // see below.
+            AnnotationMirrorSet firstBoundDefaults = new AnnotationMirrorSet();
+
+            AnnotationMirrorSet annos = new AnnotationMirrorSet();
             boolean firstBound = true;
-            for (AnnotatedTypeMirror bound : getBounds()) {
-                for (AnnotationMirror a : bound.getAnnotationsField()) {
+            for (AnnotatedTypeMirror bound : theBounds) {
+                AnnotationMirrorSet contributions = bound.getAnnotationsField();
+                if (!explicitlyConstrained.isEmpty()) {
+                    AnnotationMirrorSet defaults =
+                            ownDefaultsInBareHierarchies(bound, explicitlyConstrained, scope);
+                    if (!defaults.isEmpty()) {
+                        contributions = new AnnotationMirrorSet(contributions);
+                        contributions.addAll(defaults);
+                        if (firstBound) {
+                            firstBoundDefaults.addAll(defaults);
+                        }
+                    }
+                }
+                for (AnnotationMirror a : contributions) {
                     AnnotationMirror existing =
                             qualHierarchy.findAnnotationInSameHierarchy(annos, a);
                     if (existing == null) {
@@ -3096,10 +3180,62 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
                 }
                 firstBound = false;
             }
+
+            // In a hierarchy the first bound does not constrain explicitly, keep the summary only
+            // if combining moved it off the first bound's own default. If it did not, remove it
+            // and defer to the following defaulting pass exactly as if the default had never been
+            // computed, so that the behavior of a checker that does not override the combining
+            // hook is unchanged.
+            for (AnnotationMirror aDefault : firstBoundDefaults) {
+                AnnotationMirror summary =
+                        qualHierarchy.findAnnotationInSameHierarchy(annos, aDefault);
+                if (summary != null && AnnotationUtils.areSame(summary, aDefault)) {
+                    annos.remove(summary);
+                }
+            }
+
             // addAnnotations dispatches to the overridden addAnnotation, whose
             // fixupBoundAnnotations copies the primary annotation onto every bound, homogenizing
             // them.
             addAnnotations(annos);
+        }
+
+        /**
+         * Returns {@code bound}'s own default qualifier in each hierarchy that {@code bound} does
+         * not constrain explicitly, out of the given hierarchies. The bound is defaulted on its
+         * own, independently of the other bounds' qualifiers.
+         *
+         * @param bound a bound of this intersection type
+         * @param hierarchies the hierarchies to compute a default in, each represented by an
+         *     annotation in it
+         * @param scope the element in whose scope {@code bound} is defaulted
+         * @return {@code bound}'s own default in each of {@code hierarchies} it does not constrain
+         *     explicitly; empty if it constrains all of them
+         */
+        private AnnotationMirrorSet ownDefaultsInBareHierarchies(
+                AnnotatedTypeMirror bound, AnnotationMirrorSet hierarchies, Element scope) {
+            AnnotationMirrorSet bare = new AnnotationMirrorSet();
+            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
+            AnnotationMirrorSet written = bound.getAnnotationsField();
+            for (AnnotationMirror a : hierarchies) {
+                if (qualHierarchy.findAnnotationInSameHierarchy(written, a) == null) {
+                    bare.add(a);
+                }
+            }
+            if (bare.isEmpty()) {
+                return bare;
+            }
+            AnnotatedTypeMirror defaulted =
+                    createType(bound.getUnderlyingType(), atypeFactory, false);
+            atypeFactory.addComputedTypeAnnotations(scope, defaulted);
+            AnnotationMirrorSet result = new AnnotationMirrorSet();
+            for (AnnotationMirror a : bare) {
+                AnnotationMirror ownDefault = defaulted.getAnnotationInHierarchy(a);
+                if (ownDefault != null) {
+                    result.add(ownDefault);
+                }
+            }
+            return result;
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2941,16 +2941,15 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *
          * <p>This returns the same types as {@link #directSupertypes()}.
          *
-         * <p>The returned bounds are homogenized: whichever of {@link
-         * #copyIntersectionBoundAnnotations()} or {@link #summarizeDefaultedBounds()} last ran
-         * summarized the bounds' qualifiers into one qualifier per hierarchy and wrote that summary
-         * onto every bound (see {@link #addAnnotation}), so a bound's own qualifier is not
-         * recoverable from this method, only from the summary. This is not just a precision
-         * optimization: {@link DefaultTypeHierarchy}'s intersection subtyping methods (for example
-         * {@code visitIntersection_Type}) read only this method, never this intersection's own
-         * primary annotation directly, so a hierarchy left un-homogenized on a bound would not be
-         * seen by ordinary subtype checks at all. Homogenizing can also be strictly more precise
-         * than keeping each bound's own qualifier: a hierarchy that only one bound constrains is
+         * <p>The returned bounds are homogenized: {@link #summarizeBounds()} summarized the bounds'
+         * qualifiers into one qualifier per hierarchy and wrote that summary onto every bound (see
+         * {@link #addAnnotation}), so a bound's own qualifier is not recoverable from this method,
+         * only from the summary. This is not just a precision optimization: {@link
+         * DefaultTypeHierarchy}'s intersection subtyping methods (for example {@code
+         * visitIntersection_Type}) read only this method, never this intersection's own primary
+         * annotation directly, so a hierarchy left un-homogenized on a bound would not be seen by
+         * ordinary subtype checks at all. Homogenizing can also be strictly more precise than
+         * keeping each bound's own qualifier: a hierarchy that only one bound constrains is
          * propagated to the others rather than defaulted away. For example, in {@code @Odd Number &
          * Cloneable} the {@code @Odd} summary is written onto the {@code Cloneable} bound, so a
          * value of the intersection is {@code @Odd} when viewed as {@code Cloneable}; per-bound
@@ -2978,20 +2977,32 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * whatever {@link
          * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy(AnnotationMirror,
          * AnnotationMirror, QualifierHierarchy)} returns. Adding the result as this intersection's
-         * own primary annotation homogenizes it onto every bound (see {@link #addAnnotation}).
+         * own primary annotation homogenizes it onto every bound (see {@link #addAnnotation}); a
+         * bound whose own annotation differs from the summary does not keep it, so {@code
+         * BaseTypeVisitor.checkExplicitAnnotationsOnIntersectionBounds} warns when that annotation
+         * was explicit. See {@code framework/tests/lubglb/IntersectionBoundOrderA.java}.
          *
-         * <p>Unlike {@link #copyIntersectionBoundAnnotations()}, which runs during type
-         * construction and can only see bounds' explicit annotations, this reads each bound's real
-         * (explicit-or-defaulted) qualifier via {@link #getAnnotationInHierarchy}, so the combining
-         * hook is consulted uniformly whether a conflicting qualifier is written or defaulted. It
-         * is meant to be called after each bound has already been independently defaulted &mdash;
-         * see the {@code QualifierDefaults} caller, the only one, for how that ordering is
-         * arranged. Consequently, a type variable's own intersection upper bound is summarized only
-         * when the enclosing {@code AnnotatedTypeFactory} runs {@code QualifierDefaults}; an {@code
-         * AnnotatedTypeFactory} that does not (there is one in this repository, used only for
-         * debugging output) leaves it unsummarized.
+         * <p>This reads each bound's qualifier via {@link #getAnnotationInHierarchy}, so it
+         * reflects whatever is on a bound when this method runs, uniformly whether that came from
+         * an explicit annotation or from defaulting &mdash; there is no separate explicit-only
+         * variant of this method. Which of those two a given caller sees depends only on when in
+         * the pipeline it calls this method: {@code QualifierDefaults} calls it, for a type
+         * variable's own intersection upper bound, only after each bound has already been
+         * independently defaulted, so the combining hook sees every bound's real qualifier; calling
+         * it any earlier for that position would see only bounds' explicit annotations, since
+         * defaulting has not run yet, exactly like the intersection cast target case below. A type
+         * variable's own intersection upper bound is summarized only when the enclosing {@code
+         * AnnotatedTypeFactory} runs {@code QualifierDefaults}; one that does not (there is one in
+         * this repository, used only for debugging output) leaves it unsummarized.
+         *
+         * <p>An intersection cast target's construction also calls this method, but before
+         * defaulting, so only explicit annotations are seen there; a hierarchy no bound constrains
+         * explicitly is simply left out of the summary, because a cast target's remaining
+         * hierarchies are instead filled from the cast operand by {@code
+         * PropagationTreeAnnotator#visitTypeCast}, not by {@code QualifierDefaults}. See {@code
+         * framework/tests/lubglb/IntersectionBoundDefaulting.java}.
          */
-        public void summarizeDefaultedBounds() {
+        public void summarizeBounds() {
             QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
             AnnotationMirrorSet annos = new AnnotationMirrorSet();
             for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
@@ -3035,83 +3046,6 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          */
         public void setBounds(List<AnnotatedTypeMirror> bounds) {
             this.bounds = bounds;
-        }
-
-        /**
-         * Summarizes the bounds' <em>explicit</em> annotations (in each hierarchy) into the primary
-         * annotation location of the intersection type: the first bound's explicit qualifier there,
-         * or, if a later bound is explicitly annotated differently, whatever {@link
-         * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy(AnnotationMirror,
-         * AnnotationMirror, QualifierHierarchy)} returns (first-wins by default). Adding the result
-         * homogenizes it onto every bound (see {@link #getBounds()}); a bound whose explicit
-         * annotation differs from the summary does not keep it, so {@code
-         * BaseTypeVisitor.checkExplicitAnnotationsOnIntersectionBounds} warns about it. See {@code
-         * framework/tests/lubglb/IntersectionBoundOrderA.java}.
-         *
-         * <p>This method runs before defaulting and sees only explicit annotations, so a hierarchy
-         * no bound constrains explicitly is left out of the summary (deferred to the ordinary
-         * defaulting pass) when {@code deferFirstBoundDefault} is true. It is called by {@code
-         * AbstractViewpointAdapter}, on already-adapted, already-defaulted bound copies where every
-         * hierarchy is already populated (so deferral is not actually exercised there), and, with
-         * {@code deferFirstBoundDefault} false (never deferring), by an intersection cast target's
-         * construction: a cast target's remaining hierarchies are instead filled from the cast
-         * operand by {@code PropagationTreeAnnotator#visitTypeCast} &mdash; deferring there would
-         * let the operand override an explicitly written bound instead. See {@link
-         * #copyIntersectionBoundAnnotations(boolean)}.
-         *
-         * <p>A type variable's own intersection upper bound is summarized differently, by {@link
-         * #summarizeDefaultedBounds()}, after each bound has been independently defaulted, so that
-         * a bound's real qualifier &mdash; explicit or defaulted &mdash; takes part in combining
-         * uniformly; this method cannot do that, since it runs before defaulting. See {@code
-         * framework/tests/lubglb/IntersectionBoundDefaulting.java}.
-         */
-        public void copyIntersectionBoundAnnotations() {
-            copyIntersectionBoundAnnotations(true);
-        }
-
-        /**
-         * Implementation of {@link #copyIntersectionBoundAnnotations()}.
-         *
-         * @param deferFirstBoundDefault whether a hierarchy that only a later bound constrains may
-         *     be left out of the summary so that a later annotation pass fills it in instead. Pass
-         *     true for {@code AbstractViewpointAdapter}'s already-defaulted bound copies and false
-         *     for an intersection cast target; the class-level discussion on {@link
-         *     #copyIntersectionBoundAnnotations()} explains why the two callers differ.
-         */
-        void copyIntersectionBoundAnnotations(boolean deferFirstBoundDefault) {
-            AnnotationMirrorSet annos = new AnnotationMirrorSet();
-            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
-            boolean firstBound = true;
-            for (AnnotatedTypeMirror bound : getBounds()) {
-                for (AnnotationMirror a : bound.getAnnotationsField()) {
-                    AnnotationMirror existing =
-                            qualHierarchy.findAnnotationInSameHierarchy(annos, a);
-                    if (existing == null) {
-                        // First-bound-wins: in defer mode only the first bound may introduce a
-                        // hierarchy into the summary. A hierarchy that only a later bound
-                        // constrains is left out, deferred to a later annotation pass. An
-                        // intersection cast passes deferFirstBoundDefault false and summarizes
-                        // every bound instead, because its unannotated hierarchies are filled
-                        // from the cast operand. See the method Javadoc.
-                        if (firstBound || !deferFirstBoundDefault) {
-                            annos.add(a);
-                        }
-                    } else if (!AnnotationUtils.areSame(existing, a)) {
-                        AnnotationMirror combined =
-                                atypeFactory.combineIntersectionBoundAnnotationsInHierarchy(
-                                        existing, a, qualHierarchy);
-                        if (combined != null && !AnnotationUtils.areSame(combined, existing)) {
-                            annos.remove(existing);
-                            annos.add(combined);
-                        }
-                    }
-                }
-                firstBound = false;
-            }
-            // addAnnotations dispatches to the overridden addAnnotation, whose
-            // fixupBoundAnnotations copies the primary annotation onto every bound, homogenizing
-            // them.
-            addAnnotations(annos);
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2941,6 +2941,21 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          *
          * <p>This returns the same types as {@link #directSupertypes()}.
          *
+         * <p>The returned bounds are homogenized: whichever of {@link
+         * #copyIntersectionBoundAnnotations()} or {@link #summarizeDefaultedBounds()} last ran
+         * summarized the bounds' qualifiers into one qualifier per hierarchy and wrote that summary
+         * onto every bound (see {@link #addAnnotation}), so a bound's own qualifier is not
+         * recoverable from this method, only from the summary. This is not just a precision
+         * optimization: {@link DefaultTypeHierarchy}'s intersection subtyping methods (for example
+         * {@code visitIntersection_Type}) read only this method, never this intersection's own
+         * primary annotation directly, so a hierarchy left un-homogenized on a bound would not be
+         * seen by ordinary subtype checks at all. Homogenizing can also be strictly more precise
+         * than keeping each bound's own qualifier: a hierarchy that only one bound constrains is
+         * propagated to the others rather than defaulted away. For example, in {@code @Odd Number &
+         * Cloneable} the {@code @Odd} summary is written onto the {@code Cloneable} bound, so a
+         * value of the intersection is {@code @Odd} when viewed as {@code Cloneable}; per-bound
+         * qualifiers would instead default that view to top.
+         *
          * @return the bounds of this, which are also the direct super types of this
          */
         public List<AnnotatedTypeMirror> getBounds() {
@@ -2955,6 +2970,57 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
                 freezeLazyComponents(bounds);
             }
             return bounds;
+        }
+
+        /**
+         * Summarizes this intersection's bounds into its own primary annotation, one hierarchy at a
+         * time: the first bound's qualifier there, or, if a later bound's qualifier conflicts,
+         * whatever {@link
+         * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy(AnnotationMirror,
+         * AnnotationMirror, QualifierHierarchy)} returns. Adding the result as this intersection's
+         * own primary annotation homogenizes it onto every bound (see {@link #addAnnotation}).
+         *
+         * <p>Unlike {@link #copyIntersectionBoundAnnotations()}, which runs during type
+         * construction and can only see bounds' explicit annotations, this reads each bound's real
+         * (explicit-or-defaulted) qualifier via {@link #getAnnotationInHierarchy}, so the combining
+         * hook is consulted uniformly whether a conflicting qualifier is written or defaulted. It
+         * is meant to be called after each bound has already been independently defaulted &mdash;
+         * see the {@code QualifierDefaults} caller, the only one, for how that ordering is
+         * arranged. Consequently, a type variable's own intersection upper bound is summarized only
+         * when the enclosing {@code AnnotatedTypeFactory} runs {@code QualifierDefaults}; an {@code
+         * AnnotatedTypeFactory} that does not (there is one in this repository, used only for
+         * debugging output) leaves it unsummarized.
+         */
+        public void summarizeDefaultedBounds() {
+            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
+            AnnotationMirrorSet annos = new AnnotationMirrorSet();
+            for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
+                AnnotationMirror summary = null;
+                for (AnnotatedTypeMirror bound : getBounds()) {
+                    AnnotationMirror qual = bound.getAnnotationInHierarchy(top);
+                    if (qual == null) {
+                        continue;
+                    }
+                    if (summary == null) {
+                        summary = qual;
+                    } else if (!AnnotationUtils.areSame(summary, qual)) {
+                        AnnotationMirror combined =
+                                atypeFactory.combineIntersectionBoundAnnotationsInHierarchy(
+                                        summary, qual, qualHierarchy);
+                        if (combined != null) {
+                            summary = combined;
+                        }
+                    }
+                }
+                if (summary != null) {
+                    annos.add(summary);
+                }
+            }
+            // replaceAnnotations, not addAnnotations: this must not depend on the (currently
+            // true) invariant that any annotation already on the intersection was already
+            // homogenized onto every bound when it was added, and so is guaranteed to be
+            // reproduced by the fold above.
+            replaceAnnotations(annos);
         }
 
         @Override
@@ -2972,95 +3038,32 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         }
 
         /**
-         * Summarize the annotations (in each hierarchy) on the bounds into the primary annotation
-         * location of the intersection type.
+         * Summarizes the bounds' <em>explicit</em> annotations (in each hierarchy) into the primary
+         * annotation location of the intersection type: the first bound's explicit qualifier there,
+         * or, if a later bound is explicitly annotated differently, whatever {@link
+         * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy(AnnotationMirror,
+         * AnnotationMirror, QualifierHierarchy)} returns (first-wins by default). Adding the result
+         * homogenizes it onto every bound (see {@link #getBounds()}); a bound whose explicit
+         * annotation differs from the summary does not keep it, so {@code
+         * BaseTypeVisitor.checkExplicitAnnotationsOnIntersectionBounds} warns about it. See {@code
+         * framework/tests/lubglb/IntersectionBoundOrderA.java}.
          *
-         * <p>The policy is simple: <b>the first bound wins, in every hierarchy</b>. The summary in
-         * a hierarchy is the first bound's qualifier there&mdash;whether the first bound is
-         * annotated explicitly or by defaulting&mdash;and later bounds never override it. This
-         * holds uniformly for explicit and defaulted qualifiers:
+         * <p>This method runs before defaulting and sees only explicit annotations, so a hierarchy
+         * no bound constrains explicitly is left out of the summary (deferred to the ordinary
+         * defaulting pass) when {@code deferFirstBoundDefault} is true. It is called by {@code
+         * AbstractViewpointAdapter}, on already-adapted, already-defaulted bound copies where every
+         * hierarchy is already populated (so deferral is not actually exercised there), and, with
+         * {@code deferFirstBoundDefault} false (never deferring), by an intersection cast target's
+         * construction: a cast target's remaining hierarchies are instead filled from the cast
+         * operand by {@code PropagationTreeAnnotator#visitTypeCast} &mdash; deferring there would
+         * let the operand override an explicitly written bound instead. See {@link
+         * #copyIntersectionBoundAnnotations(boolean)}.
          *
-         * <ul>
-         *   <li><b>The first bound is explicitly annotated in the hierarchy.</b> Its qualifier is
-         *       the summary. If a later bound is explicitly annotated differently in the same
-         *       hierarchy, the two are reconciled by {@link
-         *       AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy(AnnotationMirror,
-         *       AnnotationMirror, QualifierHierarchy)}, whose default keeps the first bound's
-         *       qualifier (first-bound-wins); a checker may override the hook to compute, for
-         *       example, the greatest lower bound. In {@code @NonNull Object & @Nullable
-         *       Serializable} both bounds constrain the nullness hierarchy, so the summary is
-         *       {@code @NonNull}. See {@code framework/tests/lubglb/IntersectionBoundOrderA.java}.
-         *   <li><b>The first bound is not explicitly annotated in the hierarchy.</b> This method
-         *       runs before defaulting, so rather than summarize a later bound's explicit qualifier
-         *       it leaves the hierarchy out of the summary; the normal defaulting pass then fills
-         *       <em>the intersection's own</em> primary annotation in that hierarchy&mdash;not the
-         *       first bound's: the node being defaulted is the intersection, which has no class
-         *       element, so a default keyed to the first bound's own class (for example
-         *       {@code @DefaultQualifierForUse}) does not apply to it, while a default keyed to the
-         *       shared defaulting location (the type variable's upper bound) does. The combining
-         *       hook above is never consulted for this case: it is reached only when two bounds are
-         *       both explicitly annotated in a hierarchy, so a checker overriding it has no say
-         *       when a hierarchy is deferred this way, even if another bound is explicitly
-         *       annotated in it. This is a known, currently open limitation. When the first bound's
-         *       own default is itself a location default, filling from the intersection's shared
-         *       location happens to equal it&mdash;for example, in {@code Object & @Nullable
-         *       Serializable} the first bound {@code Object} has no explicit nullness qualifier;
-         *       its default is {@code @NonNull} (explicit-upper-bound defaulting), so the summary
-         *       is {@code @NonNull} and the later bound's {@code @Nullable} is ignored, exactly as
-         *       if the first bound had been written {@code @NonNull Object}. But when the first
-         *       bound's own default instead comes from a type-based default (for example
-         *       {@code @DefaultQualifierForUse}), filling from the intersection's location does
-         *       <em>not</em> reproduce it: the deferred hierarchy gets the intersection's location
-         *       default, not the first bound's own (different) default. See {@code
-         *       framework/tests/lubglb/IntersectionBoundDefaulting.java}.
-         * </ul>
-         *
-         * <p>The summary is a sound upper bound of the intersection: it is the qualifier of the
-         * intersection's first bound, and the intersection is a subtype of that bound. Like any
-         * first-bound-wins choice it is source-order dependent but deterministic for a given
-         * compilation, and it can be less precise than a later bound's conflicting explicit
-         * qualifier&mdash;that imprecision is the accepted trade-off of the policy, and it applies
-         * equally whether the ignored later qualifier conflicts with the first bound's explicit or
-         * defaulted qualifier.
-         *
-         * <p>(Note that adding a primary annotation to an intersection type replaces the
-         * annotations on all bounds, so bounds whose explicit annotation differs from the summary
-         * do not keep it; {@code BaseTypeVisitor.checkExplicitAnnotationsOnIntersectionBounds}
-         * warns about such annotations. This first-bound-wins restriction applies only to an
-         * intersection that is a type variable's upper bound, not to an intersection cast target.
-         * The difference is not accidental: a type variable's upper bound and a cast target fill an
-         * unannotated position by two different, pre-existing rules, and only the former reproduces
-         * first-bound-wins when a hierarchy is deferred. A type variable's upper bound has no
-         * operand; a hierarchy left out of the summary is filled by ordinary upper-bound
-         * defaulting, using the intersection's own defaulting location&mdash;which reproduces the
-         * first bound's own default only when that default is itself a location default, not a
-         * type-based one (see the second bullet above). A cast target, by contrast, is
-         * post-processed by {@code PropagationTreeAnnotator.visitTypeCast}, which fills every
-         * hierarchy the target still lacks from the <em>cast operand's</em> effective qualifier
-         * (capped at the type-declaration bound) &mdash; the general rule, applied to every cast,
-         * that lets {@code (Object) x} adopt {@code x}'s qualifier. So deferring a hierarchy at a
-         * cast would let the operand, not the first bound's default, decide the summary: with
-         * deferral, {@code (Object & @Untainted MyInterface) taintedValue} would adopt the
-         * operand's {@code @Tainted} and a spurious {@code assignment.type.incompatible} would be
-         * reported. The cast path therefore summarizes every explicitly annotated bound instead of
-         * deferring, so the written bound annotations decide the summary independent of the
-         * operand. Unifying the two would require suppressing the operand-adoption rule for
-         * intersection casts specifically, which would make an intersection cast inconsistent with
-         * a plain cast to the same erased type; that is a worse divergence than the bound-vs-cast
-         * one, so the two paths are kept distinct deliberately. See {@link
-         * #copyIntersectionBoundAnnotations(boolean)}.)
-         *
-         * <p>The computed summary is then written back onto every bound, homogenizing them, so all
-         * bounds carry the same qualifier per hierarchy. Homogenization is sound for value-property
-         * qualifiers&mdash;a qualifier established on one bound holds for the whole value, hence
-         * for every view of it&mdash;and can be strictly more precise than keeping each bound's own
-         * qualifier: a hierarchy that only one bound constrains is propagated to the others rather
-         * than defaulted away. For example, in {@code @Odd Number & Cloneable} the {@code @Odd}
-         * summary is written onto the {@code Cloneable} bound, so a value of the intersection is
-         * {@code @Odd} when viewed as {@code Cloneable}; per-bound qualifiers would instead default
-         * that view to top. Same-hierarchy conflicts remain an accepted, deterministic trade-off:
-         * the first bound wins and later explicit qualifiers draw an {@code
-         * explicit.annotation.ignored} warning.
+         * <p>A type variable's own intersection upper bound is summarized differently, by {@link
+         * #summarizeDefaultedBounds()}, after each bound has been independently defaulted, so that
+         * a bound's real qualifier &mdash; explicit or defaulted &mdash; takes part in combining
+         * uniformly; this method cannot do that, since it runs before defaulting. See {@code
+         * framework/tests/lubglb/IntersectionBoundDefaulting.java}.
          */
         public void copyIntersectionBoundAnnotations() {
             copyIntersectionBoundAnnotations(true);
@@ -3070,10 +3073,10 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
          * Implementation of {@link #copyIntersectionBoundAnnotations()}.
          *
          * @param deferFirstBoundDefault whether a hierarchy that only a later bound constrains may
-         *     be left out of the summary so that a later annotation pass fills it with the first
-         *     bound's default. Pass true for a type variable's upper bound and false for an
-         *     intersection cast target; the class-level discussion of first-bound-wins on {@link
-         *     #copyIntersectionBoundAnnotations()} explains why the two positions differ.
+         *     be left out of the summary so that a later annotation pass fills it in instead. Pass
+         *     true for {@code AbstractViewpointAdapter}'s already-defaulted bound copies and false
+         *     for an intersection cast target; the class-level discussion on {@link
+         *     #copyIntersectionBoundAnnotations()} explains why the two callers differ.
          */
         void copyIntersectionBoundAnnotations(boolean deferFirstBoundDefault) {
             AnnotationMirrorSet annos = new AnnotationMirrorSet();
@@ -3086,12 +3089,10 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
                     if (existing == null) {
                         // First-bound-wins: in defer mode only the first bound may introduce a
                         // hierarchy into the summary. A hierarchy that only a later bound
-                        // constrains is left out, so the following defaulting pass fills it using
-                        // the intersection's own defaulting location (the type variable's upper
-                        // bound), not the first bound's -- the combining hook is not consulted for
-                        // this case. An intersection cast passes deferFirstBoundDefault false and
-                        // summarizes every bound instead, because its unannotated hierarchies are
-                        // filled from the cast operand. See the method Javadoc.
+                        // constrains is left out, deferred to a later annotation pass. An
+                        // intersection cast passes deferFirstBoundDefault false and summarizes
+                        // every bound instead, because its unannotated hierarchies are filled
+                        // from the cast operand. See the method Javadoc.
                         if (firstBound || !deferFirstBoundDefault) {
                             annos.add(a);
                         }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -3005,9 +3005,10 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         public void summarizeBounds() {
             QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
             AnnotationMirrorSet annos = new AnnotationMirrorSet();
+            List<AnnotatedTypeMirror> theBounds = getBounds();
             for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
                 AnnotationMirror summary = null;
-                for (AnnotatedTypeMirror bound : getBounds()) {
+                for (AnnotatedTypeMirror bound : theBounds) {
                     AnnotationMirror qual = bound.getAnnotationInHierarchy(top);
                     if (qual == null) {
                         continue;

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -1161,6 +1161,11 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     /**
      * An intersection is a supertype if all of its bounds are a supertype of subtype.
      *
+     * <p>See {@link #visitIntersection_Type} for why this iterates over the bounds individually
+     * rather than checking a single homogenized qualifier: each bound is a structurally distinct
+     * Java type, and the recursive subtype check needs a specific bound's full type structure to
+     * recurse into, not just its (already homogenized) primary annotation.
+     *
      * @param subtype the possible subtype
      * @param supertype the possible supertype
      * @return true {@code subtype} is a subtype of {@code supertype}
@@ -1188,6 +1193,16 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
 
     /**
      * An intersection is a subtype if one of its bounds is a subtype of {@code supertype}.
+     *
+     * <p>This still iterates over every bound even though {@link
+     * AnnotatedIntersectionType#getBounds()} has already homogenized their primary annotations to
+     * the same qualifier per hierarchy: homogenization makes the <em>qualifier</em> the same no
+     * matter which bound is consulted, but the bounds remain structurally distinct Java types (for
+     * example, {@code Object} and {@code Cloneable} in {@code Object & Cloneable}), and only one of
+     * them may be erased-subtype-comparable to {@code supertype} at all. That bound also carries
+     * the full type structure the recursive subtype check needs to recurse into &mdash; type
+     * arguments of a generic bound, for instance &mdash; which the intersection type's own primary
+     * annotation, a flat per-hierarchy qualifier with no such structure, cannot supply.
      *
      * @param subtype an intersection type
      * @param supertype an annotated type

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -229,10 +229,7 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
                 AnnotatedIntersectionType intersection =
                         (AnnotatedIntersectionType) result.getUpperBound();
                 intersection.setBounds(bounds);
-                // Pass the type parameter element so that a bound written bare in a hierarchy that
-                // another bound constrains can contribute its own default to the summary.
-                intersection.copyIntersectionBoundAnnotations(
-                        result.getUnderlyingType().asElement());
+                intersection.copyIntersectionBoundAnnotations();
         }
 
         return result;
@@ -476,8 +473,8 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
         type.setBounds(bounds);
         // A cast target's unannotated hierarchies are filled from the cast operand, not from
         // defaulting, so do not defer a later bound's hierarchy to it; summarize every bound
-        // instead (see copyIntersectionBoundAnnotations(boolean, Element)).
-        type.copyIntersectionBoundAnnotations(false, null);
+        // instead (see copyIntersectionBoundAnnotations(boolean)).
+        type.copyIntersectionBoundAnnotations(false);
         return type;
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -229,7 +229,10 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
                 AnnotatedIntersectionType intersection =
                         (AnnotatedIntersectionType) result.getUpperBound();
                 intersection.setBounds(bounds);
-                intersection.copyIntersectionBoundAnnotations();
+                // Pass the type parameter element so that a bound written bare in a hierarchy that
+                // another bound constrains can contribute its own default to the summary.
+                intersection.copyIntersectionBoundAnnotations(
+                        result.getUnderlyingType().asElement());
         }
 
         return result;
@@ -473,8 +476,8 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
         type.setBounds(bounds);
         // A cast target's unannotated hierarchies are filled from the cast operand, not from
         // defaulting, so do not defer a later bound's hierarchy to it; summarize every bound
-        // instead (see copyIntersectionBoundAnnotations(boolean)).
-        type.copyIntersectionBoundAnnotations(false);
+        // instead (see copyIntersectionBoundAnnotations(boolean, Element)).
+        type.copyIntersectionBoundAnnotations(false, null);
         return type;
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -233,7 +233,7 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
                 // annotations, would homogenize an explicitly annotated bound onto the others
                 // before defaulting has run, pre-empting a bare bound's own default (e.g.
                 // @DefaultQualifierForUse) even in a hierarchy that bound doesn't conflict in.
-                // QualifierDefaults#summarizeDefaultedBounds does the summarizing instead, after
+                // QualifierDefaults calls AnnotatedIntersectionType#summarizeBounds instead, after
                 // each bound has been defaulted on its own.
         }
 
@@ -477,9 +477,8 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
                 CollectionsPlume.mapList((Tree boundTree) -> visit(boundTree, f), tree.getBounds());
         type.setBounds(bounds);
         // A cast target's unannotated hierarchies are filled from the cast operand, not from
-        // defaulting, so do not defer a later bound's hierarchy to it; summarize every bound
-        // instead (see copyIntersectionBoundAnnotations(boolean)).
-        type.copyIntersectionBoundAnnotations(false);
+        // defaulting; see summarizeBounds's Javadoc.
+        type.summarizeBounds();
         return type;
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -229,7 +229,12 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
                 AnnotatedIntersectionType intersection =
                         (AnnotatedIntersectionType) result.getUpperBound();
                 intersection.setBounds(bounds);
-                intersection.copyIntersectionBoundAnnotations();
+                // Do not summarize the bounds here: doing so now, from only their explicit
+                // annotations, would homogenize an explicitly annotated bound onto the others
+                // before defaulting has run, pre-empting a bare bound's own default (e.g.
+                // @DefaultQualifierForUse) even in a hierarchy that bound doesn't conflict in.
+                // QualifierDefaults#summarizeDefaultedBounds does the summarizing instead, after
+                // each bound has been defaulted on its own.
         }
 
         return result;

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -1253,10 +1253,9 @@ public class QualifierDefaults {
                 // that bound on its own. Recurse into the bounds first -- scanning a bound
                 // applies its own defaults normally, since a bound is not itself an intersection
                 // -- then summarize the individually defaulted bounds into the intersection's
-                // primary annotation. See
-                // AnnotatedIntersectionType#copyIntersectionBoundAnnotations.
+                // primary annotation. See AnnotatedIntersectionType#summarizeBounds.
                 Void result = super.scan(t, null);
-                ((AnnotatedIntersectionType) t).summarizeDefaultedBounds();
+                ((AnnotatedIntersectionType) t).summarizeBounds();
                 return result;
             }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -21,6 +21,7 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedIntersectionType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedUnionType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
@@ -1240,6 +1241,23 @@ public class QualifierDefaults {
                 // Type variables and wildcards are separately handled in the corresponding visitors
                 // below.
                 return super.scan(t, null);
+            }
+
+            if (t.getKind() == TypeKind.INTERSECTION
+                    && isUpperBound
+                    && boundType == BoundType.TYPEVAR_UPPER) {
+                // A type variable's own intersection upper bound is also handled specially:
+                // applying a default directly to the intersection here would homogenize it onto
+                // every bound (see AnnotatedIntersectionType#addAnnotation) before a
+                // bound-specific default (e.g. @DefaultQualifierForUse) got a chance to apply to
+                // that bound on its own. Recurse into the bounds first -- scanning a bound
+                // applies its own defaults normally, since a bound is not itself an intersection
+                // -- then summarize the individually defaulted bounds into the intersection's
+                // primary annotation. See
+                // AnnotatedIntersectionType#copyIntersectionBoundAnnotations.
+                Void result = super.scan(t, null);
+                ((AnnotatedIntersectionType) t).summarizeDefaultedBounds();
+                return result;
             }
 
             boolean isTopLevelType = t == outer.type;

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
@@ -175,11 +175,7 @@ abstract class TypeParamElementAnnotationApplier extends IndexedElementAnnotatio
 
                     bounds.get(boundIndex).replaceAnnotation(anno); // TODO: WHY NOT ADD?
                 }
-                // Pass the type parameter element so that a bound left bare in a hierarchy that
-                // another bound constrains can contribute its own default to the summary.
-                ((AnnotatedIntersectionType) upperBoundType)
-                        .copyIntersectionBoundAnnotations(
-                                typeParam.getUnderlyingType().asElement());
+                ((AnnotatedIntersectionType) upperBoundType).copyIntersectionBoundAnnotations();
 
             } else {
                 upperBoundType.addAnnotations(upperBounds);

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
@@ -175,7 +175,11 @@ abstract class TypeParamElementAnnotationApplier extends IndexedElementAnnotatio
 
                     bounds.get(boundIndex).replaceAnnotation(anno); // TODO: WHY NOT ADD?
                 }
-                ((AnnotatedIntersectionType) upperBoundType).copyIntersectionBoundAnnotations();
+                // Pass the type parameter element so that a bound left bare in a hierarchy that
+                // another bound constrains can contribute its own default to the summary.
+                ((AnnotatedIntersectionType) upperBoundType)
+                        .copyIntersectionBoundAnnotations(
+                                typeParam.getUnderlyingType().asElement());
 
             } else {
                 upperBoundType.addAnnotations(upperBounds);

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
@@ -175,7 +175,8 @@ abstract class TypeParamElementAnnotationApplier extends IndexedElementAnnotatio
 
                     bounds.get(boundIndex).replaceAnnotation(anno); // TODO: WHY NOT ADD?
                 }
-                ((AnnotatedIntersectionType) upperBoundType).copyIntersectionBoundAnnotations();
+                // Do not summarize the bounds here: see the matching comment in
+                // TypeFromTypeTreeVisitor#visitTypeParameter.
 
             } else {
                 upperBoundType.addAnnotations(upperBounds);

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/IntersectionGlbTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/IntersectionGlbTest.java
@@ -1,0 +1,31 @@
+package org.checkerframework.framework.test.junit;
+
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.checkerframework.framework.testchecker.intersectionglb.IntersectionGlbChecker;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.List;
+
+/** Tests a checker that overrides how an intersection type's bound qualifiers are combined. */
+public class IntersectionGlbTest extends CheckerFrameworkPerDirectoryTest {
+
+    /**
+     * Creates an IntersectionGlbTest.
+     *
+     * @param testFiles the files containing test code, which will be type-checked
+     */
+    public IntersectionGlbTest(List<File> testFiles) {
+        super(testFiles, IntersectionGlbChecker.class, "intersectionglb");
+    }
+
+    /**
+     * Returns the test directories.
+     *
+     * @return the test directories
+     */
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"intersectionglb"};
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/intersectionglb/IntersectionGlbAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/intersectionglb/IntersectionGlbAnnotatedTypeFactory.java
@@ -1,0 +1,62 @@
+package org.checkerframework.framework.testchecker.intersectionglb;
+
+import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbA;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbB;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbC;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbD;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbE;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbF;
+import org.checkerframework.framework.testchecker.lubglb.quals.PolyLubglb;
+import org.checkerframework.framework.type.QualifierHierarchy;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+
+/** The type factory for {@link IntersectionGlbChecker}. */
+public class IntersectionGlbAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
+
+    /**
+     * Creates an IntersectionGlbAnnotatedTypeFactory.
+     *
+     * @param checker the checker
+     */
+    @SuppressWarnings("this-escape")
+    public IntersectionGlbAnnotatedTypeFactory(BaseTypeChecker checker) {
+        super(checker);
+        this.postInit();
+    }
+
+    @Override
+    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+        return new HashSet<Class<? extends Annotation>>(
+                Arrays.asList(
+                        LubglbA.class,
+                        LubglbB.class,
+                        LubglbC.class,
+                        LubglbD.class,
+                        LubglbE.class,
+                        LubglbF.class,
+                        PolyLubglb.class));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation is order-independent: it returns the greatest lower bound of the two
+     * qualifiers.
+     */
+    @Override
+    protected AnnotationMirror combineIntersectionBoundAnnotationsInHierarchy(
+            AnnotationMirror existingAnnotation,
+            AnnotationMirror newAnnotation,
+            QualifierHierarchy qualifierHierarchy) {
+        return qualifierHierarchy.greatestLowerBoundQualifiersOnly(
+                existingAnnotation, newAnnotation);
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/intersectionglb/IntersectionGlbChecker.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/intersectionglb/IntersectionGlbChecker.java
@@ -1,0 +1,16 @@
+package org.checkerframework.framework.testchecker.intersectionglb;
+
+import org.checkerframework.common.basetype.BaseTypeChecker;
+
+/**
+ * A checker over the {@code lubglb} qualifier hierarchy whose type factory summarizes an
+ * intersection type's bounds by their greatest lower bound instead of by first-bound-wins. It tests
+ * {@link
+ * org.checkerframework.framework.type.AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy},
+ * which no checker in this repository overrides.
+ */
+public class IntersectionGlbChecker extends BaseTypeChecker {
+
+    /** Creates an IntersectionGlbChecker. */
+    public IntersectionGlbChecker() {}
+}

--- a/framework/tests/intersectionglb/IntersectionBoundCombining.java
+++ b/framework/tests/intersectionglb/IntersectionBoundCombining.java
@@ -1,18 +1,16 @@
-import org.checkerframework.framework.qual.DefaultQualifierForUse;
-import org.checkerframework.framework.testchecker.lubglb.quals.LubglbA;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbB;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbC;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbD;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbE;
 
 // This checker overrides AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy to
-// return the greatest lower bound, so an intersection type's summary is the GLB of its bounds'
-// qualifiers instead of the first bound's qualifier. Every bound has a say, whether its qualifier
-// is written on it or is its own default: copyIntersectionBoundAnnotations computes a bound's own
-// default when another bound constrains that hierarchy explicitly, and passes it to the combining
-// hook exactly like a written qualifier. The companion file
-// framework/tests/lubglb/IntersectionBoundDefaulting.java covers the same declarations under the
-// default (first-bound-wins) hook.
+// return the greatest lower bound, so an intersection type's summary is the GLB of two bounds'
+// qualifiers instead of the first bound's qualifier, whenever both bounds are explicitly
+// annotated in a hierarchy. (A bare bound's own default does not take part in combining; see the
+// second bullet of AnnotatedIntersectionType#copyIntersectionBoundAnnotations's Javadoc for why
+// that is a known limitation, not addressed here.) The companion files
+// framework/tests/lubglb/IntersectionBoundOrderA.java and IntersectionBoundOrderB.java cover the
+// same both-explicit declarations under the default (first-bound-wins) hook.
 //
 // Hierarchy: @LubglbA is the top and the default qualifier; @LubglbB and @LubglbC are its
 // subtypes; @LubglbD is a subtype of both, so glb(@LubglbB, @LubglbC) is @LubglbD.
@@ -22,11 +20,7 @@ public class IntersectionBoundCombining {
 
     interface IfaceB {}
 
-    // Uses of IfaceC default to @LubglbC rather than to the top @LubglbA.
-    @DefaultQualifierForUse(LubglbC.class)
-    interface IfaceC {}
-
-    static class Impl implements IfaceA, IfaceB, IfaceC {}
+    static class Impl implements IfaceA, IfaceB {}
 
     // Both bounds are explicitly annotated, so both take part in combining: the summary is
     // glb(@LubglbB, @LubglbC) = @LubglbD. Neither written qualifier is the summary, so both are
@@ -40,32 +34,9 @@ public class IntersectionBoundCombining {
         bothExplicit(b);
     }
 
-    // The first bound is bare; its own default is the top @LubglbA. That default takes part in
-    // combining, so the summary is glb(@LubglbA, @LubglbC) = @LubglbC. Under first-bound-wins the
-    // summary would be the first bound's default @LubglbA and the written @LubglbC would be
-    // ignored.
-    <S extends IfaceA & @LubglbC IfaceB> void bareFirstBound(S p) {}
-
-    void useBareFirstBound(@LubglbC Impl c, @LubglbA Impl a) {
-        bareFirstBound(c);
-        // :: error: (type.arguments.not.inferred)
-        bareFirstBound(a);
-    }
-
-    // The later bound is bare; its own default is @LubglbC. That default takes part in combining
-    // just as the first bound's does, so the summary is glb(@LubglbB, @LubglbC) = @LubglbD.
-    // :: warning: (explicit.annotation.ignored)
-    <S extends @LubglbB IfaceA & IfaceC> void bareLaterBound(S p) {}
-
-    void useBareLaterBound(@LubglbD Impl d, @LubglbB Impl b) {
-        bareLaterBound(d);
-        // :: error: (type.arguments.not.inferred)
-        bareLaterBound(b);
-    }
-
     // @LubglbB and @LubglbC are true siblings: neither is a subtype of the other, so neither
     // bound's own qualifier alone reaches @LubglbD. Reading the type parameter back out (rather
-    // than inferring it from an argument, as the tests above do) is still accepted for @LubglbD,
+    // than inferring it from an argument, as the test above does) is still accepted for @LubglbD,
     // because the summary glb(@LubglbB, @LubglbC) is @LubglbD; a checker that instead checked each
     // bound's own qualifier individually would have to reject this. @LubglbE is unrelated to
     // @LubglbD (it is under @LubglbC only), so it is rejected.

--- a/framework/tests/intersectionglb/IntersectionBoundCombining.java
+++ b/framework/tests/intersectionglb/IntersectionBoundCombining.java
@@ -1,4 +1,6 @@
+import org.checkerframework.framework.qual.DefaultQualifier;
 import org.checkerframework.framework.qual.DefaultQualifierForUse;
+import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbA;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbB;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbC;
@@ -87,4 +89,47 @@ public class IntersectionBoundCombining {
     // hook -- but is included here too since this checker exercises the summarizing code path
     // most thoroughly.
     static class Recursive<T extends Recursive<T> & @LubglbB IfaceA> {}
+
+    // Regression test: self-reference in the SECOND bound position, not just the first. The
+    // enclosing type must be an interface here, since only a first bound may be a class.
+    interface RecursiveSecond<T extends @LubglbB IfaceA & RecursiveSecond<T>> {}
+
+    // Regression test: mutually recursive F-bounds across two classes (P's own bound mentions Q,
+    // and vice versa), not just a single self-referential class.
+    static class MutuallyRecursiveP<
+            T extends MutuallyRecursiveP<T, U> & IfaceA,
+            U extends MutuallyRecursiveQ<T, U> & @LubglbB IfaceB> {}
+
+    static class MutuallyRecursiveQ<
+            T extends MutuallyRecursiveP<T, U> & IfaceA,
+            U extends MutuallyRecursiveQ<T, U> & @LubglbB IfaceB> {}
+
+    // A bare bound's own default can come from a location default, not just a type-based one
+    // (@DefaultQualifierForUse, as bareLaterBound above uses). Here IfaceA's own default in this
+    // scope is @LubglbB (not the checker's usual top default @LubglbA), so the summary is
+    // glb(@LubglbB, @LubglbC) = @LubglbD.
+    @DefaultQualifier(value = LubglbB.class, locations = TypeUseLocation.UPPER_BOUND)
+    static class LocationDefault {
+        // :: warning: (explicit.annotation.ignored)
+        <T extends IfaceA & @LubglbC IfaceB> void m(T t) {
+            @LubglbD Object accepted = t;
+            // :: error: (assignment.type.incompatible)
+            @LubglbE Object rejected = t;
+        }
+    }
+
+    interface IfaceThird {}
+
+    // Order independence across 3+ bounds: the same three qualifiers (the default @LubglbA, an
+    // explicit @LubglbB, an explicit @LubglbC) reach the same summary glb(@LubglbB, @LubglbC) =
+    // @LubglbD regardless of which bound each is written on.
+    // :: warning: (explicit.annotation.ignored) :: warning: (explicit.annotation.ignored)
+    <T extends IfaceA & @LubglbB IfaceB & @LubglbC IfaceThird> void threeBoundForward(T t) {
+        @LubglbD Object accepted = t;
+    }
+
+    // :: warning: (explicit.annotation.ignored) :: warning: (explicit.annotation.ignored)
+    <T extends @LubglbC IfaceA & @LubglbB IfaceB & IfaceThird> void threeBoundReordered(T t) {
+        @LubglbD Object accepted = t;
+    }
 }

--- a/framework/tests/intersectionglb/IntersectionBoundCombining.java
+++ b/framework/tests/intersectionglb/IntersectionBoundCombining.java
@@ -1,0 +1,78 @@
+import org.checkerframework.framework.qual.DefaultQualifierForUse;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbA;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbB;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbC;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbD;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbE;
+
+// This checker overrides AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy to
+// return the greatest lower bound, so an intersection type's summary is the GLB of its bounds'
+// qualifiers instead of the first bound's qualifier. Every bound has a say, whether its qualifier
+// is written on it or is its own default: copyIntersectionBoundAnnotations computes a bound's own
+// default when another bound constrains that hierarchy explicitly, and passes it to the combining
+// hook exactly like a written qualifier. The companion file
+// framework/tests/lubglb/IntersectionBoundDefaulting.java covers the same declarations under the
+// default (first-bound-wins) hook.
+//
+// Hierarchy: @LubglbA is the top and the default qualifier; @LubglbB and @LubglbC are its
+// subtypes; @LubglbD is a subtype of both, so glb(@LubglbB, @LubglbC) is @LubglbD.
+public class IntersectionBoundCombining {
+
+    interface IfaceA {}
+
+    interface IfaceB {}
+
+    // Uses of IfaceC default to @LubglbC rather than to the top @LubglbA.
+    @DefaultQualifierForUse(LubglbC.class)
+    interface IfaceC {}
+
+    static class Impl implements IfaceA, IfaceB, IfaceC {}
+
+    // Both bounds are explicitly annotated, so both take part in combining: the summary is
+    // glb(@LubglbB, @LubglbC) = @LubglbD. Neither written qualifier is the summary, so both are
+    // reported as ignored.
+    // :: warning: (explicit.annotation.ignored) :: warning: (explicit.annotation.ignored)
+    <S extends @LubglbB IfaceA & @LubglbC IfaceB> void bothExplicit(S p) {}
+
+    void useBothExplicit(@LubglbD Impl d, @LubglbB Impl b) {
+        bothExplicit(d);
+        // :: error: (type.arguments.not.inferred)
+        bothExplicit(b);
+    }
+
+    // The first bound is bare; its own default is the top @LubglbA. That default takes part in
+    // combining, so the summary is glb(@LubglbA, @LubglbC) = @LubglbC. Under first-bound-wins the
+    // summary would be the first bound's default @LubglbA and the written @LubglbC would be
+    // ignored.
+    <S extends IfaceA & @LubglbC IfaceB> void bareFirstBound(S p) {}
+
+    void useBareFirstBound(@LubglbC Impl c, @LubglbA Impl a) {
+        bareFirstBound(c);
+        // :: error: (type.arguments.not.inferred)
+        bareFirstBound(a);
+    }
+
+    // The later bound is bare; its own default is @LubglbC. That default takes part in combining
+    // just as the first bound's does, so the summary is glb(@LubglbB, @LubglbC) = @LubglbD.
+    // :: warning: (explicit.annotation.ignored)
+    <S extends @LubglbB IfaceA & IfaceC> void bareLaterBound(S p) {}
+
+    void useBareLaterBound(@LubglbD Impl d, @LubglbB Impl b) {
+        bareLaterBound(d);
+        // :: error: (type.arguments.not.inferred)
+        bareLaterBound(b);
+    }
+
+    // @LubglbB and @LubglbC are true siblings: neither is a subtype of the other, so neither
+    // bound's own qualifier alone reaches @LubglbD. Reading the type parameter back out (rather
+    // than inferring it from an argument, as the tests above do) is still accepted for @LubglbD,
+    // because the summary glb(@LubglbB, @LubglbC) is @LubglbD; a checker that instead checked each
+    // bound's own qualifier individually would have to reject this. @LubglbE is unrelated to
+    // @LubglbD (it is under @LubglbC only), so it is rejected.
+    // :: warning: (explicit.annotation.ignored) :: warning: (explicit.annotation.ignored)
+    <T extends @LubglbB IfaceA & @LubglbC IfaceB> void siblingBounds(T t) {
+        @LubglbD Object accepted = t;
+        // :: error: (assignment.type.incompatible)
+        @LubglbE Object rejected = t;
+    }
+}

--- a/framework/tests/intersectionglb/IntersectionBoundCombining.java
+++ b/framework/tests/intersectionglb/IntersectionBoundCombining.java
@@ -1,16 +1,18 @@
+import org.checkerframework.framework.qual.DefaultQualifierForUse;
+import org.checkerframework.framework.testchecker.lubglb.quals.LubglbA;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbB;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbC;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbD;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbE;
 
 // This checker overrides AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy to
-// return the greatest lower bound, so an intersection type's summary is the GLB of two bounds'
-// qualifiers instead of the first bound's qualifier, whenever both bounds are explicitly
-// annotated in a hierarchy. (A bare bound's own default does not take part in combining; see the
-// second bullet of AnnotatedIntersectionType#copyIntersectionBoundAnnotations's Javadoc for why
-// that is a known limitation, not addressed here.) The companion files
-// framework/tests/lubglb/IntersectionBoundOrderA.java and IntersectionBoundOrderB.java cover the
-// same both-explicit declarations under the default (first-bound-wins) hook.
+// return the greatest lower bound, so an intersection type's summary is the GLB of its bounds'
+// qualifiers instead of the first bound's qualifier. Every bound has a say, whether its qualifier
+// is written on it or is its own default: each bound is defaulted independently before the bounds
+// are summarized, so a bare bound's own default (location-based or, e.g., @DefaultQualifierForUse)
+// takes part in combining exactly like a written qualifier. The companion file
+// framework/tests/lubglb/IntersectionBoundDefaulting.java covers the bare-bound declarations under
+// the default (first-bound-wins) hook.
 //
 // Hierarchy: @LubglbA is the top and the default qualifier; @LubglbB and @LubglbC are its
 // subtypes; @LubglbD is a subtype of both, so glb(@LubglbB, @LubglbC) is @LubglbD.
@@ -20,7 +22,11 @@ public class IntersectionBoundCombining {
 
     interface IfaceB {}
 
-    static class Impl implements IfaceA, IfaceB {}
+    // Uses of IfaceC default to @LubglbC rather than to the top @LubglbA.
+    @DefaultQualifierForUse(LubglbC.class)
+    interface IfaceC {}
+
+    static class Impl implements IfaceA, IfaceB, IfaceC {}
 
     // Both bounds are explicitly annotated, so both take part in combining: the summary is
     // glb(@LubglbB, @LubglbC) = @LubglbD. Neither written qualifier is the summary, so both are
@@ -34,9 +40,33 @@ public class IntersectionBoundCombining {
         bothExplicit(b);
     }
 
+    // The first bound is bare; its own default is the top @LubglbA (IfaceA has no
+    // @DefaultQualifierForUse). That default takes part in combining, so the summary is
+    // glb(@LubglbA, @LubglbC) = @LubglbC. Under first-bound-wins the summary would be the first
+    // bound's default @LubglbA and the written @LubglbC would be ignored.
+    <S extends IfaceA & @LubglbC IfaceB> void bareFirstBound(S p) {}
+
+    void useBareFirstBound(@LubglbC Impl c, @LubglbA Impl a) {
+        bareFirstBound(c);
+        // :: error: (type.arguments.not.inferred)
+        bareFirstBound(a);
+    }
+
+    // The later bound is bare, and its own default comes from @DefaultQualifierForUse rather than
+    // from its location: @LubglbC. That default takes part in combining just as a location default
+    // does, so the summary is glb(@LubglbB, @LubglbC) = @LubglbD.
+    // :: warning: (explicit.annotation.ignored)
+    <S extends @LubglbB IfaceA & IfaceC> void bareLaterBound(S p) {}
+
+    void useBareLaterBound(@LubglbD Impl d, @LubglbB Impl b) {
+        bareLaterBound(d);
+        // :: error: (type.arguments.not.inferred)
+        bareLaterBound(b);
+    }
+
     // @LubglbB and @LubglbC are true siblings: neither is a subtype of the other, so neither
     // bound's own qualifier alone reaches @LubglbD. Reading the type parameter back out (rather
-    // than inferring it from an argument, as the test above does) is still accepted for @LubglbD,
+    // than inferring it from an argument, as the tests above do) is still accepted for @LubglbD,
     // because the summary glb(@LubglbB, @LubglbC) is @LubglbD; a checker that instead checked each
     // bound's own qualifier individually would have to reject this. @LubglbE is unrelated to
     // @LubglbD (it is under @LubglbC only), so it is rejected.
@@ -46,4 +76,15 @@ public class IntersectionBoundCombining {
         // :: error: (assignment.type.incompatible)
         @LubglbE Object rejected = t;
     }
+
+    // Regression test: an F-bounded intersection bound (a bound that mentions the enclosing type
+    // parameter's own declaration) must not crash. Defaulting Recursive's own bare bound used to
+    // re-enter construction of the same type parameter's upper bound. The first bound's own
+    // default is the top @LubglbA (Recursive has no @DefaultQualifierForUse); glb(@LubglbA,
+    // @LubglbB) is @LubglbB, so the written qualifier is not ignored -- it already is the summary.
+    // This is unrelated to GLB specifically -- see
+    // framework/tests/lubglb/IntersectionBoundDefaulting.java for the same case under the default
+    // hook -- but is included here too since this checker exercises the summarizing code path
+    // most thoroughly.
+    static class Recursive<T extends Recursive<T> & @LubglbB IfaceA> {}
 }

--- a/framework/tests/lubglb/IntersectionBoundDefaulting.java
+++ b/framework/tests/lubglb/IntersectionBoundDefaulting.java
@@ -1,3 +1,4 @@
+import org.checkerframework.framework.qual.DefaultQualifierForUse;
 import org.checkerframework.framework.testchecker.lubglb.quals.*;
 
 // Companion to IntersectionBoundOrderA/B.java. Those files cover the case where MULTIPLE bounds
@@ -6,14 +7,13 @@ import org.checkerframework.framework.testchecker.lubglb.quals.*;
 // (it relies on defaulting) and only a LATER bound is explicitly annotated.
 //
 // First-bound-wins holds uniformly, whether the first bound is annotated explicitly or by
-// defaulting. AnnotatedIntersectionType#copyIntersectionBoundAnnotations() lets only the first
-// bound introduce a hierarchy into the summary; a hierarchy that only a later bound constrains is
-// left out of the summary and filled by the normal defaulting pass with the FIRST bound's own
-// default. The first bound and the whole intersection sit at the same defaulting location (the type
-// variable's upper bound), so that default is exactly the first bound's value in the hierarchy. So
-// the summary is the first bound's default, NOT the later bound's explicit qualifier, and the later
-// bound's ignored explicit qualifier draws an explicit.annotation.ignored warning (just as an
-// explicitly annotated first bound would cause the later bound to be ignored).
+// defaulting, and whether the default is a location default (implicit-upper-bound defaulting,
+// the top qualifier here) or a type-based one (@DefaultQualifierForUse): each bound is defaulted
+// on its own -- see QualifierDefaults's handling of a type variable's intersection upper bound --
+// before the bounds are summarized, so the summary is the first bound's own real qualifier,
+// whichever kind of default produced it, and a later bound's ignored explicit qualifier draws an
+// explicit.annotation.ignored warning (just as an explicitly annotated first bound would cause
+// the later bound to be ignored).
 public class IntersectionBoundDefaulting {
 
     interface OrderIfaceA {}
@@ -46,4 +46,34 @@ public class IntersectionBoundDefaulting {
         // @LubglbA and NOT the second bound's explicit @LubglbC (which would reject @LubglbA).
         call(a);
     }
+
+    // Uses of DefaultedIface default to @LubglbC, not to the top @LubglbA: a type-based default,
+    // not a location-based one. First-bound-wins still holds: the summary is the first bound's
+    // own default @LubglbC (not @LubglbA, the intersection's own location default, and not the
+    // second bound's explicit @LubglbA), so the second bound's @LubglbA is ignored.
+    @DefaultQualifierForUse(LubglbC.class)
+    interface DefaultedIface {}
+
+    static class DefaultedImpl implements DefaultedIface, OrderIfaceB {}
+
+    // :: warning: (explicit.annotation.ignored)
+    <S extends DefaultedIface & @LubglbA OrderIfaceB> void callTypeBased(S p) {}
+
+    void useTypeBasedC(@LubglbC DefaultedImpl c) {
+        callTypeBased(c);
+    }
+
+    void useTypeBasedTop(@LubglbA DefaultedImpl a) {
+        // :: error: (type.arguments.not.inferred)
+        callTypeBased(a);
+    }
+
+    // Regression test: an F-bounded intersection bound (a bound that mentions the enclosing type
+    // parameter's own declaration) must not crash defaulting. Recursive's own bare bound used to
+    // re-enter construction of the same type parameter's upper bound while computing its default.
+    // The first bound's own default is the top @LubglbA (Recursive has no
+    // @DefaultQualifierForUse); first-bound-wins keeps it over the second bound's explicit
+    // @LubglbC.
+    // :: warning: (explicit.annotation.ignored)
+    static class Recursive<T extends Recursive<T> & @LubglbC OrderIfaceA> {}
 }

--- a/framework/tests/lubglb/IntersectionBoundDefaulting.java
+++ b/framework/tests/lubglb/IntersectionBoundDefaulting.java
@@ -76,4 +76,22 @@ public class IntersectionBoundDefaulting {
     // @LubglbC.
     // :: warning: (explicit.annotation.ignored)
     static class Recursive<T extends Recursive<T> & @LubglbC OrderIfaceA> {}
+
+    // Regression test: self-reference in the SECOND bound position, not just the first. The
+    // enclosing type must be an interface here, since only a first bound may be a class.
+    interface RecursiveSecond<T extends @LubglbC OrderIfaceA & RecursiveSecond<T>> {}
+
+    // Regression test: mutually recursive F-bounds across two classes (P's own bound mentions Q,
+    // and vice versa), not just a single self-referential class. The first bound (the
+    // self/mutually-referential one) is bare, defaulting to the top @LubglbA, so the second
+    // bound's explicit @LubglbC is ignored, as in Recursive above.
+    static class MutuallyRecursiveP<
+            T extends MutuallyRecursiveP<T, U> & OrderIfaceA,
+            // :: warning: (explicit.annotation.ignored)
+            U extends MutuallyRecursiveQ<T, U> & @LubglbC OrderIfaceB> {}
+
+    static class MutuallyRecursiveQ<
+            T extends MutuallyRecursiveP<T, U> & OrderIfaceA,
+            // :: warning: (explicit.annotation.ignored)
+            U extends MutuallyRecursiveQ<T, U> & @LubglbC OrderIfaceB> {}
 }


### PR DESCRIPTION
## Summary

`AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy` (introduced in #1875, for reconciling conflicting intersection-bound qualifiers, e.g. computing a greatest lower bound instead of first-wins) was consulted only when two bounds were both explicitly annotated in a hierarchy. Whenever one side's qualifier came from defaulting instead, the hook was never called, so overriding it had no effect — including on #1875's own motivating example.

- `QualifierDefaults` now special-cases a type variable's own intersection upper bound: instead of applying a default directly to the intersection node (which immediately homogenizes it onto every bound, pre-empting any bound-specific default), it lets each bound be defaulted independently first, then calls the single summarizing method, `AnnotatedIntersectionType.summarizeBounds`, which folds the combining hook over each bound's real qualifier — explicit or defaulted, uniformly, since the method reads whatever is on a bound when it's called rather than caring how it got there.
- There is only one summarizing method now, not two. `AbstractViewpointAdapter` turned out not to need an explicit-only variant either — its bounds are already fully defaulted by the time viewpoint adaptation runs — so it now calls `summarizeBounds` too. That leaves an intersection cast target's construction as the only caller that still sees explicit-only annotations, which is inherent to that position (a cast target's bounds are never defaulted by `QualifierDefaults`; its remaining hierarchies are filled from the cast operand by a different mechanism instead), not a leftover restriction. The two methods this PR originally added (`copyIntersectionBoundAnnotations`'s public no-arg overload and `summarizeDefaultedBounds`) are consequently merged into one, and the now-dead public overload is removed.
- **User-visible side effect, not just the combining-hook fix**: even under the default (first-bound-wins) hook, an intersection whose first bound relies on a type-based default (e.g. `@DefaultQualifierForUse`) now correctly summarizes to that default, instead of to the intersection's own location default — #1875 incorrectly assumed those always coincide. See `IntersectionBoundDefaulting.java`'s `callTypeBased` test.
- Adds `IntersectionGlbChecker`/`IntersectionGlbAnnotatedTypeFactory` test infrastructure, restores/extends `IntersectionBoundCombining.java`, and extends `IntersectionBoundDefaulting.java`, both now covering: bare-first-bound and bare-later-bound (type-based and location-based defaults), sibling-bound GLB dominance, order independence across 3+ bounds in two source orders, and F-bounded self-reference in the first bound position, the second bound position, and across two mutually recursive classes.
- Documents in `DefaultTypeHierarchy.java` why intersection subtyping still iterates bounds individually even though they're homogenized (structural type distinctness, not just qualifiers).
- Corrects the #1875 changelog/Javadoc inaccuracies described above.

## What was tried first and reverted (kept visible in history)

An earlier version computed a bare bound's own default via a synthetic, standalone defaulting call issued from inside `copyIntersectionBoundAnnotations` during type construction. An independent review (self-requested mid-PR) found, and I independently reproduced, that this crashed with `StackOverflowError` on an F-bounded type parameter (`class Recursive<T extends Recursive<T> & @Q Cloneable>`) for every checker, and separately computed defaults at the wrong location even where it didn't crash. That version is reverted in an earlier commit on this branch; the current fix avoids both problems structurally by letting each bound go through the ordinary, correctly-located defaulting pass in its own right, instead of predicting what that pass would compute from inside type construction.

## Update: merged master, including #1944

#1944 (`AnnotatedIntersectionType.clearAnnotations()` now propagates to bounds) landed on master separately, since it's a useful invariant on its own regardless of this PR. Master is now merged into this branch, and `summarizeBounds`'s own explicit per-bound clearing loop — needed before #1944, since `clearAnnotations()` didn't yet reach the bounds on its own — is removed as redundant now that the override does that.

## Test plan

- [x] `./gradlew :framework:test` (full suite) — passes, run multiple times across iterations of this change, including after merging master
- [x] `./gradlew :checker:test` (full suite) — passes, run multiple times, including after merging master; this change touches core defaulting used by every checker, not just intersection-bound-specific test infrastructure
- [x] `./gradlew :framework:spotlessApply` — no changes
- [x] `./gradlew javadocDoclintAll --rerun-tasks` — same pre-existing baseline warning counts on every touched file, nothing new
- [x] Verified against both the default (first-wins) and GLB-combine test checkers, via `checker/bin/javac` and now as permanent regression tests: no crash on F-bounded self-reference (first position, second position, mutual recursion across two classes); bare-first-bound and bare-later-bound (type-based and location-based defaults) correctly participate in combining; the GLB summary is order-independent across 3+ bounds
- [x] The JDK's own `<T extends Object & Comparable<? super T>>` shape (`Collections.min`/`max`), already exercised qualifier-sensitively by the Tainting Checker's test suite, unaffected (`:checker:test --tests "*TaintingTest*"` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLj2wCz6koCVrfLhHkN5R

