### PR TITLE
Test that capture keeps an explicitly-written wildcard bound qualifier

### DIFF
--- a/checker/tests/nullness/generics/CapturedWildcards.java
+++ b/checker/tests/nullness/generics/CapturedWildcards.java
@@ -15,4 +15,41 @@ public class CapturedWildcards {
         // :: error: (dereference.of.nullable)
         return list.stream().anyMatch(je -> je.contains(other));
     }
+
+    // The capture of a wildcard must keep the qualifier that was written on the wildcard's bound,
+    // rather than the qualifier that the type parameter's declaration would default to. The
+    // enhanced for loops below read `list` bare -- the read itself is what capture-converts the
+    // type, with no type-variable substitution involved -- so the loop variable's type is the
+    // captured type variable, and its upper bound decides whether the dereference is an error.
+
+    public void bareReadNullableBound(List<? extends @Nullable MyClass> list) {
+        for (MyClass elt : list) {
+            // :: error: (dereference.of.nullable)
+            elt.toString();
+        }
+    }
+
+    public void bareReadNonNullBound(List<? extends MyClass> list) {
+        for (MyClass elt : list) {
+            elt.toString();
+        }
+    }
+
+    public void bareReadNullableBoundOfNullableTypeParameter(
+            MyList<? extends @Nullable MyClass> list) {
+        for (MyClass elt : list) {
+            // :: error: (dereference.of.nullable)
+            elt.toString();
+        }
+    }
+
+    // The wildcard bound is more restrictive than the type parameter's declared bound, so the
+    // capture's upper bound is the wildcard's.
+    public void bareReadNonNullBoundOfNullableTypeParameter(MyList<? extends MyClass> list) {
+        for (MyClass elt : list) {
+            elt.toString();
+        }
+    }
+
+    interface MyList<T extends @Nullable Object> extends Iterable<T> {}
 }


### PR DESCRIPTION
## Summary

Adds regression-test coverage for capture conversion of a bare (non-member-access) read of a wildcard-typed variable, e.g.:

```java
void bareReadNullableBound(List<? extends @Nullable MyClass> list) {
  for (MyClass elt : list) {
    elt.toString(); // should be flagged
  }
}
```

Investigation for a JSpecify conformance-corpus gap initially suspected that `AnnotatedTypeFactory.annotateCapturedTypeVar`'s GLB computation for the captured type variable's upper bound was preferring the type parameter's *declared* upper-bound qualifier over the qualifier explicitly written on the wildcard's `extends` bound. Instrumentation showed that's not the case: CF's capture conversion already produces the correct answer here. The apparent bug in the original repro came from an unrelated classpath ordering issue (a downstream checker's own annotated JDK being shadowed by `checker.jar`'s), not from this code path.

No behavior changes; this PR only adds test cases (four enhanced-for scenarios in `CapturedWildcards.java`: `@Nullable`/unannotated wildcard bound, each over `java.util.List` and over a locally declared `MyList<T extends @Nullable Object>`) to pin down that CF already handles this correctly, since no existing test previously covered a bare read.

## Test plan

- [x] `./gradlew :checker:test --tests "*NullnessTest*"` — pass
- [x] `./gradlew :framework:test :checker:test` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)