### PR TITLE
QualifierHierarchy: document the LUB/GLB consistency isSubtypeQualifiers requires

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -206,6 +206,17 @@ separate per-bound API: for any target, if some bound's own qualifier is a
 subtype of it, the greatest lower bound of the bounds' qualifiers is a
 subtype of it too.
 
+`QualifierHierarchy.isSubtypeQualifiers`, `leastUpperBoundQualifiers`, and
+`greatestLowerBoundQualifiers` now document that an override of any one of
+them must stay consistent with the others: a qualifier hierarchy whose true
+subtyping relation depends on something a static, declarative lattice
+cannot express (for example, a checker option) needs its LUB/GLB
+computation updated to match, not just `isSubtypeQualifiers`, or a caller
+that combines qualifiers with one and later checks the result with the
+other, such as `combineIntersectionBoundAnnotationsInHierarchy`'s suggested
+`greatestLowerBoundQualifiersOnly` override, can derive a summary the
+qualifier hierarchy's own subtype check would not itself have accepted.
+
 `AnnotatedIntersectionType.clearAnnotations()` now also clears every bound's
 annotations, matching `addAnnotation`/`removeAnnotation`, which already
 propagate to bounds. Previously, clearing only the intersection's own

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1681,8 +1681,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * QualifierHierarchy#greatestLowerBoundQualifiers} being consistent with {@link
      * QualifierHierarchy#isSubtypeQualifiers} for the qualifier hierarchy in use (see that method's
      * documentation): if a qualifier hierarchy's true subtyping relation depends on something a
-     * static declarative lattice cannot express, such as a checker option, and its greatest-lower-
-     * bound computation was not updated to match, the summary this method returns can be a
+     * static declarative lattice cannot express, such as a checker option, and its computation of
+     * the greatest lower bound was not updated to match, the summary this method returns can be a
      * qualifier the qualifier hierarchy's own subtype check would not itself have derived,
      * producing a spurious type error where none existed before the summary was combined -- not a
      * fault of this method or of homogenization, but of that inconsistency.

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1672,11 +1672,20 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * equals one of the bounds' own annotations and the intersection is a subtype of each of its
      * bounds.
      *
