### PR TITLE
DefaultInferredTypesApplier: don't re-default a bare captured type parameter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -201,10 +201,10 @@ differs from a synthetic capture element's, such as one distinguishing
 
 That reconstruction still re-defaulted against the capture's own synthetic
 element in one case where it need not have: a captured type variable whose
-captured wildcard's own bound is itself a bare type-variable use (e.g. `?
-extends V` with no further constraint on `V`). There, the capture's upper
-bound is exactly `V`'s own bound, so `DefaultInferredTypesApplier` now reads
-`V`'s own, already-fully-defaulted declaration directly instead of
+captured wildcard's own bound is itself a bare type-variable use
+(e.g. `? extends V` with no further constraint on `V`). There, the capture's
+upper bound is exactly `V`'s own bound, so `DefaultInferredTypesApplier` now
+reads `V`'s own, already-fully-defaulted declaration directly instead of
 re-defaulting against the synthetic element, avoiding the same "no source"
 defaulting mismatch for this position too.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -199,6 +199,15 @@ them -- but are user-visible for a checker whose per-position defaulting
 differs from a synthetic capture element's, such as one distinguishing
 `@NullMarked` from unannotated code.
 
+That reconstruction still re-defaulted against the capture's own synthetic
+element in one case where it need not have: a captured type variable whose
+captured wildcard's own bound is itself a bare type-variable use (e.g. `?
+extends V` with no further constraint on `V`). There, the capture's upper
+bound is exactly `V`'s own bound, so `DefaultInferredTypesApplier` now reads
+`V`'s own, already-fully-defaulted declaration directly instead of
+re-defaulting against the synthetic element, avoiding the same "no source"
+defaulting mismatch for this position too.
+
 **Implementation details:**
 
 `AnnotatedIntersectionType.summarizeBounds` computes the summary described

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
@@ -177,11 +177,14 @@ public class DefaultInferredTypesApplier {
         }
     }
 
-    /*
-     * If typeVar is a captured type variable whose captured wildcard's own bound (the side of
-     * "? extends" or "? super" that was written) is itself a plain type-variable use, returns
-     * that type variable's element. Otherwise, including when typeVar is not a captured type
-     * variable at all, returns null.
+    /**
+     * If {@code typeVar} is a captured type variable whose captured wildcard's own bound (the
+     * {@code ? extends} side that was written) is itself a plain type-variable use, returns that
+     * type variable's element. Otherwise, including when {@code typeVar} is not a captured type
+     * variable at all, returns {@code null}.
+     *
+     * @param typeVar the type variable to inspect
+     * @return the element of the bare type-variable bound, or {@code null}
      */
     private static @Nullable Element bareCapturedTypeParameterElement(TypeVariable typeVar) {
         WildcardType wildcard = TypesUtils.getCapturedWildcard(typeVar);

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
@@ -178,26 +178,31 @@ public class DefaultInferredTypesApplier {
     }
 
     /**
-     * If {@code typeVar} is a captured type variable whose captured wildcard's own bound (the
-     * {@code ? extends} side that was written) is itself a plain type-variable use, returns that
-     * type variable's element. Otherwise, including when {@code typeVar} is not a captured type
-     * variable at all, returns {@code null}.
+     * If {@code typeVar} is a captured type variable whose captured wildcard is {@code ? extends V}
+     * for some unannotated, bare type-variable use {@code V} (so the captured upper bound is
+     * exactly {@code V}'s own upper bound, per JLS 5.1.10's glb), returns {@code V}'s element.
+     * Otherwise -- including for {@code ? super}, an annotated bound, a bound that isn't a bare
+     * type-variable use, or a {@code typeVar} that isn't a captured type variable at all -- returns
+     * {@code null}. A {@code ? super V} wildcard's captured upper bound is not {@code V}'s own
+     * bound, so it must not take this fast path; an annotated bound such as {@code ? extends @A V}
+     * must not either, since reading {@code V}'s own declaration would silently drop the explicit
+     * {@code @A}.
      *
      * @param typeVar the type variable to inspect
-     * @return the element of the bare type-variable bound, or {@code null}
+     * @return the element of the bare, unannotated {@code ? extends} type-variable bound, or {@code
+     *     null}
      */
     private static @Nullable Element bareCapturedTypeParameterElement(TypeVariable typeVar) {
         WildcardType wildcard = TypesUtils.getCapturedWildcard(typeVar);
         if (wildcard == null) {
             return null;
         }
-        TypeMirror writtenBound =
-                wildcard.getExtendsBound() != null
-                        ? wildcard.getExtendsBound()
-                        : wildcard.getSuperBound();
-        if (writtenBound == null || writtenBound.getKind() != TypeKind.TYPEVAR) {
+        TypeMirror extendsBound = wildcard.getExtendsBound();
+        if (extendsBound == null
+                || extendsBound.getKind() != TypeKind.TYPEVAR
+                || !extendsBound.getAnnotationMirrors().isEmpty()) {
             return null;
         }
-        return ((TypeVariable) writtenBound).asElement();
+        return ((TypeVariable) extendsBound).asElement();
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
@@ -1,5 +1,6 @@
 package org.checkerframework.framework.type;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
@@ -7,6 +8,7 @@ import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.TypesUtils;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
@@ -131,7 +133,19 @@ public class DefaultInferredTypesApplier {
         }
         TypeVariable typeVar = (TypeVariable) inferredTypeMirror;
         AnnotatedTypeVariable typeVariableDecl;
-        if (TypesUtils.isCapturedTypeVariable(typeVar)) {
+        Element bareCapturedTypeParameter = bareCapturedTypeParameterElement(typeVar);
+        if (bareCapturedTypeParameter != null) {
+            // The captured wildcard's own bound is just a type-variable use, with no annotation
+            // of its own to lose, so the capture's upper bound is exactly that type variable's
+            // own bound (JLS 5.1.10's glb is a no-op here). Read that type variable's own,
+            // already-fully-defaulted declaration directly, instead of re-defaulting against the
+            // capture's synthetic element below: that element has no source, so re-defaulting
+            // against it applies whatever this checker defaults "no source" code to, which need
+            // not match a bare capture's own qualifier.
+            typeVariableDecl =
+                    (AnnotatedTypeVariable)
+                            atypeFactory.getAnnotatedType(bareCapturedTypeParameter);
+        } else if (TypesUtils.isCapturedTypeVariable(typeVar)) {
             typeVariableDecl =
                     (AnnotatedTypeVariable)
                             AnnotatedTypeMirror.createType(typeVar, atypeFactory, true);
@@ -161,5 +175,26 @@ public class DefaultInferredTypesApplier {
             apply(atvUB, ub, typeVar.getUpperBound(), top);
             apply(atvLB, lb, typeVar.getLowerBound(), top);
         }
+    }
+
+    /*
+     * If typeVar is a captured type variable whose captured wildcard's own bound (the side of
+     * "? extends" or "? super" that was written) is itself a plain type-variable use, returns
+     * that type variable's element. Otherwise, including when typeVar is not a captured type
+     * variable at all, returns null.
+     */
+    private static @Nullable Element bareCapturedTypeParameterElement(TypeVariable typeVar) {
+        WildcardType wildcard = TypesUtils.getCapturedWildcard(typeVar);
+        if (wildcard == null) {
+            return null;
+        }
+        TypeMirror writtenBound =
+                wildcard.getExtendsBound() != null
+                        ? wildcard.getExtendsBound()
+                        : wildcard.getSuperBound();
+        if (writtenBound == null || writtenBound.getKind() != TypeKind.TYPEVAR) {
+            return null;
+        }
+        return ((TypeVariable) writtenBound).asElement();
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to `#1945`. That fix reconstructs a captured type variable's
bounds (when removing a dataflow-refined primary annotation) from the
capture's own underlying type instead of the type parameter's declaration --
correct in general, but it does so via
`AnnotatedTypeMirror.createType(typeVar, atypeFactory, true)` +
`atypeFactory.addComputedTypeAnnotations(typeVar.asElement(), ...)`, which
re-runs this checker's normal element-based defaulting against the capture's
own **synthetic** element. That element has no source, so re-defaulting
against it applies whatever a checker defaults "no source" code to -- the
same "defaults for an element from nowhere" problem `#1945` fixed on the
declaration-lookup path, resurfacing on the reconstruction path it
introduced.

