### PR TITLE
DefaultInferredTypesApplier: fix bare-captured-type-parameter level mismatch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -206,7 +206,10 @@ captured wildcard's own bound is itself a bare type-variable use
 upper bound is exactly `V`'s own bound, so `DefaultInferredTypesApplier` now
 reads `V`'s own, already-fully-defaulted declaration directly instead of
 re-defaulting against the synthetic element, avoiding the same "no source"
-defaulting mismatch for this position too.
+defaulting mismatch for this position too. That fix initially installed the
+annotation from `V`'s own upper bound (e.g. `Object`'s) onto the capture,
+one level too deep; it now installs `V`'s own annotation, which is typically
+absent for a bare, unannotated type-variable use.
 
 **Implementation details:**
 

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultInferredTypesApplier.java
@@ -133,8 +133,15 @@ public class DefaultInferredTypesApplier {
         }
         TypeVariable typeVar = (TypeVariable) inferredTypeMirror;
         AnnotatedTypeVariable typeVariableDecl;
-        Element bareCapturedTypeParameter = bareCapturedTypeParameterElement(typeVar);
-        if (bareCapturedTypeParameter != null) {
+        // Whether typeVariableDecl below represents the captured wildcard's own bare
+        // type-variable bound directly (true), rather than a reconstruction of the capture
+        // itself (false, the general case). This matters below: in the general case,
+        // typeVariableDecl mirrors annotatedTypeVariable one-for-one, so its own upper/lower
+        // bounds correspond to annotatedTypeVariable's; here, typeVariableDecl itself
+        // corresponds to annotatedTypeVariable's upper bound, one level shallower.
+        boolean bareCapturedTypeParameter;
+        Element bareElement = bareCapturedTypeParameterElement(typeVar);
+        if (bareElement != null) {
             // The captured wildcard's own bound is just a type-variable use, with no annotation
             // of its own to lose, so the capture's upper bound is exactly that type variable's
             // own bound (JLS 5.1.10's glb is a no-op here). Read that type variable's own,
@@ -142,15 +149,16 @@ public class DefaultInferredTypesApplier {
             // capture's synthetic element below: that element has no source, so re-defaulting
             // against it applies whatever this checker defaults "no source" code to, which need
             // not match a bare capture's own qualifier.
-            typeVariableDecl =
-                    (AnnotatedTypeVariable)
-                            atypeFactory.getAnnotatedType(bareCapturedTypeParameter);
+            bareCapturedTypeParameter = true;
+            typeVariableDecl = (AnnotatedTypeVariable) atypeFactory.getAnnotatedType(bareElement);
         } else if (TypesUtils.isCapturedTypeVariable(typeVar)) {
+            bareCapturedTypeParameter = false;
             typeVariableDecl =
                     (AnnotatedTypeVariable)
                             AnnotatedTypeMirror.createType(typeVar, atypeFactory, true);
             atypeFactory.addComputedTypeAnnotations(typeVar.asElement(), typeVariableDecl);
         } else {
+            bareCapturedTypeParameter = false;
             typeVariableDecl =
                     (AnnotatedTypeVariable) atypeFactory.getAnnotatedType(typeVar.asElement());
         }
@@ -162,7 +170,15 @@ public class DefaultInferredTypesApplier {
                         previousAnnotation,
                         annotatedTypeVariable.getUnderlyingType())) {
             // TODO: clean up this method and whole class.
-            AnnotationMirror ub = typeVariableDecl.getUpperBound().getAnnotationInHierarchy(top);
+            AnnotationMirror ub =
+                    bareCapturedTypeParameter
+                            // typeVariableDecl is the bound itself here, so its own annotation
+                            // (possibly none, for a bare, unannotated type-variable use) is what
+                            // belongs on the capture's upper bound -- not the annotation on ITS
+                            // upper bound, which would read one level too deep (e.g. Object's
+                            // nullability instead of the type variable's own).
+                            ? typeVariableDecl.getAnnotationInHierarchy(top)
+                            : typeVariableDecl.getUpperBound().getAnnotationInHierarchy(top);
             AnnotationMirror lb = typeVariableDecl.getLowerBound().getAnnotationInHierarchy(top);
             AnnotatedTypeMirror atvUB = annotatedTypeVariable.getUpperBound();
             AnnotatedTypeMirror atvLB = annotatedTypeVariable.getLowerBound();


### PR DESCRIPTION
## Summary

Follow-up to `#1947`. A downstream re-test (via a sibling task-tracking
repo, not part of this PR) found `#1947`'s fast path changed the symptom
without fixing the underlying case it targeted: for `Map<Object, ? extends
V>`, a bare `? extends V` capture's inferred type went from `V` forced
non-null before `#1947` to `V` forced nullable after -- neither matching the
wanted bare `V` with no primary annotation of its own.

Root cause: `removePrimaryAnnotationTypeVar`'s surrounding code assumes
`typeVariableDecl` mirrors the captured type variable one level down --
`typeVariableDecl.getUpperBound()`'s annotation is what gets installed onto
the capture's own upper bound, because in the general case `typeVariableDecl`
is a full reconstruction of the capture itself, so its upper bound
corresponds to the capture's upper bound. `#1947`'s fast path instead set
`typeVariableDecl` to the captured wildcard's own bound (`V`'s declaration)
*directly* -- one level shallower -- so extracting
`typeVariableDecl.getUpperBound()`'s annotation reads from `V`'s own upper
bound (e.g. `Object`'s nullability) instead of `V`'s own annotation.

Fixed by reading `typeVariableDecl`'s own annotation directly for this case.
When that's absent (the common case for a bare, unannotated type-variable
use), the value passed downstream is `null`, and `apply()`'s existing
recursive dispatch already handles that correctly for a directly-declared
type variable -- no new logic needed there.

## Caveat

Not independently reproduced against a downstream checker: this
repository's own checkers don't have per-position "no source" defaulting
(no `@NullMarked`/unmarked-code distinction), so no in-repo test
discriminates between the old and new behavior here, same limitation as
`#1947` itself. `#1947`'s own CI run was fully green (including
`jspecify-reference-checker`) despite this specific gap existing, so CI
passing here should not be read as confirming the fix -- downstream
re-verification against the motivating case (`Map<Object, ? extends V>`,
both strict and lenient mode) is the real gate.

## Test plan (light -- relying on CI plus downstream verification)

- [x] `./gradlew :framework:compileJava`
- [x] `./gradlew :framework:spotlessApply` -- no changes beyond this PR's own edits
- [x] `./checker/bin/javac -processor nullness checker/tests/nullness/IssueCaptureBoundSmear.java` --
      still 0 errors
- [x] `./gradlew :checker:test --tests "*NullnessTest*"` -- 23/23 green
- [x] `./gradlew javadocDoclintAll --rerun-tasks` -- matches established baseline (8), no new warnings
- [ ] Full `alltests` not run locally -- opening this PR to let CI cover it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLj2wCz6koCVrfLhHkN5R