-     * <p>A checker that wants an order-independent, more precise summary&mdash;for example a
-     * JSpecify-style integration&mdash;may override this to return {@code
+     * <p>A checker that wants an order-independent, more precise summary -- for example a
+     * JSpecify-style integration -- may override this to return {@code
      * qualifierHierarchy.greatestLowerBoundQualifiersOnly(existingAnnotation, newAnnotation)}. This
      * method decides only how the per-hierarchy summary is computed; that summary is always written
-     * back onto every bound (homogenization).
+     * back onto every bound (homogenization). Computing it via {@code
+     * greatestLowerBoundQualifiersOnly} additionally relies on {@link
+     * QualifierHierarchy#greatestLowerBoundQualifiers} being consistent with {@link
+     * QualifierHierarchy#isSubtypeQualifiers} for the qualifier hierarchy in use (see that method's
+     * documentation): if a qualifier hierarchy's true subtyping relation depends on something a
+     * static declarative lattice cannot express, such as a checker option, and its greatest-lower-
+     * bound computation was not updated to match, the summary this method returns can be a
+     * qualifier the qualifier hierarchy's own subtype check would not itself have derived,
+     * producing a spurious type error where none existed before the summary was combined -- not a
+     * fault of this method or of homogenization, but of that inconsistency.
      *
      * @param existingAnnotation the annotation already chosen for this hierarchy, from an earlier
      *     bound in source order

--- a/framework/src/main/java/org/checkerframework/framework/type/QualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/QualifierHierarchy.java
@@ -173,6 +173,21 @@ public abstract class QualifierHierarchy {
      * makes it easy to find places where code outside the framework is ignoring Java basetypes --
      * at calls to {@link #isSubtypeQualifiersOnly}.
      *
+     * <p>An override must stay consistent with {@link #leastUpperBoundQualifiers} and {@link
+     * #greatestLowerBoundQualifiers}: for any two qualifiers {@code a} and {@code b} in the same
+     * hierarchy, {@code leastUpperBoundQualifiers(a, b)} must be a supertype of both {@code a} and
+     * {@code b} under this method, {@code greatestLowerBoundQualifiers(a, b)} must be a subtype of
+     * both, and each must be the <em>greatest</em> or <em>least</em> such qualifier -- not merely
+     * any upper or lower bound. This matters even for a qualifier hierarchy whose true subtyping
+     * relation is not fully expressible as a static, declarative lattice (for example, one that
+     * depends on a checker option such as a strict/lenient mode): if this method special-cases such
+     * a situation but {@link #leastUpperBoundQualifiers}/{@link #greatestLowerBoundQualifiers} do
+     * not, a caller that combines qualifiers with one and later checks the result with the other --
+     * as {@link AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy} does when
+     * overridden to return a greatest lower bound -- can derive a summary that this method would
+     * not itself have accepted, producing a spurious type error where none existed before the
+     * summary was combined.
+     *
      * @param subQualifier possible subqualifier
      * @param superQualifier possible superqualifier
      * @return true iff {@code subQualifier} is a subqualifier of, or equal to, {@code
@@ -359,6 +374,12 @@ public abstract class QualifierHierarchy {
      * <ul>
      *   <li>For NonNull, leastUpperBound('Nullable', 'NonNull') &rArr; Nullable
      * </ul>
+     *
+     * <p>Must stay consistent with {@link #isSubtypeQualifiers}: the result must be a supertype of
+     * both {@code qualifier1} and {@code qualifier2}, and no other common supertype may be its
+     * supertype. See {@link #isSubtypeQualifiers}'s documentation for why this matters even for a
+     * qualifier hierarchy whose true subtyping relation is not fully expressible as a static,
+     * declarative lattice.
      *
      * @param qualifier1 the first qualifier; may not be in the same hierarchy as {@code qualifier2}
      * @param qualifier2 the second qualifier; may not be in the same hierarchy as {@code
@@ -569,6 +590,12 @@ public abstract class QualifierHierarchy {
      * Returns the greatest lower bound for the qualifiers qualifier1 and qualifier2. Returns null
      * if the qualifiers are not from the same qualifier hierarchy.
      *
+     * <p>Must stay consistent with {@link #isSubtypeQualifiers}: the result must be a subtype of
+     * both {@code qualifier1} and {@code qualifier2}, and no other common subtype may be its
+     * subtype. See {@link #isSubtypeQualifiers}'s documentation for why this matters even for a
+     * qualifier hierarchy whose true subtyping relation is not fully expressible as a static,
+     * declarative lattice.
+     *
      * @param qualifier1 first qualifier
      * @param qualifier2 second qualifier
      * @return greatest lower bound of the two annotations, or null if the two annotations are not
@@ -582,6 +609,13 @@ public abstract class QualifierHierarchy {
     /**
      * Returns the greatest lower bound for the qualifiers qualifier1 and qualifier2. Returns null
      * if the qualifiers are not from the same qualifier hierarchy.
+     *
+     * <p>Delegates to {@link #greatestLowerBoundQualifiers}; see that method's documentation for
+     * the consistency this result is required to have with {@link #isSubtypeQualifiers}. A caller
+     * that combines qualifiers with this method and later has them checked by a subtype query --
+     * such as {@link AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy}'s
+     * suggested use of this method to compute an intersection's per-hierarchy summary -- relies on
+     * that consistency holding for the qualifier hierarchy in use.
      *
      * @param qualifier1 first qualifier
      * @param qualifier2 second qualifier
@@ -598,6 +632,10 @@ public abstract class QualifierHierarchy {
     /**
      * Returns the greatest lower bound for the qualifiers qualifier1 and qualifier2. Returns null
      * if the qualifiers are not from the same qualifier hierarchy.
+     *
+     * <p>When both types are relevant, delegates to {@link #greatestLowerBoundQualifiers}; see that
+     * method's documentation for the consistency this result is required to have with {@link
+     * #isSubtypeQualifiers}.
      *
      * @param qualifier1 first qualifier
      * @param tm1 the type that is annotated by qualifier1

--- a/framework/src/main/java/org/checkerframework/framework/type/QualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/QualifierHierarchy.java
@@ -176,17 +176,18 @@ public abstract class QualifierHierarchy {
      * <p>An override must stay consistent with {@link #leastUpperBoundQualifiers} and {@link
      * #greatestLowerBoundQualifiers}: for any two qualifiers {@code a} and {@code b} in the same
      * hierarchy, {@code leastUpperBoundQualifiers(a, b)} must be a supertype of both {@code a} and
-     * {@code b} under this method, {@code greatestLowerBoundQualifiers(a, b)} must be a subtype of
-     * both, and each must be the <em>greatest</em> or <em>least</em> such qualifier -- not merely
-     * any upper or lower bound. This matters even for a qualifier hierarchy whose true subtyping
-     * relation is not fully expressible as a static, declarative lattice (for example, one that
-     * depends on a checker option such as a strict/lenient mode): if this method special-cases such
-     * a situation but {@link #leastUpperBoundQualifiers}/{@link #greatestLowerBoundQualifiers} do
-     * not, a caller that combines qualifiers with one and later checks the result with the other --
-     * as {@link AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy} does when
-     * overridden to return a greatest lower bound -- can derive a summary that this method would
-     * not itself have accepted, producing a spurious type error where none existed before the
-     * summary was combined.
+     * {@code b} under this method and a subtype of every other common supertype of the two (i.e.,
+     * the <em>least</em> such supertype, not merely some upper bound); {@code
+     * greatestLowerBoundQualifiers(a, b)} must be a subtype of both and a supertype of every other
+     * common subtype of the two (i.e., the <em>greatest</em> such subtype). This matters even for a
+     * qualifier hierarchy whose true subtyping relation is not fully expressible as a static,
+     * declarative lattice (for example, one that depends on a checker option such as a
+     * strict/lenient mode): if this method special-cases such a situation but {@link
+     * #leastUpperBoundQualifiers}/{@link #greatestLowerBoundQualifiers} do not, a caller that
+     * combines qualifiers with one and later checks the result with the other -- as {@link
+     * AnnotatedTypeFactory#combineIntersectionBoundAnnotationsInHierarchy} does when overridden to
+     * return a greatest lower bound -- can derive a summary that this method would not itself have
+     * accepted, producing a spurious type error where none existed before the summary was combined.
      *
      * @param subQualifier possible subqualifier
      * @param superQualifier possible superqualifier
@@ -376,10 +377,10 @@ public abstract class QualifierHierarchy {
      * </ul>
      *
      * <p>Must stay consistent with {@link #isSubtypeQualifiers}: the result must be a supertype of
-     * both {@code qualifier1} and {@code qualifier2}, and no other common supertype may be its
-     * supertype. See {@link #isSubtypeQualifiers}'s documentation for why this matters even for a
-     * qualifier hierarchy whose true subtyping relation is not fully expressible as a static,
-     * declarative lattice.
+     * both {@code qualifier1} and {@code qualifier2}, and a subtype of every other common supertype
+     * of the two (i.e., the least such supertype). See {@link #isSubtypeQualifiers}'s documentation
+     * for why this matters even for a qualifier hierarchy whose true subtyping relation is not
+     * fully expressible as a static, declarative lattice.
      *
      * @param qualifier1 the first qualifier; may not be in the same hierarchy as {@code qualifier2}
      * @param qualifier2 the second qualifier; may not be in the same hierarchy as {@code
@@ -591,10 +592,10 @@ public abstract class QualifierHierarchy {
      * if the qualifiers are not from the same qualifier hierarchy.
      *
      * <p>Must stay consistent with {@link #isSubtypeQualifiers}: the result must be a subtype of
-     * both {@code qualifier1} and {@code qualifier2}, and no other common subtype may be its
-     * subtype. See {@link #isSubtypeQualifiers}'s documentation for why this matters even for a
-     * qualifier hierarchy whose true subtyping relation is not fully expressible as a static,
-     * declarative lattice.
+     * both {@code qualifier1} and {@code qualifier2}, and a supertype of every other common subtype
+     * of the two (i.e., the greatest such subtype). See {@link #isSubtypeQualifiers}'s
+     * documentation for why this matters even for a qualifier hierarchy whose true subtyping
+     * relation is not fully expressible as a static, declarative lattice.
      *
      * @param qualifier1 first qualifier
      * @param qualifier2 second qualifier


### PR DESCRIPTION
## Summary

`AnnotatedTypeFactory.combineIntersectionBoundAnnotationsInHierarchy`'s
Javadoc suggests that a checker wanting an order-independent intersection
summary override it to return
`qualifierHierarchy.greatestLowerBoundQualifiersOnly(existingAnnotation,
newAnnotation)`. That relies on an implicit contract that was never written
down: `QualifierHierarchy.greatestLowerBoundQualifiers` (and
`leastUpperBoundQualifiers`) must compute a result that is actually a
lower (or upper) bound *under the same subtype relation `isSubtypeQualifiers`
defines*, and the *greatest* (or *least*) one -- not just any common bound
under some other, possibly looser, notion of subtyping.

This surfaced in practice: a checker whose true subtyping relation depends
on a checker option (e.g. a strict/lenient mode) and is therefore not fully
expressible as a static, declarative lattice overrode `isSubtypeQualifiers`
to be option-sensitive, but not its GLB computation. Routing
`combineIntersectionBoundAnnotationsInHierarchy` through
`greatestLowerBoundQualifiersOnly`, exactly as the Javadoc suggests, then
produced a summary for one bound shape that the checker's own subtype check
would not itself have derived, causing a spurious `type.arguments.not.inferred`
where there previously was none. That is not a checker-framework defect --
`combineIntersectionBoundAnnotationsInHierarchy` and
`greatestLowerBoundQualifiersOnly` both behave exactly as implemented -- but
the contract that made this surprising was undocumented, so this PR
documents it on all four affected methods:
`QualifierHierarchy.isSubtypeQualifiers`, `leastUpperBoundQualifiers`,
`greatestLowerBoundQualifiers`, and `greatestLowerBoundQualifiersOnly` (plus
a pointer from `greatestLowerBoundShallow`, which delegates to the same
method), and adds a caveat to `combineIntersectionBoundAnnotationsInHierarchy`'s
own suggested-override paragraph in `AnnotatedTypeFactory`.

Also fixes two `&mdash;` HTML entities in that same Javadoc paragraph
(introduced by an earlier PR) to plain ASCII `--`, matching this repo's
documentation style elsewhere.

Documentation only; no behavior change.

## Test plan

- [x] `./gradlew :framework:compileJava` -- succeeds
- [x] `./gradlew :framework:spotlessApply` -- no changes beyond this PR's own edits
- [x] `./gradlew javadocDoclintAll --rerun-tasks` -- identical warning counts on
      both touched files before and after this change (31 on
      `AnnotatedTypeFactory.java`, 0 on `QualifierHierarchy.java`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLj2wCz6koCVrfLhHkN5R