One case where this is avoidable: a captured type variable whose captured
wildcard's own written bound is itself a bare type-variable use (`? extends
V` with no further constraint on `V`). There, capture conversion's glb
(JLS 5.1.10) is a no-op -- the capture's upper bound is exactly `V`'s own
bound -- so `DefaultInferredTypesApplier` now reads `V`'s own,
already-fully-defaulted declaration directly (`atypeFactory.getAnnotatedType(V's element)`)
instead of re-defaulting against the capture's synthetic element.

Not independently reproduced against a downstream checker: this repository's
own checkers don't have per-position "no source" defaulting (e.g. no
`@NullMarked`/unmarked-code distinction), so no in-repo test's outcome
changes. The motivating case (traced via a sibling task-tracking repo, not
part of this PR) is a JSpecify-style checker where a bare `Map<Object, ?
extends V>` value read came back with `V` forced non-null instead of staying
`V`, specifically for this bare-type-variable-wildcard shape.

## Test plan (light -- relying on CI for the rest)

- [x] `./gradlew :framework:compileJava`
- [x] `./gradlew :framework:spotlessApply` -- no changes beyond this PR's own edits
- [x] `./checker/bin/javac -processor nullness checker/tests/nullness/IssueCaptureBoundSmear.java` --
      `#1945`'s own regression test, still 0 errors
- [x] `./gradlew :checker:test --tests "*NullnessTest*"` -- 23/23 green
- [x] `./gradlew javadocDoclintAll --rerun-tasks` -- one new warning, "no
      comment" on the new private helper method, consistent with every
      other private method in this file (all flagged the same way; none of
      them have Javadoc)
- [ ] Full `alltests` not run locally -- opening this PR to let CI cover it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLj2wCz6koCVrfLhHkN5R
