### PR TITLE
BaseTypeVisitor: fix `-AcheckCastElementType` crash on downcasts

### DIFF
--- a/checker/tests/nullness-checkcastelementtype/Downcast.java
+++ b/checker/tests/nullness-checkcastelementtype/Downcast.java
@@ -11,6 +11,9 @@ public class Downcast {
 
     interface SubSupplier<T extends @Nullable Object> extends Supplier<T> {}
 
+    interface SubSupplierExtra<T extends @Nullable Object, U extends @Nullable Object>
+            extends Supplier<T> {}
+
     interface Unrelated<T extends @Nullable Object> {}
 
     interface UnrelatedNoTypeArgs {}
@@ -66,5 +69,18 @@ public class Downcast {
         // number of type arguments.
         // :: warning: (cast.unsafe)
         UnrelatedNoTypeArgs cast = (UnrelatedNoTypeArgs) supplier;
+    }
+
+    void downcastFromWildcard(Supplier<?> supplier) {
+        // The source's type argument is an unbounded wildcard, so there is nothing more specific
+        // to compare against the cast type's type argument.
+        SubSupplier<@Nullable String> cast = (SubSupplier<@Nullable String>) supplier;
+    }
+
+    void downcastToExtraTypeArgument(Supplier<@Nullable String> supplier) {
+        // The cast type declares a type argument, U, that Supplier does not have.
+        SubSupplierExtra<@Nullable String, @Nullable String> cast =
+                // :: warning: (cast.unsafe)
+                (SubSupplierExtra<@Nullable String, @Nullable String>) supplier;
     }
 }

--- a/checker/tests/nullness-checkcastelementtype/Downcast.java
+++ b/checker/tests/nullness-checkcastelementtype/Downcast.java
@@ -49,6 +49,18 @@ public class Downcast {
         Unrelated<String> cast = (Unrelated<String>) supplier;
     }
 
