### PR TITLE
AnnotatedTypeVariable/AnnotatedWildcardType: propagate clearAnnotations() to bounds

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -262,6 +262,19 @@ summary from the adapted bounds: that call was already a no-op (the copy's
 own primary annotation starts empty), and clearing there now would discard
 the adapted bounds' qualifiers before they are read.
 
+`AnnotatedWildcardType.clearAnnotations()` now likewise also clears both
+bounds' annotations, for the same reason and matching its own
+`addAnnotation`/`removeAnnotation`, which already propagated. Auditing
+every other `AnnotatedTypeMirror` subclass for the same gap found one more
+candidate, `AnnotatedTypeVariable`, but its bounds are not made to
+propagate: at least one caller (`AsSuperVisitor.visitTypevar_Typevar`)
+relies on the current, primary-only behavior to avoid disturbing a bound's
+existing annotations while it computes a fresh replacement separately, and
+making it propagate there causes a real crash. The other subclasses that
+could smear a primary onto a component (`AnnotatedArrayType`,
+`AnnotatedDeclaredType`, `AnnotatedUnionType`) do not do so in the first
+place, so they have no equivalent gap.
+
 `BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
 JDK-8054309 collapsed-wildcard-bound comparison to a new overridable
 `areCollapsedWildcardBoundsEqual` method, instead of inlining a bidirectional

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -262,16 +262,20 @@ summary from the adapted bounds: that call was already a no-op (the copy's
 own primary annotation starts empty), and clearing there now would discard
 the adapted bounds' qualifiers before they are read.
 
-`AnnotatedWildcardType.clearAnnotations()` now likewise also clears both
-bounds' annotations, for the same reason and matching its own
-`addAnnotation`/`removeAnnotation`, which already propagated. Auditing
-every other `AnnotatedTypeMirror` subclass for the same gap found one more
-candidate, `AnnotatedTypeVariable`, but its bounds are not made to
-propagate: at least one caller (`AsSuperVisitor.visitTypevar_Typevar`)
-relies on the current, primary-only behavior to avoid disturbing a bound's
-existing annotations while it computes a fresh replacement separately, and
-making it propagate there causes a real crash. The other subclasses that
-could smear a primary onto a component (`AnnotatedArrayType`,
+`AnnotatedWildcardType.clearAnnotations()` and
+`AnnotatedTypeVariable.clearAnnotations()` now likewise also clear their
+bounds' annotations, for the same reason and matching their own
+`addAnnotation`/`removeAnnotation`, which already propagated. Making
+`AnnotatedTypeVariable` consistent this way surfaced a latent bug in
+`AnnotatedTypes.glbSubtype` (used during capture conversion): it deep-copies
+a type variable, clears the copy's annotations to recompute its own primary
+per hierarchy, and previously relied on the copy's bounds keeping their
+original annotations for any hierarchy it did not go on to explicitly
+restrict -- a safe assumption when clearing was primary-only, but not once
+clearing reached the bounds too. `glbSubtype` now snapshots the copy's
+bounds before clearing and restores them (at whatever nesting depth) as the
+starting point that logic already assumed. The other subclasses that could
+smear a primary onto a component (`AnnotatedArrayType`,
 `AnnotatedDeclaredType`, `AnnotatedUnionType`) do not do so in the first
 place, so they have no equivalent gap.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -267,17 +267,20 @@ the adapted bounds' qualifiers before they are read.
 bounds' annotations, for the same reason and matching their own
 `addAnnotation`/`removeAnnotation`, which already propagated. Making
 `AnnotatedTypeVariable` consistent this way surfaced a latent bug in
-`AnnotatedTypes.glbSubtype` (used during capture conversion): it deep-copies
-a type variable, clears the copy's annotations to recompute its own primary
-per hierarchy, and previously relied on the copy's bounds keeping their
-original annotations for any hierarchy it did not go on to explicitly
-restrict -- a safe assumption when clearing was primary-only, but not once
-clearing reached the bounds too. `glbSubtype` now snapshots the copy's
-bounds before clearing and restores them (at whatever nesting depth) as the
-starting point that logic already assumed. The other subclasses that could
-smear a primary onto a component (`AnnotatedArrayType`,
-`AnnotatedDeclaredType`, `AnnotatedUnionType`) do not do so in the first
-place, so they have no equivalent gap.
+`AnnotatedTypes.glbSubtype` (used during capture conversion): it copies a
+type variable or wildcard, clears the copy's annotations to recompute its
+own primary per hierarchy, and previously relied on the copy's bounds
+keeping their original annotations for any hierarchy it did not go on to
+explicitly restrict -- a safe assumption when clearing was primary-only,
+but not once clearing reached the bounds too. `glbSubtype` now builds that
+copy with `shallowCopy(false)` instead of `deepCopy()` plus
+`clearAnnotations()`: for a type variable or wildcard, `shallowCopy(false)`
+already means exactly that (see its own Javadoc), so the bounds keep their
+original annotations for free, at any nesting depth, without a separate
+snapshot-and-restore step. The other composite subclasses
+(`AnnotatedArrayType`, `AnnotatedDeclaredType`, `AnnotatedUnionType`) do not
+smear a primary onto their components at all, so they have no equivalent
+gap.
 
 `BaseTypeValidator.checkExplicitSuperBoundWildcards` now delegates its
 JDK-8054309 collapsed-wildcard-bound comparison to a new overridable

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -888,7 +888,12 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         return changed;
     }
 
-    /** Removes all primary annotations on this type. */
+    /**
+     * Removes all primary annotations on this type and, in the case of {@link
+     * AnnotatedTypeVariable}s, {@link AnnotatedWildcardType}s, and {@link
+     * AnnotatedIntersectionType}s, clears all bounds too, matching {@link #addAnnotation} and
+     * {@link #removeAnnotation}, which already propagate to bounds for those three kinds.
+     */
     // typetools: clearPrimaryAnnotations
     public void clearAnnotations() {
         checkMutable();

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -3112,6 +3112,36 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
 
     // TODO: Ensure union types are handled everywhere.
     // TODO: Should field "annotations" contain anything?
+    /**
+     * Represents a union type, the type of a multi-catch parameter (for example, {@code catch
+     * (IOException | SQLException e)}).
+     *
+     * <p>Unlike {@link AnnotatedIntersectionType}, {@link AnnotatedTypeVariable}, and {@link
+     * AnnotatedWildcardType}, this class does not override {@code addAnnotation}, {@code
+     * removeAnnotation}, or {@code clearAnnotations} to propagate to its components ({@link
+     * #getAlternatives()}), and must not: those three types' bounds are meant to be homogenized
+     * (every bound shares the same qualifier per hierarchy, since the type IS-A each of its bounds
+     * simultaneously), but a union's alternatives are meant to stay heterogeneous. {@code catch
+     * (IOException | SQLException e)} can legitimately have a different qualifier on {@code
+     * IOException} than on {@code SQLException}; {@link
+     * org.checkerframework.common.basetype.BaseTypeVisitor#checkExceptionParameter} and {@link
+     * org.checkerframework.common.basetype.BaseTypeVisitor#checkThrownExpression} both validate
+     * this type's own primary annotation and each alternative independently rather than assuming
+     * they agree. Propagating like the other three types would forcibly overwrite (on {@code
+     * addAnnotation}) or erase (on {@code removeAnnotation}/{@code clearAnnotations}) that
+     * per-alternative information instead of preserving it.
+     *
+     * <p>This type's own primary annotation is instead a <em>derived</em> summary of the
+     * alternatives -- the least upper bound of their qualifiers, not a value that gets pushed down
+     * onto them -- computed by {@code AsSuperVisitor.ensurePrimaryIsCorrectForUnions}, since every
+     * alternative must be assignable to a catch parameter of this union type. A caller that does
+     * need to push one qualifier onto every alternative -- for example, applying the same default
+     * to an entirely unannotated {@code catch} parameter -- does so with {@code
+     * addMissingAnnotation(s)}, which only fills a hierarchy an alternative doesn't already have an
+     * opinion on, rather than {@code addAnnotation}, which would overwrite one it does. See {@code
+     * AsSuperVisitor#copyPrimaryAnnos}'s union case and {@code QualifierDefaults}'s {@code
+     * EXCEPTION_PARAMETER} case.
+     */
     public static class AnnotatedUnionType extends AnnotatedTypeMirror {
 
         /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2194,6 +2194,26 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         }
 
         /**
+         * {@inheritDoc}
+         *
+         * <p>Also clears both bounds' annotations, for the same reason {@link
+         * #removeAnnotation(AnnotationMirror)} does: leaving a bound's annotations in place while
+         * clearing only this type variable's own primary annotation would let a bound keep a stale
+         * qualifier that a caller clearing this type is trying to discard, with no local signal
+         * that the two had gone out of sync.
+         */
+        @Override
+        public void clearAnnotations() {
+            super.clearAnnotations();
+            if (lowerBound != null) {
+                lowerBound.clearAnnotations();
+            }
+            if (upperBound != null) {
+                upperBound.clearAnnotations();
+            }
+        }
+
+        /**
          * Change whether this {@code AnnotatedTypeVariable} is considered a use or a declaration
          * (use this method with caution).
          *

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -3115,8 +3115,6 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         }
     }
 
-    // TODO: Ensure union types are handled everywhere.
-    // TODO: Should field "annotations" contain anything?
     /**
      * Represents a union type, the type of a multi-catch parameter (for example, {@code catch
      * (IOException | SQLException e)}).
@@ -3126,9 +3124,9 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
      * removeAnnotation}, or {@code clearAnnotations} to propagate to its components ({@link
      * #getAlternatives()}), and must not: those three types' bounds are meant to be homogenized
      * (every bound shares the same qualifier per hierarchy, since the type IS-A each of its bounds
-     * simultaneously), but a union's alternatives are meant to stay heterogeneous. {@code catch
-     * (IOException | SQLException e)} can legitimately have a different qualifier on {@code
-     * IOException} than on {@code SQLException}; {@link
+     * simultaneously), but a union's alternatives are meant to stay heterogeneous -- the example
+     * above can legitimately have a different qualifier on {@code IOException} than on {@code
+     * SQLException}. {@link
      * org.checkerframework.common.basetype.BaseTypeVisitor#checkExceptionParameter} and {@link
      * org.checkerframework.common.basetype.BaseTypeVisitor#checkThrownExpression} both validate
      * this type's own primary annotation and each alternative independently rather than assuming
@@ -3147,6 +3145,8 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
      * AsSuperVisitor#copyPrimaryAnnos}'s union case and {@code QualifierDefaults}'s {@code
      * EXCEPTION_PARAMETER} case.
      */
+    // TODO: Ensure union types are handled everywhere.
+    // TODO: Should field "annotations" contain anything?
     public static class AnnotatedUnionType extends AnnotatedTypeMirror {
 
         /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2630,6 +2630,26 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         }
 
         /**
+         * {@inheritDoc}
+         *
+         * <p>Also clears both bounds' annotations, for the same reason {@link
+         * #removeAnnotation(AnnotationMirror)} does: leaving a bound's annotations in place while
+         * clearing only this wildcard's own primary annotation would let a bound keep a stale
+         * qualifier that a caller clearing this type is trying to discard, with no local signal
+         * that the two had gone out of sync.
+         */
+        @Override
+        public void clearAnnotations() {
+            super.clearAnnotations();
+            if (superBound != null) {
+                superBound.clearAnnotations();
+            }
+            if (extendsBound != null) {
+                extendsBound.clearAnnotations();
+            }
+        }
+
+        /**
          * Sets the super bound of this wildcard.
          *
          * <p>This method is for framework usage only.

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1032,7 +1032,26 @@ public class AnnotatedTypes {
             AnnotatedTypeMirror subtype,
             AnnotatedTypeMirror supertype) {
         AnnotatedTypeMirror glb = subtype.deepCopy();
+        // clearAnnotations() also clears a type variable's bounds (recursively, at every nested
+        // level), but this method's loop below only overwrites a bound when a hierarchy
+        // specifically needs restricting; every other hierarchy, at every nesting depth, is meant
+        // to keep subtype's own (deep-copied) bound annotation, as it did before the clear.
+        // Snapshot glb's bounds (a full structural deep copy of subtype's own bounds) before
+        // clearing, and restore that snapshot afterward as the starting point the loop below
+        // selectively overrides.
+        AnnotatedTypeMirror preClearUpperBound = null;
+        AnnotatedTypeMirror preClearLowerBound = null;
+        if (glb.getKind() == TypeKind.TYPEVAR) {
+            AnnotatedTypeVariable glbVar = (AnnotatedTypeVariable) glb;
+            preClearUpperBound = glbVar.getUpperBound().deepCopy();
+            preClearLowerBound = glbVar.getLowerBound().deepCopy();
+        }
         glb.clearAnnotations();
+        if (glb.getKind() == TypeKind.TYPEVAR) {
+            AnnotatedTypeVariable glbVar = (AnnotatedTypeVariable) glb;
+            glbVar.setUpperBound(preClearUpperBound);
+            glbVar.setLowerBound(preClearLowerBound);
+        }
 
         TypeMirror subTM = subtype.getUnderlyingType();
         TypeMirror superTM = supertype.getUnderlyingType();

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1031,26 +1031,19 @@ public class AnnotatedTypes {
             QualifierHierarchy qualHierarchy,
             AnnotatedTypeMirror subtype,
             AnnotatedTypeMirror supertype) {
-        AnnotatedTypeMirror glb = subtype.deepCopy();
-        // clearAnnotations() also clears a type variable's bounds (recursively, at every nested
-        // level), but this method's loop below only overwrites a bound when a hierarchy
-        // specifically needs restricting; every other hierarchy, at every nesting depth, is meant
-        // to keep subtype's own (deep-copied) bound annotation, as it did before the clear.
-        // Snapshot glb's bounds (a full structural deep copy of subtype's own bounds) before
-        // clearing, and restore that snapshot afterward as the starting point the loop below
-        // selectively overrides.
-        AnnotatedTypeMirror preClearUpperBound = null;
-        AnnotatedTypeMirror preClearLowerBound = null;
-        if (glb.getKind() == TypeKind.TYPEVAR) {
-            AnnotatedTypeVariable glbVar = (AnnotatedTypeVariable) glb;
-            preClearUpperBound = glbVar.getUpperBound().deepCopy();
-            preClearLowerBound = glbVar.getLowerBound().deepCopy();
-        }
-        glb.clearAnnotations();
-        if (glb.getKind() == TypeKind.TYPEVAR) {
-            AnnotatedTypeVariable glbVar = (AnnotatedTypeVariable) glb;
-            glbVar.setUpperBound(preClearUpperBound);
-            glbVar.setLowerBound(preClearLowerBound);
+        // glb's own primary annotations are recomputed per hierarchy below, so start from a copy
+        // of subtype that has none. For a type variable or wildcard, use shallowCopy(false): a
+        // deep copy (they can't be shallow-copied; see their shallowCopy Javadoc) whose primary
+        // annotation set alone is cleared. Plain clearAnnotations() would clear the bounds too
+        // (recursively, at any nesting depth), but the loop below overwrites a bound only in a
+        // hierarchy that needs restricting; every other hierarchy is meant to keep subtype's own
+        // bound annotations exactly as they were, which shallowCopy(false) preserves for free.
+        AnnotatedTypeMirror glb;
+        if (subtype.getKind() == TypeKind.TYPEVAR || subtype.getKind() == TypeKind.WILDCARD) {
+            glb = subtype.shallowCopy(false);
+        } else {
+            glb = subtype.deepCopy();
+            glb.clearAnnotations();
         }
 
         TypeMirror subTM = subtype.getUnderlyingType();


### PR DESCRIPTION
## Summary

`#1944` made `AnnotatedIntersectionType.clearAnnotations()` propagate to
bounds, matching `addAnnotation`/`removeAnnotation`, which already did.
This audits every other `AnnotatedTypeMirror` subclass for the same gap.

