### PR TITLE
AnnotatedIntersectionType: propagate clearAnnotations() to bounds

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -178,6 +178,17 @@ functional interface whose method declares a generic `throws` clause.
 
 **Implementation details:**
 
+`AnnotatedIntersectionType.clearAnnotations()` now also clears every bound's
+annotations, matching `addAnnotation`/`removeAnnotation`, which already
+propagate to bounds. Previously, clearing only the intersection's own
+primary annotation while leaving a bound's annotations in place could let a
+bound keep a qualifier a caller was trying to discard, with no way to tell
+that the two had gone out of sync. `AbstractViewpointAdapter` no longer
+clears an adapted intersection copy's annotations before recomputing its
+summary from the adapted bounds: that call was already a no-op (the copy's
+own primary annotation starts empty), and clearing there now would discard
+the adapted bounds' qualifiers before they are read.
+
 `BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
 JDK-8054309 collapsed-wildcard-bound comparison to a new overridable
 `areCollapsedWildcardBoundsEqual` method, instead of inlining a bidirectional

--- a/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AbstractViewpointAdapter.java
@@ -516,10 +516,15 @@ public abstract class AbstractViewpointAdapter implements ViewpointAdapter {
         for (AnnotatedTypeMirror bound : bounds) {
             adaptedBounds.add(adaptBound.apply(bound));
         }
-        // First replace the bounds copied by shallowCopy with the adapted bounds. Then clear the
-        // shallow copy's stale primary annotations and recompute them from the adapted bounds.
+        // Replace the bounds copied by shallowCopy with the adapted bounds, then recompute the
+        // intersection's own primary annotation from them. copyIntersectionBoundAnnotations reads
+        // each bound's own annotations, so it must run directly on the adapted bounds -- do not
+        // clear here first, which (now that AnnotatedIntersectionType#clearAnnotations also
+        // clears every bound) would discard adaptBound's results before
+        // copyIntersectionBoundAnnotations ever sees them. This clear was already a no-op before
+        // that change too: shallowCopy(false) leaves the intersection's own primary annotation
+        // empty, which is all this call ever cleared.
         intersection.setBounds(adaptedBounds);
-        intersection.clearAnnotations();
         intersection.copyIntersectionBoundAnnotations();
         return intersection;
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2872,6 +2872,25 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         }
 
         /**
+         * {@inheritDoc}
+         *
+         * <p>Also clears every bound's annotations, for the same reason {@link
+         * #removeAnnotation(AnnotationMirror)} does: leaving a bound's annotations in place while
+         * clearing only the intersection's own primary annotation would let a bound keep a stale
+         * qualifier that a caller clearing this type is trying to discard, with no local signal
+         * that the two had gone out of sync.
+         */
+        @Override
+        public void clearAnnotations() {
+            super.clearAnnotations();
+            if (bounds != null) {
+                for (AnnotatedTypeMirror bound : bounds) {
+                    bound.clearAnnotations();
+                }
+            }
+        }
+
+        /**
          * Copies {@link #primaryAnnotations} to all the bounds, replacing any existing annotations
          * in the same hierarchy.
          */


### PR DESCRIPTION
## Summary

- `addAnnotation`/`removeAnnotation` on `AnnotatedIntersectionType` already propagate to every bound; `clearAnnotations()` was the odd one out, clearing only the intersection's own primary annotation. A caller that clears an intersection to recompute its annotations from scratch (a real, existing pattern in this codebase -- see `AnnotatedTypes#glbSubtype` and other `clearAnnotations()` call sites) could leave a bound holding a stale qualifier the recomputation was meant to discard, with no signal that the two had gone out of sync.
- Found while auditing `clearAnnotations()` call sites after fixing exactly this class of bug elsewhere (a not-yet-merged change to how a type variable's intersection upper bound is summarized after defaulting).
- Surfaced an existing, latent interaction in `AbstractViewpointAdapter#adaptIntersectionBounds`: it replaces an intersection copy's bounds with freshly adapted ones, then called `clearAnnotations()` before recomputing the copy's own primary annotation from those adapted bounds. With `clearAnnotations()` now also clearing bounds, that call would discard the adapted bounds' qualifiers before they're ever read. Removed it -- it was already a no-op before this change too, since the copy's own primary annotation starts empty (`shallowCopy(false)`), which is all it ever cleared.

## Test plan

- [x] `./gradlew :framework:test` (full suite) -- passes
- [x] `./gradlew :checker:test` (full suite) -- passes
- [x] `./gradlew :framework:test --tests "org.checkerframework.framework.test.junit.ViewpointTestCheckerTest"` -- passes; exercises `framework/tests/viewpointtest/IntersectionTypes.java`'s `ViewpointAdaptedIntersectionBound`, which goes through exactly the `AbstractViewpointAdapter` path this touches
- [x] `./gradlew :framework:spotlessApply` -- no changes
- [x] `./gradlew javadocDoclintAll --rerun-tasks` -- same warning counts as plain master on both changed files (24 pre-existing on `AnnotatedTypeMirror.java`, 0 on `AbstractViewpointAdapter.java`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLj2wCz6koCVrfLhHkN5R