+    <T extends @Nullable Object> void castToOtherTypeArgument(List<T> list) {
+        // The type hierarchy cannot compare the type arguments T and Number.
+        // :: warning: (cast.unsafe)
+        List<Number> cast = (List<Number>) list;
+    }
+
+    <T extends @Nullable Object> void downcastToOtherTypeArgument(List<T> list) {
+        // The type hierarchy cannot compare the type arguments T and Number.
+        // :: warning: (cast.unsafe)
+        ArrayList<Number> cast = (ArrayList<Number>) list;
+    }
+
     void crossCastNoTypeArgs(Supplier<String> supplier) {
         // The warning is issued because the cast type and the expression's type have a different
         // number of type arguments.

--- a/checker/tests/nullness-checkcastelementtype/Downcast.java
+++ b/checker/tests/nullness-checkcastelementtype/Downcast.java
@@ -1,0 +1,58 @@
+// Test case for casts whose cast type is not a supertype of the type of the cast expression.
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("unchecked") // The casts are unchecked casts.
+public class Downcast {
+    interface Supplier<T extends @Nullable Object> {}
+
+    interface SubSupplier<T extends @Nullable Object> extends Supplier<T> {}
+
+    interface Unrelated<T extends @Nullable Object> {}
+
+    interface UnrelatedNoTypeArgs {}
+
+    <T extends @Nullable Object> void downcastTypeVariable(Supplier<T> supplier) {
+        SubSupplier<T> cast = (SubSupplier<T>) supplier;
+    }
+
+    void downcastSafe(Supplier<@Nullable String> supplier) {
+        SubSupplier<@Nullable String> cast = (SubSupplier<@Nullable String>) supplier;
+    }
+
+    void downcastUnsafe(Supplier<@Nullable String> supplier) {
+        // :: warning: (cast.unsafe)
+        SubSupplier<String> cast = (SubSupplier<String>) supplier;
+    }
+
+    void downcastUnsafeNested(Supplier<List<@Nullable String>> supplier) {
+        // :: warning: (cast.unsafe)
+        SubSupplier<List<String>> cast = (SubSupplier<List<String>>) supplier;
+    }
+
+    void downcastFromObject(Object o) {
+        // The cast type has type arguments that the expression's type does not have.
+        // :: warning: (cast.unsafe)
+        List<String> cast = (List<String>) o;
+    }
+
+    void downcastToSubclass(List<String> list) {
+        ArrayList<String> cast = (ArrayList<String>) list;
+    }
+
+    void crossCast(Supplier<String> supplier) {
+        // Nothing is known about the type arguments of an unrelated type.
+        // :: warning: (cast.unsafe)
+        Unrelated<String> cast = (Unrelated<String>) supplier;
+    }
+
+    void crossCastNoTypeArgs(Supplier<String> supplier) {
+        // The warning is issued because the cast type and the expression's type have a different
+        // number of type arguments.
+        // :: warning: (cast.unsafe)
+        UnrelatedNoTypeArgs cast = (UnrelatedNoTypeArgs) supplier;
+    }
+}

--- a/checker/tests/nullness-checkcastelementtype/InstanceOfPatternDowncast.java
+++ b/checker/tests/nullness-checkcastelementtype/InstanceOfPatternDowncast.java
@@ -1,0 +1,24 @@
+// isTypeCastSafe (fixed for downcasts in BaseTypeVisitor) is also called from
+// visitInstanceOf's binding-pattern check, not just from checkTypecastSafety. Test that call
+// site too, so that a downcast-shaped instanceof pattern does not crash the way a downcast cast
+// expression used to.
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class InstanceOfPatternDowncast {
+    interface Supplier<T extends @Nullable Object> {}
+
+    interface SubSupplier<T extends @Nullable Object> extends Supplier<T> {}
+
+    void test(Supplier<@Nullable String> supplier) {
+        // TODO: this narrows the type argument's nullness (@Nullable String to String) the same
+        // way Downcast.java's downcastUnsafe does via an explicit cast, but -AcheckCastElementType
+        // does not warn here. visitInstanceOf's binding-pattern check shares isTypeCastSafe with
+        // the cast check, so this looks like a pre-existing, separate gap in that call site
+        // (not something this file's downcast fix introduced or fixes) rather than a difference
+        // in what is safe.
+        if (supplier instanceof SubSupplier<String> sub) {
+            sub.toString();
+        }
+    }
+}

--- a/checker/tests/nullness-checkcastelementtype/InstanceOfPatternDowncast.java
+++ b/checker/tests/nullness-checkcastelementtype/InstanceOfPatternDowncast.java
@@ -1,3 +1,4 @@
+// @below-java17-jdk-skip-test
 // isTypeCastSafe (fixed for downcasts in BaseTypeVisitor) is also called from
 // visitInstanceOf's binding-pattern check, not just from checkTypecastSafety. Test that call
 // site too, so that a downcast-shaped instanceof pattern does not crash the way a downcast cast

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -211,6 +211,18 @@ annotation from `V`'s own upper bound (e.g. `Object`'s) onto the capture,
 one level too deep; it now installs `V`'s own annotation, which is typically
 absent for a bare, unannotated type-variable use.
 
+Fixed a crash (`AsSuperVisitor: type is not an erased subtype of supertype`)
+when `-AcheckCastElementType` checked a cast whose cast type is not a supertype
+of the type of the cast expression: a downcast such as `(ArrayList<String>)
+list`, or a cast between unrelated types such as two interfaces. The check
+asked the type hierarchy whether the expression's type is a subtype of the cast
+type, which only holds for an upcast. For a downcast, the cast type is now
+viewed as the expression's type, so that the type arguments the two types have
+in common are compared. For a cast between unrelated types, nothing is known
+about the cast type's type arguments, so the cast is reported as not statically
+verifiable, as a cast to a type with a different number of type arguments
+already was.
+
 **Implementation details:**
 
 `AnnotatedIntersectionType.summarizeBounds` computes the summary described

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -223,6 +223,14 @@ about the cast type's type arguments, so the cast is reported as not statically
 verifiable, as a cast to a type with a different number of type arguments
 already was.
 
+A cast whose types the type hierarchy cannot compare no longer crashes
+`-AcheckCastElementType` either; it is reported as not statically verifiable.
+For example, `(List<Number>) list`, where `list` has type `List<T>`, makes the
+type hierarchy compare the type argument `Number` with the type variable `T`,
+a combination for which `StructuralEqualityComparer` has no case. A cast is the
+only place where the type hierarchy is asked about types that Java's own
+subtyping does not relate.
+
 **Implementation details:**
 
 `AnnotatedIntersectionType.summarizeBounds` computes the summary described

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2975,7 +2975,34 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             }
             TypeMirror newExprTM = newExprType.getUnderlyingType();
 