**Fixed:** `AnnotatedWildcardType.clearAnnotations()` and
`AnnotatedTypeVariable.clearAnnotations()` now also clear their bounds'
annotations, for the same reason `#1944` gave for intersections and
matching their own `addAnnotation`/`removeAnnotation`, which already
propagated.

Making `AnnotatedTypeVariable` consistent this way initially crashed
`framework/tests/all-systems/AsSuperCrashes.java` with a
`NullPointerException`. The true root cause was not `AsSuperVisitor` (an
earlier, incorrect diagnosis) but a latent bug in
`AnnotatedTypes.glbSubtype`, used during capture conversion: it copied a
type variable or wildcard, cleared the copy's annotations to recompute its
own primary per hierarchy, and relied on the copy's bounds keeping their
original annotations for any hierarchy it did not go on to explicitly
restrict -- a safe assumption when clearing was primary-only, but not once
clearing reached the bounds too.

`glbSubtype` now builds that copy with `shallowCopy(false)` instead of a
plain `deepCopy()` + `clearAnnotations()`: for a type variable or wildcard,
`shallowCopy(false)` already means exactly that (see its own Javadoc), so
the bounds keep their original annotations for free, at any nesting depth,
with a single structural copy. (An Opus review of this branch caught that
this is both cheaper and more correct than an earlier deep-copy-snapshot-
and-restore fix, which worked but did three structural copies instead of
one and could disturb structural self-reference for recursive type
variables like `<T extends Comparable<T>>`.)

**Not changed:** `AnnotatedUnionType` does not get the same propagation
treatment. Its class Javadoc now explains why: a union's alternatives are
meant to stay heterogeneous (`catch (IOException | SQLException e)` can
legitimately have a different qualifier on each alternative), unlike the
bounds of the other three types, which are meant to be homogenized.
`AnnotatedArrayType` and `AnnotatedDeclaredType` don't smear a primary onto
their components at all, so they have no equivalent gap either.

## Test plan

- [x] `./gradlew :framework:test` (full suite) -- green
- [x] `./gradlew :checker:test` (full suite) -- green
- [x] `./gradlew :framework:spotlessApply` -- no changes
- [x] Both crash repros (`framework/tests/all-systems/AsSuperCrashes.java`
      and `framework/tests/all-systems/PQueue.java`, the latter needed to
      catch a nested-type-variable-bound gap in an earlier fix attempt)
      verified directly via `checker/bin/javac -processor value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLj2wCz6koCVrfLhHkN5R
