### PR TITLE
Add regression tests for stub-provided type-parameter bound widening/narrowing

### DIFF
--- a/framework/src/test/java/org/checkerframework/framework/test/junit/StubBoundTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/StubBoundTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.framework.test.junit;
+
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.checkerframework.framework.testchecker.nontopdefault.StubBoundChecker;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.List;
+
+public class StubBoundTest extends CheckerFrameworkPerDirectoryTest {
+
+    public StubBoundTest(List<File> testFiles) {
+        super(
+                testFiles,
+                StubBoundChecker.class,
+                "stubbound",
+                "-Astubs=tests/stubbound/StubBounds.astub",
+                "-AmergeStubsWithSource");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"stubbound"};
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/StubBoundTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/StubBoundTest.java
@@ -7,8 +7,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.io.File;
 import java.util.List;
 
+/** JUnit tests for stub-provided type-parameter bound widening/narrowing. */
 public class StubBoundTest extends CheckerFrameworkPerDirectoryTest {
 
+    /**
+     * Create a StubBoundTest.
+     *
+     * @param testFiles the files containing test code, which will be type-checked
+     */
     public StubBoundTest(List<File> testFiles) {
         super(
                 testFiles,
@@ -18,6 +24,11 @@ public class StubBoundTest extends CheckerFrameworkPerDirectoryTest {
                 "-AmergeStubsWithSource");
     }
 
+    /**
+     * Define the test directories for this test.
+     *
+     * @return the test directories
+     */
     @Parameters
     public static String[] getTestDirs() {
         return new String[] {"stubbound"};

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundAnnotatedTypeFactory.java
@@ -9,7 +9,13 @@ import org.checkerframework.javacutil.AnnotationBuilder;
 
 import javax.lang.model.element.AnnotationMirror;
 
+/** The annotated type factory for the StubBound test checker. */
 public class StubBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
+    /**
+     * Create a StubBoundAnnotatedTypeFactory.
+     *
+     * @param checker the checker to which this factory belongs
+     */
     @SuppressWarnings("this-escape")
     public StubBoundAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundAnnotatedTypeFactory.java
@@ -1,0 +1,26 @@
+package org.checkerframework.framework.testchecker.nontopdefault;
+
+import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.qual.TypeUseLocation;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDMiddle;
+import org.checkerframework.framework.util.defaults.QualifierDefaults;
+import org.checkerframework.javacutil.AnnotationBuilder;
+
+import javax.lang.model.element.AnnotationMirror;
+
+public class StubBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
+    @SuppressWarnings("this-escape")
+    public StubBoundAnnotatedTypeFactory(BaseTypeChecker checker) {
+        super(checker);
+        this.postInit();
+    }
+
+    @Override
+    protected void addCheckedCodeDefaults(QualifierDefaults defs) {
+        super.addCheckedCodeDefaults(defs);
+        AnnotationMirror middle = AnnotationBuilder.fromClass(elements, NTDMiddle.class);
+        defs.addCheckedCodeDefault(middle, TypeUseLocation.UPPER_BOUND);
+        defs.addUncheckedCodeDefault(middle, TypeUseLocation.UPPER_BOUND);
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundChecker.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundChecker.java
@@ -2,4 +2,5 @@ package org.checkerframework.framework.testchecker.nontopdefault;
 
 import org.checkerframework.common.basetype.BaseTypeChecker;
 
+/** A test checker for stub-provided type-parameter bound widening/narrowing. */
 public class StubBoundChecker extends BaseTypeChecker {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundChecker.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/nontopdefault/StubBoundChecker.java
@@ -1,0 +1,5 @@
+package org.checkerframework.framework.testchecker.nontopdefault;
+
+import org.checkerframework.common.basetype.BaseTypeChecker;
+
+public class StubBoundChecker extends BaseTypeChecker {}

--- a/framework/tests/stubbound/SourceStubBounds.java
+++ b/framework/tests/stubbound/SourceStubBounds.java
@@ -1,0 +1,28 @@
+package nontopdefault;
+
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDBottom;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDMiddle;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDTop;
+
+// Same as StubBounds.java's widen()/narrow(), but for a class declared in source (merged with
+// the stub via -AmergeStubsWithSource) rather than purely stub-declared like java.util.Map/List.
+
+@SuppressWarnings("inconsistent.constructor.type")
+@DefaultQualifier(NTDMiddle.class)
+class SourceWidenMe<E> {}
+
+@SuppressWarnings("inconsistent.constructor.type")
+class SourceNarrowMe<E> {}
+
+@SuppressWarnings("inconsistent.constructor.type")
+public class SourceStubBounds {
+    void test() {
+        SourceWidenMe<@NTDTop Object> okWiden = null;
+        SourceWidenMe<@NTDMiddle Object> okMiddle = null;
+
+        SourceNarrowMe<@NTDBottom Object> okNarrow = null;
+        // :: error: (type.argument.type.incompatible)
+        SourceNarrowMe<@NTDMiddle Object> errorMiddle = null;
+    }
+}

--- a/framework/tests/stubbound/StubBounds.astub
+++ b/framework/tests/stubbound/StubBounds.astub
@@ -1,0 +1,10 @@
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDTop;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDBottom;
+
+package java.util;
+class Map<K extends @NTDTop Object, V extends @NTDTop Object> {}
+class List<E extends @NTDBottom Object> {}
+
+package nontopdefault;
+class SourceWidenMe<E extends @NTDTop Object> {}
+class SourceNarrowMe<E extends @NTDBottom Object> {}

--- a/framework/tests/stubbound/StubBounds.java
+++ b/framework/tests/stubbound/StubBounds.java
@@ -1,0 +1,22 @@
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDBottom;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDMiddle;
+import org.checkerframework.framework.testchecker.nontopdefault.qual.NTDTop;
+
+import java.util.List;
+import java.util.Map;
+
+// A stub file's explicit annotation on a type parameter's upper bound must be honored, whether
+// it widens or narrows the bound beyond the checker's own UPPER_BOUND default (@NTDMiddle here).
+@SuppressWarnings("inconsistent.constructor.type")
+public class StubBounds {
+    void widen() {
+        Map<@NTDTop Object, @NTDTop Object> ok = null;
+        Map<@NTDMiddle Object, @NTDMiddle Object> check = null;
+    }
+
+    void narrow() {
+        // :: error: (type.argument.type.incompatible)
+        List<@NTDMiddle Object> ok = null;
+        List<@NTDBottom Object> okNarrow = null;
+    }
+}


### PR DESCRIPTION
## Summary

Adds regression tests verifying that an explicit stub-file annotation on a
type parameter's upper bound is honored over the checker's own
`UPPER_BOUND` default, whether it widens or narrows the bound -- both for a
purely stub-declared class (`java.util.Map`/`List`) and for one merged with
a source declaration via `-AmergeStubsWithSource` (`SourceWidenMe`/
`SourceNarrowMe`).

This started from an investigation into a suspected "stub bound annotation
clobbering" bug, which would have motivated a defensive `clearAnnotations()`
call in `AnnotationFileParser`/`BinaryStubReader` before applying a stub's
bound annotations. That fix is **not** included here: instrumenting both
call sites and running every scenario in this test file showed the type
variable being annotated is always empty at that point already, so there
was nothing for the extra `clearAnnotations()` call to do -- no reproducing
case was found. If a real clobbering case turns up later, this test file is
the place to add it.

## Test plan

- [x] `./gradlew :framework:test --tests "*StubBoundTest*"` -- passes
- [x] `./gradlew :framework:test :checker:test --tests "*Stub*"` -- full
      stub-related suite green, including `NullnessBinaryStubDiffTest`'s
      binary/text stub equivalence check (0 mismatches)
- [x] `./gradlew :framework:spotlessApply` -- no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLj2wCz6koCVrfLhHkN5R