-            if (!typeHierarchy.isSubtype(newExprType, newCastType)) {
+            // TypeHierarchy#isSubtype may only be called if the underlying Java type of its first
+            // argument is a subtype of the underlying Java type of its second argument.  That
+            // holds for an upcast, but not for a downcast such as "(ArrayList<String>) list", nor
+            // for a cross-cast between unrelated types such as two interfaces.
+            if (TypesUtils.isErasedSubtype(newExprTM, newCastTM, types)) {
+                if (!typeHierarchy.isSubtype(newExprType, newCastType)) {
+                    return false;
+                }
+            } else if (TypesUtils.isErasedSubtype(newCastTM, newExprTM, types)) {
+                // This is a downcast.  View the cast type as the expression's type; this
+                // substitutes the cast type's type arguments into the expression's type.  Compare
+                // that with the expression's type, which checks the type arguments that the two
+                // types have in common.  (A downcast guarantees nothing about type arguments that
+                // only the cast type has; the check of the number of type arguments below warns
+                // about those.)
+                AnnotatedTypeMirror castTypeAsExprType =
+                        AnnotatedTypes.asSuper(atypeFactory, newCastType, newExprType);
+                if (!typeHierarchy.isSubtype(newExprType, castTypeAsExprType)) {
+                    return false;
+                }
+            } else if (newCastType.getKind() == TypeKind.DECLARED
+                    && newExprType.getKind() == TypeKind.DECLARED
+                    && !((AnnotatedDeclaredType) newCastType).isUnderlyingTypeRaw()
+                    && !((AnnotatedDeclaredType) newCastType).getTypeArguments().isEmpty()) {
+                // The Java types are unrelated, as in a cast between two interfaces.  The
+                // expression's type says nothing about the cast type's type arguments, so warn,
+                // as is done below for a cast to a type with a different number of type
+                // arguments.
                 return false;
             }
             if (newCastType.getKind() == TypeKind.ARRAY

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2979,30 +2979,42 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             // argument is a subtype of the underlying Java type of its second argument.  That
             // holds for an upcast, but not for a downcast such as "(ArrayList<String>) list", nor
             // for a cross-cast between unrelated types such as two interfaces.
-            if (TypesUtils.isErasedSubtype(newExprTM, newCastTM, types)) {
-                if (!typeHierarchy.isSubtype(newExprType, newCastType)) {
+            try {
+                if (TypesUtils.isErasedSubtype(newExprTM, newCastTM, types)) {
+                    if (!typeHierarchy.isSubtype(newExprType, newCastType)) {
+                        return false;
+                    }
+                } else if (TypesUtils.isErasedSubtype(newCastTM, newExprTM, types)) {
+                    // This is a downcast.  View the cast type as the expression's type; this
+                    // substitutes the cast type's type arguments into the expression's type.
+                    // Compare that with the expression's type, which checks the type arguments
+                    // that the two types have in common.  (A downcast guarantees nothing about
+                    // type arguments that only the cast type has; the check of the number of type
+                    // arguments below warns about those.)
+                    AnnotatedTypeMirror castTypeAsExprType =
+                            AnnotatedTypes.asSuper(atypeFactory, newCastType, newExprType);
+                    if (!typeHierarchy.isSubtype(newExprType, castTypeAsExprType)) {
+                        return false;
+                    }
+                } else if (newCastType.getKind() == TypeKind.DECLARED
+                        && newExprType.getKind() == TypeKind.DECLARED
+                        && !((AnnotatedDeclaredType) newCastType).isUnderlyingTypeRaw()
+                        && !((AnnotatedDeclaredType) newCastType).getTypeArguments().isEmpty()) {
+                    // The Java types are unrelated, as in a cast between two interfaces.  The
+                    // expression's type says nothing about the cast type's type arguments, so
+                    // warn, as is done below for a cast to a type with a different number of type
+                    // arguments.
                     return false;
                 }
-            } else if (TypesUtils.isErasedSubtype(newCastTM, newExprTM, types)) {
-                // This is a downcast.  View the cast type as the expression's type; this
-                // substitutes the cast type's type arguments into the expression's type.  Compare
-                // that with the expression's type, which checks the type arguments that the two
-                // types have in common.  (A downcast guarantees nothing about type arguments that
-                // only the cast type has; the check of the number of type arguments below warns
-                // about those.)
-                AnnotatedTypeMirror castTypeAsExprType =
-                        AnnotatedTypes.asSuper(atypeFactory, newCastType, newExprType);
-                if (!typeHierarchy.isSubtype(newExprType, castTypeAsExprType)) {
-                    return false;
-                }
-            } else if (newCastType.getKind() == TypeKind.DECLARED
-                    && newExprType.getKind() == TypeKind.DECLARED
-                    && !((AnnotatedDeclaredType) newCastType).isUnderlyingTypeRaw()
-                    && !((AnnotatedDeclaredType) newCastType).getTypeArguments().isEmpty()) {
-                // The Java types are unrelated, as in a cast between two interfaces.  The
-                // expression's type says nothing about the cast type's type arguments, so warn,
-                // as is done below for a cast to a type with a different number of type
-                // arguments.
+            } catch (BugInCF e) {
+                // A cast may relate types that the type hierarchy cannot compare, even when their
+                // erasures are in a subtype relationship.  For example, for the cast
+                // "(List<Number>) list" where list has type "List<T>", the type hierarchy compares
+                // the type arguments Number and T, and StructuralEqualityComparer has no case for
+                // a declared type and a type variable.  Report the cast as not statically
+                // verifiable rather than aborting the compilation.  DefaultTypeHierarchy#isSubtype
+                // clears its visit histories in a finally block, so a thrown exception leaves no
+                // stale state behind.
                 return false;
             }
             if (newCastType.getKind() == TypeKind.ARRAY


### PR DESCRIPTION
## Summary

`-AcheckCastElementType` (the option that makes CF's cast-safety check look past primary qualifiers into a cast's nested type arguments) crashed with `BugInCF` in `AsSuperVisitor` on essentially any generic downcast or cross-cast, e.g.:

```java
interface Supplier<T extends @Nullable Object> {}
interface NonnullSupplier<T> extends Supplier<T> {}

<T extends @Nullable Object> void test(Supplier<T> supplier) {
  NonnullSupplier<T> cast = (NonnullSupplier<T>) supplier; // crashed
}
```

`checkTypecastSafety`'s downcast path was calling `DefaultTypeHierarchy.isSubtype(exprType, castType)` — ordinary subtype-checking machinery whose own javadoc says not to call it this way, because the underlying Java types aren't in the right subtyping relationship for a downcast. That question reaches `AsSuperVisitor`, which has no graceful fallback and throws unconditionally when asked about a pair with no real subtype relationship.

* `BaseTypeVisitor: check the element types of a downcast without crashing` — fixes this entirely inside `BaseTypeVisitor.isTypeCastSafe`: for a downcast, view the *cast type as the expression's type* (`AnnotatedTypes.asSuper`) and compare from there, checking exactly the type arguments the two types share. Cross-casts to unrelated parameterized types now warn (previously crashed) instead of being silently unchecked.
* `BaseTypeVisitor: report a cast the type hierarchy cannot check, don't crash` — guards a second, independent, pre-existing crash (type-variable vs. concrete-type mismatches, e.g. `(List<Number>) listOfT`, crashing in both cast directions on master today) by reporting `cast.unsafe` instead of aborting compilation.
* `Test more cast-shape coverage for -AcheckCastElementType downcasts` — two more structural shapes (downcast from an unbounded wildcard source; downcast to a type with an additional type parameter), found by cross-referencing pre-existing disabled `TODO` assertions elsewhere in the test suite.

Regression tests added to `checker/tests/nullness-checkcastelementtype/Downcast.java` (an existing test directory/JUnit runner, not a new one) cover the original crash repro, safe/unsafe nullness-narrowing downcasts, nested type arguments, cross-casts, and both crash classes.

A corpus sweep of ~970 existing test files with `-AcheckCastElementType` enabled showed zero crashes after the fix.

Note: this does not by itself make `-AcheckCastElementType` produce every diagnostic a downstream checker might want (e.g. a cast that narrows a type parameter's *bound* rather than its element type is a different, unrelated check) — it only fixes the crash and correctly checks element-type safety for downcasts.

## Test plan

- [x] `./gradlew :framework:test :checker:test` — BUILD SUCCESSFUL
- [x] jtreg, typecheck, and other `alltests` components pass individually
- [x] Corpus sweep of `framework/tests/all-systems`, `checker/tests/all-systems`, `checker/tests/nullness` (970 files) with `-AcheckCastElementType` enabled: zero crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)