### PR TITLE
BaseTypeVisitor: sound-by-default type-parameter-bound override checking

### DIFF
--- a/checker/jtreg/nullness/issue824/Class2.java
+++ b/checker/jtreg/nullness/issue824/Class2.java
@@ -20,6 +20,10 @@ public class Class2<X> extends Class1<X> {
         class1.wildcardSuper(gen);
     }
 
+    // Class1's stub declares <T extends @NonNull Object>; this override's <T> widens the upper
+    // bound to the implicit @Nullable Object. That is a sound override of the type-parameter
+    // bound: this method's own body is still constrained by T's (unchanged, @NonNull) lower
+    // bound, so it cannot return a value the wider upper bound alone would not already permit.
     @Override
     public <T> T methodTypeParam(T t) {
         return super.methodTypeParam(t);

--- a/checker/jtreg/nullness/issue824/Class2.out
+++ b/checker/jtreg/nullness/issue824/Class2.out
@@ -4,6 +4,5 @@ Class2.java:15:47: compiler.err.proc.messager: (type.argument.type.incompatible)
 Class2.java:16:31: compiler.err.proc.messager: (type.arguments.not.inferred)
 Class2.java:19:31: compiler.err.proc.messager: (type.arguments.not.inferred)
 Class2.java:20:30: compiler.err.proc.messager: (argument.type.incompatible)
-Class2.java:24:16: compiler.err.proc.messager: (override.return.invalid)
-Class2.java:25:37: compiler.err.proc.messager: (type.arguments.not.inferred)
-8 errors
+Class2.java:29:37: compiler.err.proc.messager: (type.arguments.not.inferred)
+7 errors

--- a/checker/tests/interning/OverrideTypeParamBound.java
+++ b/checker/tests/interning/OverrideTypeParamBound.java
@@ -1,0 +1,55 @@
+// Regression tests for eisop#1965, checked independently of the Nullness Checker: the
+// override-type-parameter-bound check is a framework-level property of
+// BaseTypeVisitor.OverrideChecker, not specific to Nullness's qualifier hierarchy.
+
+import org.checkerframework.checker.interning.qual.Interned;
+import org.checkerframework.checker.interning.qual.UnknownInterned;
+
+class OverrideTypeParamBound {
+
+    // Positive control: identical bound, so nothing is reported.
+    static class SameBounds {
+        <T extends @UnknownInterned Object> void consume(T p) {}
+    }
+
+    static class SameBoundsOverride extends SameBounds {
+        @Override
+        <T extends @UnknownInterned Object> void consume(T p) {}
+    }
+
+    // Upper bound narrowed, type parameter used as a parameter. A caller going through the
+    // overridden method's declared bound may instantiate the type parameter with an
+    // @UnknownInterned value; if the override's own bound requires @Interned, it wrongly gets
+    // exercised with a value it cannot safely treat as interned.
+    static class Super {
+        <T extends @UnknownInterned Object> void consume(T p) {}
+    }
+
+    static class SubNarrowUpperParam extends Super {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <T extends @Interned Object> void consume(T p) {}
+    }
+
+    static void triggerNarrowUpperParam(Super s) {
+        // Not @Interned: a plain "new Object()" is never interned.
+        s.<Object>consume(new Object());
+    }
+
+    // Positive control: upper bound widened, type parameter used as a return type. The override's
+    // body is checked once against its own (wider) upper bound and cannot manufacture a value
+    // outside it, so every value it returns still satisfies Super2's narrower upper bound --
+    // sound containment, regardless of the type parameter's position.
+    static class Super2 {
+        <T extends @Interned Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+
+    static class SubWidenUpperReturn extends Super2 {
+        @Override
+        <T extends @UnknownInterned Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/checker/tests/interning/OverrideTypeParamBound.java
+++ b/checker/tests/interning/OverrideTypeParamBound.java
@@ -20,7 +20,9 @@ class OverrideTypeParamBound {
     // Upper bound narrowed, type parameter used as a parameter. A caller going through the
     // overridden method's declared bound may instantiate the type parameter with an
     // @UnknownInterned value; if the override's own bound requires @Interned, it wrongly gets
-    // exercised with a value it cannot safely treat as interned.
+    // exercised with a value it cannot safely treat as interned. The parameter occurrence is
+    // bare, so isParameterOverrideValid's own type-variable fallback independently reaches the
+    // same declared-bound mismatch and reports a second diagnostic.
     static class Super {
         <T extends @UnknownInterned Object> void consume(T p) {}
     }
@@ -28,6 +30,7 @@ class OverrideTypeParamBound {
     static class SubNarrowUpperParam extends Super {
         @Override
         // :: error: (override.typaram.invalid)
+        // :: error: (override.param.invalid)
         <T extends @Interned Object> void consume(T p) {}
     }
 

--- a/checker/tests/interning/OverrideTypeParamBound.java
+++ b/checker/tests/interning/OverrideTypeParamBound.java
@@ -39,10 +39,12 @@ class OverrideTypeParamBound {
         s.<Object>consume(new Object());
     }
 
-    // Positive control: upper bound widened, type parameter used as a return type. The override's
-    // body is checked once against its own (wider) upper bound and cannot manufacture a value
-    // outside it, so every value it returns still satisfies Super2's narrower upper bound --
-    // sound containment, regardless of the type parameter's position.
+    // Positive control: upper bound widened, type parameter used as a return type. What makes
+    // this sound is the LOWER bound, not the upper one: the override's body can only manufacture a
+    // fresh T from T's lower bound, which containment leaves unchanged (here it defaults to the
+    // Interning hierarchy's bottom, @InternedDistinct). Widening the upper bound merely makes the
+    // body more conservative about values it was handed; it grants no new ability to produce one.
+    // Sound containment, regardless of the type parameter's position.
     static class Super2 {
         <T extends @Interned Object> T produce() {
             throw new RuntimeException();

--- a/checker/tests/nullness/Issue577.java
+++ b/checker/tests/nullness/Issue577.java
@@ -11,6 +11,7 @@ class Banana<T extends Number> extends Apple<int[]> {
     class InnerBanana extends InnerApple<long[]> {
         @Override
         // :: error: (override.typaram.invalid)
+        // :: error: (override.param.invalid)
         <F2 extends Object> void foo(int[] array, long[] array2, F2 param3) {}
     }
 }

--- a/checker/tests/nullness/Issue577.java
+++ b/checker/tests/nullness/Issue577.java
@@ -10,7 +10,7 @@ class Banana<T extends Number> extends Apple<int[]> {
 
     class InnerBanana extends InnerApple<long[]> {
         @Override
-        // :: error: (override.param.invalid)
+        // :: error: (override.typaram.invalid)
         <F2 extends Object> void foo(int[] array, long[] array2, F2 param3) {}
     }
 }

--- a/checker/tests/nullness/OverrideTypeParamBound.java
+++ b/checker/tests/nullness/OverrideTypeParamBound.java
@@ -5,6 +5,12 @@
 // nested class below isolates one combination of which bound differs, in which direction, and how
 // the type parameter is used; several combinations are sound and expect no diagnostic, since
 // containment (not equality) is position-independent already.
+//
+// The final section below (Super9 through Super12) instead keeps both sides' type-parameter
+// declarations identical and requalifies a single parameter or return occurrence with its own
+// explicit annotation -- a containment mismatch entirely invisible to
+// isTypeParameterBoundOverrideValid, caught only by isParameterOverrideValid/
+// isReturnOverrideValid's own type-variable fallback (PR #1961 review, comment 5396576208).
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -56,7 +62,9 @@ public class OverrideTypeParamBound {
     // caller of the overridden signature may instantiate T as @NonNull, per Super's (narrower)
     // lower bound -- an NPE the checker is supposed to prevent. Containment requires the
     // override's lower bound to be a subtype of (i.e. at least as restrictive as) the overridden
-    // one, so widening it is still rejected.
+    // one, so widening it is still rejected. This return type occurrence is bare (no explicit
+    // annotation of its own), so isReturnOverrideValid's own type-variable fallback independently
+    // reaches the same, now-widened, declared lower bound and reports a second diagnostic.
 
     static class Super {
         <T extends @Nullable Object> T pick(T p) {
@@ -67,6 +75,7 @@ public class OverrideTypeParamBound {
     static class SubWidenLowerReturn extends Super {
         @Override
         // :: error: (override.typaram.invalid)
+        // :: error: (override.return.invalid)
         <@Nullable T extends @Nullable Object> T pick(T p) {
             T t = null;
             return t;
@@ -85,7 +94,9 @@ public class OverrideTypeParamBound {
     // ---- Upper bound narrowed, type parameter used as a parameter. ----
     // A caller of Super2's declared signature may pass an @Nullable value; SubNarrowUpperParam's
     // own upper bound only accepts @NonNull. Containment requires the overridden upper bound to
-    // be a subtype of the override's, so narrowing is rejected.
+    // be a subtype of the override's, so narrowing is rejected. The parameter occurrence is bare,
+    // so isParameterOverrideValid's own type-variable fallback independently reaches the same
+    // declared-bound mismatch and reports a second diagnostic.
 
     static class Super2 {
         <T extends @Nullable Object> void consume(T p) {}
@@ -94,6 +105,7 @@ public class OverrideTypeParamBound {
     static class SubNarrowUpperParam extends Super2 {
         @Override
         // :: error: (override.typaram.invalid)
+        // :: error: (override.param.invalid)
         <T extends @NonNull Object> void consume(T p) {}
     }
 
@@ -182,9 +194,11 @@ public class OverrideTypeParamBound {
     }
 
     // ---- Multiple type parameters: only the second one's bound differs. ----
-    // Confirms checkTypeParameterBounds compares type parameters positionally -- one diagnostic
+    // Confirms checkTypeParameterBounds compares type parameters positionally -- diagnostics only
     // for the mismatched index, none for the matching one -- not one verdict for the whole
-    // method.
+    // method. U's parameter occurrence is bare, so it draws a second diagnostic the same way the
+    // single-type-parameter cases above do; T's occurrence draws none, since T's own bound did
+    // not change.
 
     static class Super8 {
         <T extends @Nullable Object, U extends @Nullable Object> void consumeTwo(T p1, U p2) {}
@@ -196,6 +210,85 @@ public class OverrideTypeParamBound {
                         T extends @Nullable Object,
                         // :: error: (override.typaram.invalid)
                         U extends @NonNull Object>
+                // :: error: (override.param.invalid)
                 void consumeTwo(T p1, U p2) {}
+    }
+
+    // ---- Requalified occurrences: an explicit annotation on a parameter or return type, not on
+    // the type parameter's own declaration. Both type parameters below declare the identical bound
+    // <T extends @Nullable Object>, so checkTypeParameterBounds sees no mismatch; the unsoundness
+    // (eisop#1961 review, comment 5396576208) is entirely in the requalified occurrence, which only
+    // isParameterOverrideValid/isReturnOverrideValid's own type-variable fallback can see.
+
+    // Parameter requalified narrower than the shared declared bound: a caller of Super9's declared
+    // signature may pass an @Nullable value; SubRequalifiedParamNarrower's own parameter only
+    // accepts @NonNull, then dereferences it unconditionally.
+    static class Super9 {
+        <T extends @Nullable Object> void m(T p) {}
+    }
+
+    static class SubRequalifiedParamNarrower extends Super9 {
+        @Override
+        // :: error: (override.param.invalid)
+        <T extends @Nullable Object> void m(@NonNull T p) {
+            p.toString();
+        }
+    }
+
+    private static void triggerRequalifiedParamNarrower(Super9 s) {
+        s.<@Nullable String>m(null);
+    }
+
+    // Positive control: parameter requalified wider than the shared declared bound. Super10's own
+    // parameter already only accepts @NonNull; SubRequalifiedParamWider accepts the full
+    // (unrestricted, @Nullable) range T allows, a strictly weaker requirement -- sound, since every
+    // value a caller of Super10's declared signature could pass is also accepted here.
+    static class Super10 {
+        <T extends @Nullable Object> void m(@NonNull T p) {}
+    }
+
+    static class SubRequalifiedParamWider extends Super10 {
+        @Override
+        <T extends @Nullable Object> void m(T p) {}
+    }
+
+    // Return requalified wider than the shared declared bound: a caller of Super11's declared
+    // signature (via an explicit type witness) expects a @NonNull result; SubRequalifiedReturnWider
+    // always returns @Nullable, regardless of the type argument the caller chose.
+    static class Super11 {
+        <T extends @Nullable Object> T get(T p) {
+            return p;
+        }
+    }
+
+    static class SubRequalifiedReturnWider extends Super11 {
+        @Override
+        // :: error: (override.return.invalid)
+        <T extends @Nullable Object> @Nullable T get(T p) {
+            return null;
+        }
+    }
+
+    private static void triggerRequalifiedReturnWider(Super11 s) {
+        @NonNull String r = s.<@NonNull String>get("x");
+        System.out.println(r.length());
+    }
+
+    // Positive control: return requalified narrower than the shared declared bound. Super12's own
+    // return is already the full (unrestricted, @Nullable) range T allows;
+    // SubRequalifiedReturnNarrower always returns @NonNull, a strictly stronger guarantee -- sound,
+    // since a @NonNull value always satisfies whatever @Nullable result a caller of Super12's
+    // declared signature expects.
+    static class Super12 {
+        <T extends @Nullable Object> @Nullable T get() {
+            throw new RuntimeException();
+        }
+    }
+
+    static class SubRequalifiedReturnNarrower extends Super12 {
+        @Override
+        <T extends @Nullable Object> @NonNull T get() {
+            throw new RuntimeException();
+        }
     }
 }

--- a/checker/tests/nullness/OverrideTypeParamBound.java
+++ b/checker/tests/nullness/OverrideTypeParamBound.java
@@ -1,0 +1,201 @@
+// Regression tests for eisop#1965: a generic method override whose own declared type-parameter
+// bound no longer contains the overridden method's bound is unsound regardless of whether, or
+// where, the type parameter is used in the parameter or return types -- see BaseTypeVisitor
+// .OverrideChecker#isTypeParameterBoundOverrideValid's javadoc for the containment rule. Each
+// nested class below isolates one combination of which bound differs, in which direction, and how
+// the type parameter is used; several combinations are sound and expect no diagnostic, since
+// containment (not equality) is position-independent already.
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+public class OverrideTypeParamBound {
+
+    // ---- Positive controls: no bound difference, so nothing is reported. ----
+
+    static class SameBoundsExplicit {
+        <T extends @Nullable Object> T pick(T p) {
+            return p;
+        }
+    }
+
+    static class SameBoundsExplicitOverride extends SameBoundsExplicit {
+        @Override
+        <T extends @Nullable Object> T pick(T p) {
+            return p;
+        }
+    }
+
+    static class SameBoundsRenamed extends SameBoundsExplicit {
+        @Override
+        // A differently-named type parameter with the identical bound is still a valid override:
+        // only the bound is compared, never the name.
+        <U extends @Nullable Object> U pick(U p) {
+            return p;
+        }
+    }
+
+    // ---- Positive control: an unannotated bound differs only through defaulting. ----
+    // An unbounded <T> defaults to a @Nullable Object upper bound, while <T extends Object>
+    // defaults to @NonNull Object; overriding with the wider (unbounded) upper bound is sound
+    // containment even though neither declaration writes an explicit qualifier.
+
+    static class SuperExplicitObjectBound {
+        <T extends Object> void consume(T p) {}
+    }
+
+    static class SubImplicitBound extends SuperExplicitObjectBound {
+        @Override
+        <T> void consume(T p) {}
+    }
+
+    // ---- The original eisop#1965 case: lower bound widened, type parameter used as return. ----
+    // The override's own body relies on its (wider) lower bound to justify "T t = null;", but a
+    // caller of the overridden signature may instantiate T as @NonNull, per Super's (narrower)
+    // lower bound -- an NPE the checker is supposed to prevent. Containment requires the
+    // override's lower bound to be a subtype of (i.e. at least as restrictive as) the overridden
+    // one, so widening it is still rejected.
+
+    static class Super {
+        <T extends @Nullable Object> T pick(T p) {
+            return p;
+        }
+    }
+
+    static class SubWidenLowerReturn extends Super {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <@Nullable T extends @Nullable Object> T pick(T p) {
+            T t = null;
+            return t;
+        }
+    }
+
+    private static void triggerWidenLowerReturn(Super s) {
+        @NonNull String r = s.<@NonNull String>pick("x");
+        System.out.println(r.length());
+    }
+
+    public static void main(String[] args) {
+        triggerWidenLowerReturn(new SubWidenLowerReturn());
+    }
+
+    // ---- Upper bound narrowed, type parameter used as a parameter. ----
+    // A caller of Super2's declared signature may pass an @Nullable value; SubNarrowUpperParam's
+    // own upper bound only accepts @NonNull. Containment requires the overridden upper bound to
+    // be a subtype of the override's, so narrowing is rejected.
+
+    static class Super2 {
+        <T extends @Nullable Object> void consume(T p) {}
+    }
+
+    static class SubNarrowUpperParam extends Super2 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <T extends @NonNull Object> void consume(T p) {}
+    }
+
+    // ---- Positive control: upper bound widened, type parameter used as a return type. ----
+    // SubWidenUpperReturn's body is checked once against its own (wider) upper bound; it cannot
+    // manufacture a value outside what that bound allows, so every value it returns is still a
+    // genuine instance of Super3's narrower upper bound. Widening the upper bound is sound
+    // containment regardless of the type parameter's position.
+
+    static class Super3 {
+        <T extends @NonNull Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+
+    static class SubWidenUpperReturn extends Super3 {
+        @Override
+        // Throws rather than "return null;": T's own lower bound (still defaults to @NonNull
+        // here) would make that its own, unrelated error, muddying a test that is meant to
+        // isolate the upper bound alone.
+        <T extends @Nullable Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+
+    // ---- Positive control: lower bound narrowed, type parameter used as a parameter. ----
+    // SubNarrowLowerParam's own lower bound is more restrictive than Super4's; every value a
+    // caller can supply under Super4's declared signature also satisfies the narrower bound, so
+    // narrowing the lower bound is sound containment.
+
+    static class Super4 {
+        <@Nullable T extends @Nullable Object> void consume(T p) {}
+    }
+
+    static class SubNarrowLowerParam extends Super4 {
+        @Override
+        <T extends @Nullable Object> void consume(T p) {}
+    }
+
+    // ---- Both bounds differ at once: still exactly one diagnostic, for the one type parameter.
+    // ----
+
+    static class Super5 {
+        <T extends @Nullable Object> T pick(T p) {
+            return p;
+        }
+    }
+
+    static class SubBothBoundsDiffer extends Super5 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <@Nullable T extends @NonNull Object> T pick(T p) {
+            throw new RuntimeException();
+        }
+    }
+
+    // ---- Type parameter not used in either the parameter or the return type. ----
+    // No per-occurrence check (isParameterOverrideValid/isReturnOverrideValid) ever sees T here;
+    // only checkTypeParameterBounds can catch this.
+
+    static class Super6 {
+        <T extends @Nullable Object> void noop() {}
+    }
+
+    static class SubUnusedTypeParam extends Super6 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <T extends @NonNull Object> void noop() {}
+    }
+
+    // ---- Type parameter used only nested inside a parameter type, not bare. ----
+    // Unlike every case above, this reports two diagnostics, not one: the per-occurrence
+    // type-variable check that isParameterOverrideValid falls back to only ever applies to a bare
+    // occurrence, never to a type parameter nested inside List<T>. The ordinary parameter-type
+    // subtype check, which does see this nested occurrence, independently rejects it too.
+
+    static class Super7 {
+        <T extends @Nullable Object> void consumeList(List<T> p) {}
+    }
+
+    static class SubNestedTypeParam extends Super7 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        // :: error: (override.param.invalid)
+        <T extends @NonNull Object> void consumeList(List<T> p) {}
+    }
+
+    // ---- Multiple type parameters: only the second one's bound differs. ----
+    // Confirms checkTypeParameterBounds compares type parameters positionally -- one diagnostic
+    // for the mismatched index, none for the matching one -- not one verdict for the whole
+    // method.
+
+    static class Super8 {
+        <T extends @Nullable Object, U extends @Nullable Object> void consumeTwo(T p1, U p2) {}
+    }
+
+    static class SubOnlySecondTypeParamMismatched extends Super8 {
+        @Override
+        <
+                        T extends @Nullable Object,
+                        // :: error: (override.typaram.invalid)
+                        U extends @NonNull Object>
+                void consumeTwo(T p1, U p2) {}
+    }
+}

--- a/checker/tests/nullness/OverrideTypeParamBound.java
+++ b/checker/tests/nullness/OverrideTypeParamBound.java
@@ -6,6 +6,25 @@
 // the type parameter is used; several combinations are sound and expect no diagnostic, since
 // containment (not equality) is position-independent already.
 //
+// The core matrix is 2 (which bound: upper/lower) x 2 (direction: widened/narrowed) x 2 (position:
+// parameter-only/return-only):
+//
+//   upper  widened, parameter-only: SubImplicitBound      sound, accepted
+//   upper  widened, return-only:    SubWidenUpperReturn   sound, accepted
+//   upper narrowed, parameter-only: SubNarrowUpperParam   unsound, rejected
+//   upper narrowed, return-only:    SubNarrowUpperReturn  sound for this shape, rejected
+//   lower  widened, parameter-only: SubWidenLowerParam    unsound, rejected
+//   lower  widened, return-only:    SubWidenLowerReturn   unsound, rejected
+//   lower narrowed, parameter-only: SubNarrowLowerParam   sound, accepted
+//   lower narrowed, return-only:    SubNarrowLowerReturn  sound, accepted
+//
+// Throughout, the operative asymmetry is that a type parameter's UPPER bound governs what the
+// overriding body may CONSUME (dereference, pass on) and its LOWER bound governs what that body
+// may PRODUCE (manufacture as a fresh value of the type parameter). That is why widening the
+// upper bound is always safe -- it only makes the body more conservative about what it received
+// -- while widening the lower bound is not: it lets the body conjure a value that a caller going
+// through the overridden, narrower declaration never agreed to receive.
+//
 // The final section below (Super9 through Super12) instead keeps both sides' type-parameter
 // declarations identical and requalifies a single parameter or return occurrence with its own
 // explicit annotation -- a containment mismatch entirely invisible to
@@ -58,7 +77,9 @@ public class OverrideTypeParamBound {
     }
 
     // ---- The original eisop#1965 case: lower bound widened, type parameter used as return. ----
-    // The override's own body relies on its (wider) lower bound to justify "T t = null;", but a
+    // The override's own body relies on its (wider) lower bound to justify returning the null it
+    // put in "t" -- the declaration "T t = null;" alone is accepted either way, since dataflow
+    // refines the local; it is "return t;" that the narrower lower bound would reject. But a
     // caller of the overridden signature may instantiate T as @NonNull, per Super's (narrower)
     // lower bound -- an NPE the checker is supposed to prevent. Containment requires the
     // override's lower bound to be a subtype of (i.e. at least as restrictive as) the overridden
@@ -106,10 +127,16 @@ public class OverrideTypeParamBound {
     }
 
     // ---- Positive control: upper bound widened, type parameter used as a return type. ----
-    // SubWidenUpperReturn's body is checked once against its own (wider) upper bound; it cannot
-    // manufacture a value outside what that bound allows, so every value it returns is still a
-    // genuine instance of Super3's narrower upper bound. Widening the upper bound is sound
-    // containment regardless of the type parameter's position.
+    // What makes this sound is the LOWER bound, not the upper one: a body cannot manufacture a
+    // fresh value of T except from T's lower bound, and containment leaves that bound unchanged
+    // here (both sides default to @NonNull). Widening the upper bound only makes the body more
+    // conservative about values it was handed; it grants no new ability to produce one. Note that
+    // "the body cannot manufacture a value outside its own (wider) upper bound" would NOT justify
+    // this: such a value is exactly what the wider bound does allow, yet returning it is still
+    // rejected -- writing "@Nullable T t = someNullableT(); return t;" here fails with
+    // return.type.incompatible, whose printed types differ only in the lower bound
+    // ("super @Nullable NullType" vs "super @NonNull NullType"), the upper bounds being identical.
+    // Widening the upper bound is sound containment regardless of the type parameter's position.
 
     static class Super3 {
         <T extends @NonNull Object> T produce() {
@@ -128,9 +155,11 @@ public class OverrideTypeParamBound {
     }
 
     // ---- Positive control: lower bound narrowed, type parameter used as a parameter. ----
-    // SubNarrowLowerParam's own lower bound is more restrictive than Super4's; every value a
-    // caller can supply under Super4's declared signature also satisfies the narrower bound, so
-    // narrowing the lower bound is sound containment.
+    // The lower bound governs what the body may PRODUCE, not what a caller may supply (that is
+    // the upper bound's job). SubNarrowLowerParam's own lower bound is more restrictive than
+    // Super4's, so its body can manufacture strictly fewer values of T than Super4's body could
+    // -- every one of them still acceptable to a caller of Super4's declared signature. Narrowing
+    // the lower bound is therefore sound containment.
 
     static class Super4 {
         <@Nullable T extends @Nullable Object> void consume(T p) {}
@@ -139,6 +168,81 @@ public class OverrideTypeParamBound {
     static class SubNarrowLowerParam extends Super4 {
         @Override
         <T extends @Nullable Object> void consume(T p) {}
+    }
+
+    // ---- Positive control: lower bound narrowed, type parameter used only as a return type. ----
+    // The mirror image of SubNarrowLowerParam, completing the lower-bound half of the matrix.
+    // Narrowing the lower bound restricts what SubNarrowLowerReturn's body may produce, and the
+    // return type is precisely where that production becomes visible to a caller: a caller of
+    // Super14's declared signature is promised a T within Super14's (wider) lower bound, and any
+    // value satisfying the override's narrower one satisfies that promise too. Sound containment.
+
+    static class Super14 {
+        <@Nullable T extends @Nullable Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+
+    static class SubNarrowLowerReturn extends Super14 {
+        @Override
+        <T extends @Nullable Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+
+    // ---- Lower bound widened, type parameter used only as a parameter. ----
+    // Completing the matrix's last cell. It is tempting to expect the mirror image of
+    // SubNarrowUpperReturn below -- "the lower bound only matters for what the body produces, and
+    // a parameter-only type parameter produces nothing, so this is sound in principle and merely
+    // rejected by position-independence." That reasoning is wrong, and Super16 below shows why:
+    // "parameter-only" does not mean "produces nothing", because a parameter can itself be a
+    // mutable SINK for T. So this cell is genuinely unsound in general, not accepted imprecision.
+    //
+    // For this bare shape alone, nothing the body manufactures can escape, so this particular
+    // rejection is imprecise; the check cannot distinguish it from Super16's shape, and rejects
+    // both. Note that only checkTypeParameterBounds catches this: unlike every upper-bound
+    // mismatch above, the bare parameter occurrence draws no second diagnostic, because the
+    // occurrence-level subtype check on two corresponding type variables compares their effective
+    // upper bounds and never reaches the differing lower bound.
+
+    static class Super15 {
+        <T extends @Nullable Object> void consume(T p) {}
+    }
+
+    static class SubWidenLowerParam extends Super15 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <@Nullable T extends @Nullable Object> void consume(T p) {}
+    }
+
+    // The escape that makes the cell above genuinely unsound rather than merely imprecise. T
+    // occurs only in parameter position here too, but one of those parameters is a List<T> the
+    // caller still holds. The widened lower bound lets the body manufacture a null T and store it
+    // there, so a caller of Super16's declared signature -- which promised a List<@NonNull String>
+    // would only ever gain @NonNull String elements -- reads back a null. Note the body's
+    // "sink.add(manufactured)" is itself accepted: the override checks are the only thing standing
+    // between this declaration and the NPE in triggerWidenLowerParamSink.
+
+    static class Super16 {
+        <T extends @Nullable Object> void consume(T p, List<T> sink) {}
+    }
+
+    static class SubWidenLowerParamSink extends Super16 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        // :: error: (override.param.invalid)
+        <@Nullable T extends @Nullable Object> void consume(T p, List<T> sink) {
+            T manufactured = null;
+            sink.add(manufactured);
+        }
+    }
+
+    private static void triggerWidenLowerParamSink(Super16 s) {
+        List<@NonNull String> l = new java.util.ArrayList<>();
+        s.<@NonNull String>consume("x", l);
+        for (@NonNull String e : l) {
+            System.out.println(e.length());
+        }
     }
 
     // ---- Both bounds differ at once: still exactly one diagnostic, for the one type parameter.
@@ -212,12 +316,19 @@ public class OverrideTypeParamBound {
 
     // ---- Accepted imprecision: upper bound narrowed, type parameter used only as a return type.
     // ----
-    // Sound in principle -- T occurs only in the return type, so the body can never be handed a
-    // value outside its own narrower bound -- but checkTypeParameterBounds is deliberately
-    // position-independent (it cannot know, from the declaration alone, whether T is used as a
-    // parameter, a return type, both, or neither) and rejects this anyway. The converse,
+    // Sound for this particular shape -- T occurs only as a bare return type, so the body can
+    // never be handed a value outside its own narrower bound -- but checkTypeParameterBounds is
+    // deliberately position-independent (it cannot know, from the declaration alone, whether T is
+    // used as a parameter, a return type, both, or neither) and rejects this anyway. The converse,
     // SubWidenUpperReturn above, is the direction position-independence costs nothing for; this is
     // the direction it costs precision.
+    //
+    // "Return-only" is not by itself enough to make narrowing the upper bound safe, though, just
+    // as "parameter-only" was not enough to make widening the lower bound safe in
+    // SubWidenLowerParam above. Had Super13 declared "List<T> produce()", the override would hand
+    // the caller a container it still believes has @NonNull elements while the caller may add
+    // null to it -- genuinely unsound, and rejected by the nested return-type check as well as by
+    // this one. So the imprecision here is narrower than "any return-only narrowing is fine".
 
     static class Super13 {
         <T extends @Nullable Object> T produce() {
@@ -316,6 +427,7 @@ public class OverrideTypeParamBound {
     // the overridden (wider) signature would hit.
     public static void main(String[] args) {
         triggerWidenLowerReturn(new SubWidenLowerReturn());
+        triggerWidenLowerParamSink(new SubWidenLowerParamSink());
         triggerRequalifiedParamNarrower(new SubRequalifiedParamNarrower());
         triggerRequalifiedReturnWider(new SubRequalifiedReturnWider());
     }

--- a/checker/tests/nullness/OverrideTypeParamBound.java
+++ b/checker/tests/nullness/OverrideTypeParamBound.java
@@ -10,7 +10,7 @@
 // declarations identical and requalifies a single parameter or return occurrence with its own
 // explicit annotation -- a containment mismatch entirely invisible to
 // isTypeParameterBoundOverrideValid, caught only by isParameterOverrideValid/
-// isReturnOverrideValid's own type-variable fallback (PR #1961 review, comment 5396576208).
+// isReturnOverrideValid's own type-variable fallback.
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -85,10 +85,6 @@ public class OverrideTypeParamBound {
     private static void triggerWidenLowerReturn(Super s) {
         @NonNull String r = s.<@NonNull String>pick("x");
         System.out.println(r.length());
-    }
-
-    public static void main(String[] args) {
-        triggerWidenLowerReturn(new SubWidenLowerReturn());
     }
 
     // ---- Upper bound narrowed, type parameter used as a parameter. ----
@@ -214,11 +210,34 @@ public class OverrideTypeParamBound {
                 void consumeTwo(T p1, U p2) {}
     }
 
+    // ---- Accepted imprecision: upper bound narrowed, type parameter used only as a return type.
+    // ----
+    // Sound in principle -- T occurs only in the return type, so the body can never be handed a
+    // value outside its own narrower bound -- but checkTypeParameterBounds is deliberately
+    // position-independent (it cannot know, from the declaration alone, whether T is used as a
+    // parameter, a return type, both, or neither) and rejects this anyway. The converse,
+    // SubWidenUpperReturn above, is the direction position-independence costs nothing for; this is
+    // the direction it costs precision.
+
+    static class Super13 {
+        <T extends @Nullable Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+
+    static class SubNarrowUpperReturn extends Super13 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <T extends @NonNull Object> T produce() {
+            throw new RuntimeException();
+        }
+    }
+
     // ---- Requalified occurrences: an explicit annotation on a parameter or return type, not on
     // the type parameter's own declaration. Both type parameters below declare the identical bound
     // <T extends @Nullable Object>, so checkTypeParameterBounds sees no mismatch; the unsoundness
-    // (eisop#1961 review, comment 5396576208) is entirely in the requalified occurrence, which only
-    // isParameterOverrideValid/isReturnOverrideValid's own type-variable fallback can see.
+    // is entirely in the requalified occurrence, which only isParameterOverrideValid/
+    // isReturnOverrideValid's own type-variable fallback can see.
 
     // Parameter requalified narrower than the shared declared bound: a caller of Super9's declared
     // signature may pass an @Nullable value; SubRequalifiedParamNarrower's own parameter only

--- a/checker/tests/nullness/OverrideTypeParamBound.java
+++ b/checker/tests/nullness/OverrideTypeParamBound.java
@@ -310,4 +310,13 @@ public class OverrideTypeParamBound {
             throw new RuntimeException();
         }
     }
+
+    // Runs every trigger*() method above, each demonstrating -- if the preceding class's own
+    // override were accepted rather than rejected -- the NullPointerException a caller relying on
+    // the overridden (wider) signature would hit.
+    public static void main(String[] args) {
+        triggerWidenLowerReturn(new SubWidenLowerReturn());
+        triggerRequalifiedParamNarrower(new SubRequalifiedParamNarrower());
+        triggerRequalifiedReturnWider(new SubRequalifiedReturnWider());
+    }
 }

--- a/checker/tests/nullness/OverrideTypeParamBound.java
+++ b/checker/tests/nullness/OverrideTypeParamBound.java
@@ -344,6 +344,45 @@ public class OverrideTypeParamBound {
         }
     }
 
+    // ---- Known imprecision: a bound that mentions a type variable of the same method. ----
+    // isTypeParameterBoundOverrideValid compares the two declarations' bounds structurally,
+    // without first adapting the overridden method's bound to the overriding method's type
+    // variables the way JLS 8.4.2 does. When a bound mentions a type variable -- an F-bound such
+    // as <T extends Comparable<T>>, or one type parameter's bound naming another -- the
+    // comparison therefore pits the overridden method's type variable against the overriding
+    // method's distinct one, in an invariant type-argument position, and fails no matter which
+    // direction the qualifier moved.
+    //
+    // Super17/SubFBoundWiden below is the SOUND direction (the F-bound's qualifier is widened,
+    // and at any instantiation T := C both declarations reduce to the same C), yet it is
+    // rejected. Adapting the overridden bound by substituting the overriding method's type
+    // variables for the overridden method's before comparing would fix this; until then the
+    // workaround is the one the manual gives for override.typaram.invalid generally: give the
+    // overriding declaration the overridden bound, or suppress the warning. Note that identical
+    // bounds on both sides are unaffected -- the mismatch only surfaces when a qualifier actually
+    // differs -- so the common case of simply repeating <T extends Comparable<T>> is fine.
+
+    static class Super17 {
+        <T extends @NonNull Comparable<T>> void use(T p) {}
+    }
+
+    static class SubFBoundWiden extends Super17 {
+        @Override
+        // :: error: (override.typaram.invalid)
+        <T extends @Nullable Comparable<T>> void use(T p) {}
+    }
+
+    // Control for the above: identical F-bounds compare cleanly and terminate despite the
+    // self-reference, so the imprecision really is confined to a differing qualifier.
+    static class Super18 {
+        <T extends @NonNull Comparable<T>> void use(T p) {}
+    }
+
+    static class SubFBoundSame extends Super18 {
+        @Override
+        <T extends @NonNull Comparable<T>> void use(T p) {}
+    }
+
     // ---- Requalified occurrences: an explicit annotation on a parameter or return type, not on
     // the type parameter's own declaration. Both type parameters below declare the identical bound
     // <T extends @Nullable Object>, so checkTypeParameterBounds sees no mismatch; the unsoundness

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -344,46 +344,30 @@ to change the directionality, rather than duplicating the entire ~35-line
 `checkParameters` and `checkParametersMsg` loop-and-error-reporting logic. No
 behavior change for CF's own (contravariant) checkers.
 
-`BaseTypeVisitor.OverrideChecker.checkReturn` now delegates its return-type
-override compatibility check to a new overridable `isReturnOverrideValid` method,
-the return-type analogue of `isParameterOverrideValid` above (covariant by
-default, mirroring the same shape). Pure refactor; no behavior change for CF's
+`BaseTypeVisitor.OverrideChecker.checkReturn` now delegates its comparison to
+a new overridable `isReturnOverrideValid` method, the return-type analogue of
+`isParameterOverrideValid` above. Pure refactor; no behavior change for CF's
 own checkers.
 
-`BaseTypeVisitor.testTypevarContainment`'s upper-bound comparison, for two
-corresponding type variables declared by the overriding and overridden methods
-themselves, now delegates to a new overridable `isTypevarUpperBoundContained`
-method instead of inlining the subtype check. A checker that separately
-validates a method's own type-parameter bounds elsewhere (see
-`isTypeParameterBoundOverrideValid` below) can override this to unconditionally
-return `true`, deferring the question entirely to that other, more complete
-check -- so that `isParameterOverrideValid`/`isReturnOverrideValid` never
-independently reject an override on account of a type-parameter bound mismatch,
-and there is nothing to reconcile between two checks that would otherwise answer
-the same question. Pure refactor; no behavior change for CF's own checkers.
+`BaseTypeVisitor.testTypevarContainment`'s upper-bound comparison now
+delegates to a new overridable `isTypevarUpperBoundContained` method. A
+checker that separately validates a type parameter's own bound (see
+`isTypeParameterBoundOverrideValid` below) can override this to
+unconditionally return `true`, so `isParameterOverrideValid` and
+`isReturnOverrideValid` never also report the same bound mismatch. Pure
+refactor; no behavior change for CF's own checkers.
 
-`BaseTypeVisitor.OverrideChecker.checkOverride` now also runs a new
-`checkTypeParameterBounds`, comparing each of the overriding method's own type
-parameters against the corresponding type parameter of the overridden method via
-a new `isTypeParameterBoundOverrideValid` hook (default: always valid, since
-ordinary Java override rules place no constraint on a generic method's own
-type-parameter bounds beyond erasure compatibility, which javac already
-enforces). A checker whose type system attaches enforceable meaning to that bound
-(e.g. a nullness qualifier, where a narrower override bound would let a caller of
-the overridden signature pass a value the override cannot accept) can override
-just this method to enforce it, through CF's own `override.typaram.invalid`
-diagnostic and mode handling, instead of maintaining a separate, standalone check
-outside `OverrideChecker` entirely -- and, combined with overriding
-`isTypevarUpperBoundContained` above to defer to it, without needing to
-deduplicate two checks that would otherwise both report the same narrowed or
-widened bound. `isTypeParameterBoundOverrideValid` is passed the full type
-variables, not just their upper bounds, since the Checker Framework (unlike
-ordinary Java) lets a checker attach meaning to a type parameter's lower
-bound too, via the annotation written directly on the type variable (see the
-manual's "Syntax for upper and lower bounds" section); the
-`override.typaram.invalid` diagnostic reports both bounds accordingly. No
-behavior change for CF's own checkers, none of which override either new
-hook.
+`BaseTypeVisitor.OverrideChecker.checkOverride` now also runs
+`checkTypeParameterBounds`, comparing each of the overriding method's own
+type parameters against the corresponding type parameter of the overridden
+method via a new `isTypeParameterBoundOverrideValid` hook (default: always
+valid). A mismatch is reported through a new `override.typaram.invalid`
+diagnostic, showing each side's full declared bound (upper and lower, since
+-- unlike ordinary Java -- a Checker Framework type parameter can declare a
+meaningful lower bound too, via the annotation written directly on the type
+variable). Unlike the parameter/return checks, this also covers a type
+parameter that occurs only nested in the signature, or not at all. No
+behavior change for CF's own checkers, which do not override the hook.
 
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -388,6 +388,16 @@ return type, as in overriding `<T extends @Nullable Object> T produce()` with
 `override.typaram.invalid` error. Give the overriding declaration the
 overridden bound, or suppress the warning.
 
+A second, unrelated source of false positives is a bound that mentions a
+type variable of the same method -- an F-bound such as
+`<T extends Comparable<T>>`, or one type parameter's bound naming another.
+The two declarations' bounds are compared structurally, without first
+adapting the overridden method's bound to the overriding method's type
+variables (as JLS 8.4.2 does), so the comparison pits one method's type
+variable against the other's in an invariant type-argument position and
+fails whichever direction the qualifier moved. Identical bounds on both
+sides are unaffected; the same workaround applies.
+
 `isReturnOverrideValid`'s type-variable containment fallback
 (`BaseTypeVisitor.testTypevarContainment`) now uses the same containment
 direction as `isParameterOverrideValid` and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -344,6 +344,12 @@ to change the directionality, rather than duplicating the entire ~35-line
 `checkParameters` and `checkParametersMsg` loop-and-error-reporting logic. No
 behavior change for CF's own (contravariant) checkers.
 
+`BaseTypeVisitor.OverrideChecker.checkReturn` now delegates its return-type
+override compatibility check to a new overridable `isReturnOverrideValid` method,
+the return-type analogue of `isParameterOverrideValid` above (covariant by
+default, mirroring the same shape). Pure refactor; no behavior change for CF's
+own checkers.
+
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the
 implicit `Outer<XXX>` enclosing `Super` in `class Sub extends Super`, or the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -376,8 +376,14 @@ diagnostic and mode handling, instead of maintaining a separate, standalone chec
 outside `OverrideChecker` entirely -- and, combined with overriding
 `isTypevarUpperBoundContained` above to defer to it, without needing to
 deduplicate two checks that would otherwise both report the same narrowed or
-widened bound. No behavior change for CF's own checkers, none of which override
-either new hook.
+widened bound. `isTypeParameterBoundOverrideValid` is passed the full type
+variables, not just their upper bounds, since the Checker Framework (unlike
+ordinary Java) lets a checker attach meaning to a type parameter's lower
+bound too, via the annotation written directly on the type variable (see the
+manual's "Syntax for upper and lower bounds" section); the
+`override.typaram.invalid` diagnostic reports both bounds accordingly. No
+behavior change for CF's own checkers, none of which override either new
+hook.
 
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -362,6 +362,23 @@ independently reject an override on account of a type-parameter bound mismatch,
 and there is nothing to reconcile between two checks that would otherwise answer
 the same question. Pure refactor; no behavior change for CF's own checkers.
 
+`BaseTypeVisitor.OverrideChecker.checkOverride` now also runs a new
+`checkTypeParameterBounds`, comparing each of the overriding method's own type
+parameters against the corresponding type parameter of the overridden method via
+a new `isTypeParameterBoundOverrideValid` hook (default: always valid, since
+ordinary Java override rules place no constraint on a generic method's own
+type-parameter bounds beyond erasure compatibility, which javac already
+enforces). A checker whose type system attaches enforceable meaning to that bound
+(e.g. a nullness qualifier, where a narrower override bound would let a caller of
+the overridden signature pass a value the override cannot accept) can override
+just this method to enforce it, through CF's own `override.typaram.invalid`
+diagnostic and mode handling, instead of maintaining a separate, standalone check
+outside `OverrideChecker` entirely -- and, combined with overriding
+`isTypevarUpperBoundContained` above to defer to it, without needing to
+deduplicate two checks that would otherwise both report the same narrowed or
+widened bound. No behavior change for CF's own checkers, none of which override
+either new hook.
+
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the
 implicit `Outer<XXX>` enclosing `Super` in `class Sub extends Super`, or the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -350,6 +350,18 @@ the return-type analogue of `isParameterOverrideValid` above (covariant by
 default, mirroring the same shape). Pure refactor; no behavior change for CF's
 own checkers.
 
+`BaseTypeVisitor.testTypevarContainment`'s upper-bound comparison, for two
+corresponding type variables declared by the overriding and overridden methods
+themselves, now delegates to a new overridable `isTypevarUpperBoundContained`
+method instead of inlining the subtype check. A checker that separately
+validates a method's own type-parameter bounds elsewhere (see
+`isTypeParameterBoundOverrideValid` below) can override this to unconditionally
+return `true`, deferring the question entirely to that other, more complete
+check -- so that `isParameterOverrideValid`/`isReturnOverrideValid` never
+independently reject an override on account of a type-parameter bound mismatch,
+and there is nothing to reconcile between two checks that would otherwise answer
+the same question. Pure refactor; no behavior change for CF's own checkers.
+
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the
 implicit `Outer<XXX>` enclosing `Super` in `class Sub extends Super`, or the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -382,8 +382,8 @@ actually handle correctly (eisop#1965).
 
 Because the rule is position-independent, it can also newly reject an
 override that is sound only by virtue of where the type parameter is used:
-narrowing the upper bound of a type parameter that occurs only in the return
-type, as in overriding `<T extends @Nullable Object> T produce()` with
+narrowing the upper bound of a type parameter that occurs only as a bare
+return type, as in overriding `<T extends @Nullable Object> T produce()` with
 `<T extends @NonNull Object> T produce()`, is now an
 `override.typaram.invalid` error. Give the overriding declaration the
 overridden bound, or suppress the warning.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -340,33 +340,36 @@ default check is contravariant (the overridden parameter must be a subtype of th
 overriding parameter, the standard override rule in CF's type systems). A checker
 whose type rules require parameter <em>invariance</em> for overrides (both directions
 must be subtypes, as in JSpecify's override rules) can now override just this method
-to change the directionality, rather than duplicating the entire ~35-line
-`checkParameters` and `checkParametersMsg` loop-and-error-reporting logic. No
-behavior change for CF's own (contravariant) checkers.
+to change the directionality, rather than duplicating the entire `checkParameters`
+and `checkParametersMsg` loop-and-error-reporting logic.
 
 `BaseTypeVisitor.OverrideChecker.checkReturn` now delegates its comparison to
 a new overridable `isReturnOverrideValid` method, the return-type analogue of
-`isParameterOverrideValid` above. Pure refactor; no behavior change for CF's
-own checkers.
-
-`BaseTypeVisitor.testTypevarContainment` now delegates its containment check
-to a new overridable `isTypevarContained` method. A checker that separately
-validates a type parameter's own bound (see `isTypeParameterBoundOverrideValid`
-below) can override this to unconditionally return `true`, so
-`isParameterOverrideValid` and `isReturnOverrideValid` never also report the
-same bound mismatch. Pure refactor; no behavior change for CF's own checkers.
+`isParameterOverrideValid` above.
 
 `BaseTypeVisitor.OverrideChecker.checkOverride` now also runs
 `checkTypeParameterBounds`, comparing each of the overriding method's own
 type parameters against the corresponding type parameter of the overridden
-method via a new `isTypeParameterBoundOverrideValid` hook (default: always
-valid). A mismatch is reported through a new `override.typaram.invalid`
-diagnostic, showing each side's full declared bound (upper and lower, since
--- unlike ordinary Java -- a Checker Framework type parameter can declare a
-meaningful lower bound too, via the annotation written directly on the type
-variable). Unlike the parameter/return checks, this also covers a type
-parameter that occurs only nested in the signature, or not at all. No
-behavior change for CF's own checkers, which do not override the hook.
+method via a new `isTypeParameterBoundOverrideValid` hook. A mismatch is
+reported through a new `override.typaram.invalid` diagnostic, showing each
+side's full declared bound (upper and lower, since -- unlike ordinary Java --
+a Checker Framework type parameter can declare a meaningful lower bound too,
+via the annotation written directly on the type variable).
+
+The default `isTypeParameterBoundOverrideValid` requires the overriding type
+parameter's bound range to contain the overridden one's: the overridden upper
+bound must be a subtype of the overriding upper bound, and the overriding
+lower bound must be a subtype of the overridden lower bound. This holds
+regardless of whether, or where, the type parameter is used in the method's
+parameter or return types -- including a type parameter that occurs only
+nested in the signature, or not at all, neither of which the parameter/return
+checks above ever see. This is a real soundness fix: a checker whose qualifier
+hierarchy attaches enforceable meaning to a type-parameter bound (e.g.
+Nullness) now rejects an override whose bound no longer contains the
+overridden one, closing a gap where a caller of the overridden method's
+declared signature could instantiate the type parameter with a value the
+override's own body, type-checked against its own (looser) bound, does not
+actually handle correctly (eisop#1965).
 
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the
@@ -574,7 +577,7 @@ Other improvements and bug fixes:
 eisop#433, eisop#737, eisop#792, eisop#863, eisop#949, eisop#1015, eisop#1074,
 eisop#1244, eisop#1315, eisop#1564, eisop#1592, eisop#1642, eisop#1653,
 eisop#1735, eisop#1801, eisop#1818, eisop#1819, eisop#1861, eisop#1862,
-eisop#1863, eisop#1865, eisop#1887.
+eisop#1863, eisop#1865, eisop#1887, eisop#1965.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -371,25 +371,28 @@ declared signature could instantiate the type parameter with a value the
 override's own body, type-checked against its own (looser) bound, does not
 actually handle correctly (eisop#1965).
 
-`isParameterOverrideValid`'s and `isReturnOverrideValid`'s own type-variable
-containment fallback (`BaseTypeVisitor.testTypevarContainment`) now once
-again compares the two occurrences' actual bounds, instead of unconditionally
-treating any two corresponding type variables as compatible. The type
-parameter's own declared bound (checked above) and a single parameter or
-return occurrence's bound are different things: an occurrence can be
-requalified with its own explicit annotation, independent of the type
-parameter's declaration, and `isTypeParameterBoundOverrideValid` cannot see
-that requalification at all, since it only ever looks at the declaration.
-For example, overriding `<T extends @Nullable Object> void m(T p)` with
-`<T extends @Nullable Object> void m(@NonNull T p)` has identical
-type-parameter bounds on both sides, so `isTypeParameterBoundOverrideValid`
-finds no mismatch, but the override's own parameter is stricter than the
-overridden one's -- an unsound narrowing this fallback is responsible for
-catching. `isReturnOverrideValid`'s fallback direction is also corrected to
-match `isTypeParameterBoundOverrideValid`'s containment direction (an
-overriding return occurrence may widen its bound, not only narrow it), since
-the two must agree for a bare, unannotated occurrence to be judged
-consistently by both checks.
+Because the rule is position-independent, it can also newly reject an
+override that is sound only by virtue of where the type parameter is used:
+narrowing the upper bound of a type parameter that occurs only in the return
+type, as in overriding `<T extends @Nullable Object> T produce()` with
+`<T extends @NonNull Object> T produce()`, is now an
+`override.typaram.invalid` error. Give the overriding declaration the
+overridden bound, or suppress the warning.
+
+`isReturnOverrideValid`'s type-variable containment fallback
+(`BaseTypeVisitor.testTypevarContainment`) now uses the same containment
+direction as `isParameterOverrideValid` and
+`isTypeParameterBoundOverrideValid`: the overriding occurrence's bound range
+must contain the overridden one's. Previously the return-position fallback
+required the reverse. That was unsound for an occurrence requalified with a
+looser qualifier -- overriding `<T extends @Nullable Object> T get(T p)` with
+`<T extends @Nullable Object> @Nullable T get(T p)` was accepted, so a caller
+writing `s.<@NonNull String>get("x")` could receive null -- and it was a false
+positive for a bare occurrence whose type parameter soundly widens its upper
+bound. This occurrence-level fallback stays necessary even given the
+declaration-level check above, because an occurrence can be requalified with
+its own explicit annotation, which `isTypeParameterBoundOverrideValid`, which
+only ever looks at the type parameter's declaration, never sees.
 
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -371,6 +371,26 @@ declared signature could instantiate the type parameter with a value the
 override's own body, type-checked against its own (looser) bound, does not
 actually handle correctly (eisop#1965).
 
+`isParameterOverrideValid`'s and `isReturnOverrideValid`'s own type-variable
+containment fallback (`BaseTypeVisitor.testTypevarContainment`) now once
+again compares the two occurrences' actual bounds, instead of unconditionally
+treating any two corresponding type variables as compatible. The type
+parameter's own declared bound (checked above) and a single parameter or
+return occurrence's bound are different things: an occurrence can be
+requalified with its own explicit annotation, independent of the type
+parameter's declaration, and `isTypeParameterBoundOverrideValid` cannot see
+that requalification at all, since it only ever looks at the declaration.
+For example, overriding `<T extends @Nullable Object> void m(T p)` with
+`<T extends @Nullable Object> void m(@NonNull T p)` has identical
+type-parameter bounds on both sides, so `isTypeParameterBoundOverrideValid`
+finds no mismatch, but the override's own parameter is stricter than the
+overridden one's -- an unsound narrowing this fallback is responsible for
+catching. `isReturnOverrideValid`'s fallback direction is also corrected to
+match `isTypeParameterBoundOverrideValid`'s containment direction (an
+overriding return occurrence may widen its bound, not only narrow it), since
+the two must agree for a bare, unannotated occurrence to be judged
+consistently by both checks.
+
 `TypeFromTypeTreeVisitor` now restores the declared bounds of type-variable
 type arguments that appear in the enclosing type of a nested type (e.g. the
 implicit `Outer<XXX>` enclosing `Super` in `class Sub extends Super`, or the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -349,13 +349,12 @@ a new overridable `isReturnOverrideValid` method, the return-type analogue of
 `isParameterOverrideValid` above. Pure refactor; no behavior change for CF's
 own checkers.
 
-`BaseTypeVisitor.testTypevarContainment`'s upper-bound comparison now
-delegates to a new overridable `isTypevarUpperBoundContained` method. A
-checker that separately validates a type parameter's own bound (see
-`isTypeParameterBoundOverrideValid` below) can override this to
-unconditionally return `true`, so `isParameterOverrideValid` and
-`isReturnOverrideValid` never also report the same bound mismatch. Pure
-refactor; no behavior change for CF's own checkers.
+`BaseTypeVisitor.testTypevarContainment` now delegates its containment check
+to a new overridable `isTypevarContained` method. A checker that separately
+validates a type parameter's own bound (see `isTypeParameterBoundOverrideValid`
+below) can override this to unconditionally return `true`, so
+`isParameterOverrideValid` and `isReturnOverrideValid` never also report the
+same bound mismatch. Pure refactor; no behavior change for CF's own checkers.
 
 `BaseTypeVisitor.OverrideChecker.checkOverride` now also runs
 `checkTypeParameterBounds`, comparing each of the overriding method's own

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -1261,7 +1261,7 @@ similar to Java subtype rules, but taking the type qualifiers into account.
   method is invoked on an object whose type is incompatible with the
   method receiver type
 
-\item invalid overriding parameter type (override.parameter.invalid)
+\item invalid overriding parameter type (override.param.invalid)
   when a parameter in a method declaration is incompatible with that
   parameter in the overridden method's declaration
 
@@ -1272,6 +1272,17 @@ similar to Java subtype rules, but taking the type qualifiers into account.
 \item invalid overriding receiver type (override.receiver.invalid)
   when a receiver in a method declaration is incompatible with that
   receiver in the overridden method's declaration
+
+\item invalid overriding type-parameter bound (override.typaram.invalid)
+  when a method declaration's own generic type parameter has an upper or
+  lower bound (Section~\ref{generics-bounds-syntax}) that does not contain
+  the corresponding type parameter's bound in the overridden method's
+  declaration --- regardless of whether, or where, that type parameter is
+  used in the method's parameter or return types.  A checker whose type
+  system attaches no enforceable meaning to a type-parameter bound never
+  reports this; see \refclass{common/basetype}{BaseTypeVisitor}'s
+  \code{isTypeParameterBoundOverrideValid} for how to customize this
+  check.
 
 \end{itemize}
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -4451,7 +4451,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      *
      * <p>The default implementation requires {@code inner}'s upper bound to be a subtype of {@code
      * outer}'s. A checker that separately validates a method's own type-parameter bounds --
-     * elsewhere, e.g. via {@code OverrideChecker#isTypeParameterBoundOverrideValid} -- may override
+     * elsewhere, e.g. via {@link OverrideChecker#isTypeParameterBoundOverrideValid} -- may override
      * this to unconditionally return {@code true}, deferring the question entirely to that other
      * check, which (unlike this one) also covers a type parameter that appears nested inside a
      * parameter or return type rather than directly, or does not appear in either at all -- so it
@@ -4781,6 +4781,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
             boolean result = checkReturn();
             result &= checkParameters();
+            result &= checkTypeParameterBounds();
             if (isMethodReference) {
                 result &= checkMemberReferenceReceivers();
             } else {
@@ -5166,6 +5167,143 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                         posTree,
                         msgKey,
                         overrider.getElement().getParameters().get(index).toString(),
+                        pair.found,
+                        pair.required,
+                        overriderType,
+                        overrider,
+                        overriddenType,
+                        overridden);
+            }
+        }
+
+        /**
+         * Checks that each of the overriding method's own type parameters is an acceptable override
+         * of the corresponding type parameter of the overridden method, per {@link
+         * #isTypeParameterBoundOverrideValid}, and issues an error for each one that is not.
+         *
+         * <p>Corresponds positionally, like {@link #checkParameters}: the type parameter at index
+         * {@code i} of the overrider is compared against the type parameter at index {@code i} of
+         * the overridden method, for as many indices as both declare. A method reference has no
+         * type parameters of its own to compare, so this is a no-op for one -- {@code
+         * overrider.getTypeVariables()} is always empty for a method reference, which already makes
+         * this a no-op via {@code count}, but the check below is explicit about it rather than
+         * relying on that incidentally, since a subclass overriding {@link
+         * #isTypeParameterBoundOverrideValid} should not have to also verify that invariant itself.
+         *
+         * <p>Called by {@link #checkOverride} strictly after {@link #checkReturn} and {@link
+         * #checkParameters}, which is part of this method's contract, not an incidental
+         * implementation detail: a subclass overriding {@link #isTypeParameterBoundOverrideValid}
+         * may rely on {@link #isParameterOverrideValid} having already run for this
+         * overridden-method pairing by the time it is invoked, for example to avoid reporting a
+         * redundant diagnostic for a type variable it already rejected an occurrence of.
+         *
+         * @return true if every type-parameter bound is compatible
+         */
+        private boolean checkTypeParameterBounds() {
+            if (isMethodReference) {
+                return true;
+            }
+            List<AnnotatedTypeVariable> overriderTypeVars = overrider.getTypeVariables();
+            List<AnnotatedTypeVariable> overriddenTypeVars = overridden.getTypeVariables();
+            int count = Math.min(overriderTypeVars.size(), overriddenTypeVars.size());
+            boolean result = true;
+            for (int i = 0; i < count; i++) {
+                boolean success =
+                        isTypeParameterBoundOverrideValid(
+                                overriddenTypeVars.get(i), overriderTypeVars.get(i));
+                checkTypeParameterBoundsMsg(success, i, overriderTypeVars, overriddenTypeVars);
+                result &= success;
+            }
+            return result;
+        }
+
+        /**
+         * Returns true if {@code overriderTypeVar}'s upper bound is an acceptable override of
+         * {@code overriddenTypeVar}'s upper bound.
+         *
+         * <p>The default implementation imposes no constraint (always returns true): ordinary Java
+         * override rules do not constrain a generic method's own type-parameter bounds beyond
+         * erasure compatibility, which javac itself already enforces, so two methods can be in a
+         * valid override relationship with unrelated type-parameter bounds (e.g. overriding {@code
+         * <T extends Number> void f(T t)} with {@code <T> void f(T t)} is ordinary, legal Java).
+         * This exists purely as an extension point for a checker whose type system attaches
+         * enforceable meaning to that bound -- e.g. one where the bound is a nullness qualifier, so
+         * that a narrower override bound would let a caller of the overridden signature pass a
+         * value the override cannot accept, even though nothing about the parameter or return types
+         * where the type variable happens to be used would catch it (it might not be used in
+         * either).
+         *
+         * <p>Called by {@link #checkTypeParameterBounds}, itself called by {@link #checkOverride}
+         * strictly after {@link #checkReturn} and {@link #checkParameters} have already run for
+         * this overridden-method pairing -- see {@link #checkTypeParameterBounds}'s own javadoc. An
+         * override of this method may rely on that ordering, e.g. to check whether {@link
+         * #isParameterOverrideValid} already rejected an occurrence of {@code overriderTypeVar} and
+         * avoid a redundant second diagnostic for it.
+         *
+         * @param overriddenTypeVar the corresponding type parameter of the overridden method
+         * @param overriderTypeVar the type parameter of the overriding method
+         * @return true if the override is compatible for this type parameter's bound
+         */
+        protected boolean isTypeParameterBoundOverrideValid(
+                AnnotatedTypeVariable overriddenTypeVar, AnnotatedTypeVariable overriderTypeVar) {
+            return true;
+        }
+
+        /**
+         * Issues an {@code override.typaram.invalid} error for the type parameter at {@code index}
+         * if {@code success} is false.
+         *
+         * @param success whether the type parameter at {@code index} is a valid override
+         * @param index the index, into {@code overriderTypeVars} and {@code overriddenTypeVars}, of
+         *     the type parameter to report on
+         * @param overriderTypeVars the type parameters of the overriding method
+         * @param overriddenTypeVars the type parameters of the overridden method
+         */
+        private void checkTypeParameterBoundsMsg(
+                boolean success,
+                int index,
+                List<AnnotatedTypeVariable> overriderTypeVars,
+                List<AnnotatedTypeVariable> overriddenTypeVars) {
+            if (success && !showchecks) {
+                return;
+            }
+            AnnotatedTypeMirror overriderBound = overriderTypeVars.get(index).getUpperBound();
+            AnnotatedTypeMirror overriddenBound = overriddenTypeVars.get(index).getUpperBound();
+            Tree posTree =
+                    overriderTree instanceof MethodTree
+                            ? ((MethodTree) overriderTree).getTypeParameters().get(index)
+                            : overriderTree;
+
+            if (showchecks) {
+                System.out.printf(
+                        " %s (at %s):%n"
+                                + "     overrider: %s %s (type parameter %d bound %s)%n"
+                                + "    overridden: %s %s"
+                                + " (type parameter %d bound %s)%n",
+                        (success
+                                ? "success: overriding type parameter bound is compatible with overridden"
+                                : "FAILURE: overriding type parameter bound is not compatible with"
+                                        + " overridden"),
+                        fileAndLineNumber(posTree),
+                        overrider,
+                        overriderType,
+                        index,
+                        overriderBound.toString(),
+                        overridden,
+                        overriddenType,
+                        index,
+                        overriddenBound.toString());
+            }
+            if (!success) {
+                FoundRequired pair = FoundRequired.of(overriderBound, overriddenBound);
+                checker.reportError(
+                        posTree,
+                        "override.typaram.invalid",
+                        overriderTypeVars
+                                .get(index)
+                                .getUnderlyingType()
+                                .asElement()
+                                .getSimpleName(),
                         pair.found,
                         pair.required,
                         overriderType,

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -5168,12 +5168,17 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          *
          * <p>Corresponds positionally, like {@link #checkParameters}: the type parameter at index
          * {@code i} of the overrider is compared against the type parameter at index {@code i} of
-         * the overridden method, for as many indices as both declare. A method reference has no
-         * type parameters of its own to compare, so this is a no-op for one -- {@code
-         * overrider.getTypeVariables()} is always empty for a method reference, which already makes
-         * this a no-op via {@code count}, but the check below is explicit about it rather than
-         * relying on that incidentally, since a subclass overriding {@link
-         * #isTypeParameterBoundOverrideValid} should not have to also verify that invariant itself.
+         * the overridden method, for as many indices as both declare.
+         *
+         * <p>Method references are exempt. Both sides can have non-empty type-parameter lists there
+         * -- a method reference to a generic method, bound to a generic functional interface
+         * method, has them on both sides (see {@code
+         * checker/tests/nullness/java8/methodref/TestGenFunc.java}) -- so the early return below is
+         * load-bearing, not merely defensive. Those two lists are not two declarations of one
+         * overridable method: the referenced method's type parameters are instantiated at the
+         * method reference, so the position-independent containment rule this check applies does
+         * not carry over. There is also no type-parameter tree to report on, which is why {@link
+         * #checkTypeParameterBoundsMsg} can cast {@code overriderTree} to a {@code MethodTree}.
          *
          * @return true if every type-parameter bound is compatible
          */
@@ -5293,11 +5298,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 checker.reportError(
                         posTree,
                         "override.typaram.invalid",
-                        overriderTypeVars
-                                .get(index)
-                                .getUnderlyingType()
-                                .asElement()
-                                .getSimpleName(),
+                        overriderTypeVar.getUnderlyingType().asElement().getSimpleName(),
                         pair.found,
                         pair.required,
                         overriderType,

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -4435,13 +4435,36 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             AnnotatedTypeVariable outerAtv = (AnnotatedTypeVariable) outer;
 
             if (AnnotatedTypes.areCorrespondingTypeVariables(elements, innerAtv, outerAtv)) {
-                return typeHierarchy.isSubtype(innerAtv.getUpperBound(), outerAtv.getUpperBound())
+                return isTypevarUpperBoundContained(innerAtv, outerAtv)
                         && typeHierarchy.isSubtype(
                                 outerAtv.getLowerBound(), innerAtv.getLowerBound());
             }
         }
 
         return false;
+    }
+
+    /**
+     * Returns true if {@code inner}'s upper bound is acceptable given {@code outer}'s, for two
+     * corresponding type variables declared by the overriding and overridden methods themselves
+     * (the case {@link #testTypevarContainment} exists to handle).
+     *
+     * <p>The default implementation requires {@code inner}'s upper bound to be a subtype of {@code
+     * outer}'s. A checker that separately validates a method's own type-parameter bounds --
+     * elsewhere, e.g. via {@code OverrideChecker#isTypeParameterBoundOverrideValid} -- may override
+     * this to unconditionally return {@code true}, deferring the question entirely to that other
+     * check, which (unlike this one) also covers a type parameter that appears nested inside a
+     * parameter or return type rather than directly, or does not appear in either at all -- so it
+     * is usually the more complete place for a checker with that need to answer this question once,
+     * rather than answering it here too and needing to reconcile the two answers.
+     *
+     * @param inner the type variable checked for being contained in {@code outer}
+     * @param outer the type variable checked for containing {@code inner}
+     * @return true if {@code inner}'s upper bound is acceptable given {@code outer}'s
+     */
+    protected boolean isTypevarUpperBoundContained(
+            AnnotatedTypeVariable inner, AnnotatedTypeVariable outer) {
+        return typeHierarchy.isSubtype(inner.getUpperBound(), outer.getUpperBound());
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3832,18 +3832,22 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     protected static class FoundRequired {
 
         /**
-         * Something with a possibly-verbose string representation: an {@link AnnotatedTypeMirror}
-         * or an {@link AnnotatedTypeParameterBounds}, neither of which shares a supertype declaring
-         * {@code toString(boolean)}.
+         * Renders a found or required type or bounds as a string, given whether the rendering
+         * should be verbose. A factory below must implement this as {@code v -> v ?
+         * x.toString(true) : x.toString()}, not {@code x::toString} bound to the {@code
+         * toString(boolean)} overload: for {@link AnnotatedTypeMirror}, the no-argument {@code
+         * toString()} overload additionally resets otherwise-sticky formatter state (such as
+         * whether the current checker's invisible qualifiers print) that {@code toString(false)}
+         * leaves alone, so the two are not interchangeable when not verbose.
          */
-        private interface VerboseToString {
+        private interface VerboseRenderer {
             /**
-             * Returns this object's string representation.
+             * Renders the string representation.
              *
              * @param verbose if true, the returned representation is verbose
-             * @return this object's string representation
+             * @return the string representation
              */
-            String toString(boolean verbose);
+            String render(boolean verbose);
         }
 
         /** Computes {@link #verbose}; null once {@link #verbose} has been computed. */
@@ -3885,20 +3889,20 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * @param verboseComputer computes whether the two representations must be verbose to differ
          */
         private FoundRequired(
-                VerboseToString found, VerboseToString required, BooleanSupplier verboseComputer) {
+                VerboseRenderer found, VerboseRenderer required, BooleanSupplier verboseComputer) {
             this.verboseComputer = verboseComputer;
             this.found =
                     new Object() {
                         @Override
                         public String toString() {
-                            return found.toString(isVerbose());
+                            return found.render(isVerbose());
                         }
                     };
             this.required =
                     new Object() {
                         @Override
                         public String toString() {
-                            return required.toString(isVerbose());
+                            return required.render(isVerbose());
                         }
                     };
         }
@@ -3913,7 +3917,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          */
         public static FoundRequired of(AnnotatedTypeMirror found, AnnotatedTypeMirror required) {
             return new FoundRequired(
-                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
+                    v -> v ? found.toString(true) : found.toString(),
+                    v -> v ? required.toString(true) : required.toString(),
+                    () -> shouldPrintVerbose(found, required));
         }
 
         /**
@@ -3928,7 +3934,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         public static FoundRequired of(
                 AnnotatedTypeMirror found, AnnotatedTypeParameterBounds required) {
             return new FoundRequired(
-                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
+                    v -> v ? found.toString(true) : found.toString(),
+                    v -> v ? required.toString(true) : required.toString(),
+                    () -> shouldPrintVerbose(found, required));
         }
 
         /**
@@ -3944,7 +3952,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         public static FoundRequired of(
                 AnnotatedTypeParameterBounds found, AnnotatedTypeParameterBounds required) {
             return new FoundRequired(
-                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
+                    v -> v ? found.toString(true) : found.toString(),
+                    v -> v ? required.toString(true) : required.toString(),
+                    () -> shouldPrintVerbose(found, required));
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -139,6 +139,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.Vector;
+import java.util.function.BooleanSupplier;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -3830,56 +3831,36 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      */
     protected static class FoundRequired {
 
-        /** Whether the {@link #verbose} flag has been computed. */
-        private boolean verboseComputed = false;
+        /**
+         * Something with a possibly-verbose string representation: an {@link AnnotatedTypeMirror}
+         * or an {@link AnnotatedTypeParameterBounds}, neither of which shares a supertype declaring
+         * {@code toString(boolean)}.
+         */
+        private interface VerboseToString {
+            /**
+             * Returns this object's string representation.
+             *
+             * @param verbose if true, the returned representation is verbose
+             * @return this object's string representation
+             */
+            String toString(boolean verbose);
+        }
 
-        /** Whether the string representation should be verbose. */
+        /** Computes {@link #verbose}; null once {@link #verbose} has been computed. */
+        private @Nullable BooleanSupplier verboseComputer;
+
+        /** Whether the string representations should be verbose. */
         private boolean verbose = false;
 
         /**
-         * Lazily computes and memoizes whether the string representation should be verbose.
+         * Lazily computes and memoizes whether the string representations should be verbose.
          *
-         * @param foundType the found type
-         * @param requiredType the required type
          * @return true if verbose toString should be used
          */
-        private boolean isVerbose(AnnotatedTypeMirror foundType, AnnotatedTypeMirror requiredType) {
-            if (!verboseComputed) {
-                verbose = shouldPrintVerbose(foundType, requiredType);
-                verboseComputed = true;
-            }
-            return verbose;
-        }
-
-        /**
-         * Lazily computes and memoizes whether the string representation should be verbose.
-         *
-         * @param foundType the found type
-         * @param requiredBounds the required bounds
-         * @return true if verbose toString should be used
-         */
-        private boolean isVerbose(
-                AnnotatedTypeMirror foundType, AnnotatedTypeParameterBounds requiredBounds) {
-            if (!verboseComputed) {
-                verbose = shouldPrintVerbose(foundType, requiredBounds);
-                verboseComputed = true;
-            }
-            return verbose;
-        }
-
-        /**
-         * Lazily computes and memoizes whether the string representation should be verbose.
-         *
-         * @param foundBounds the found bounds
-         * @param requiredBounds the required bounds
-         * @return true if verbose toString should be used
-         */
-        private boolean isVerbose(
-                AnnotatedTypeParameterBounds foundBounds,
-                AnnotatedTypeParameterBounds requiredBounds) {
-            if (!verboseComputed) {
-                verbose = shouldPrintVerbose(foundBounds, requiredBounds);
-                verboseComputed = true;
+        private boolean isVerbose() {
+            if (verboseComputer != null) {
+                verbose = verboseComputer.getAsBoolean();
+                verboseComputer = null;
             }
             return verbose;
         }
@@ -3897,84 +3878,27 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         public final Object required;
 
         /**
-         * Create a FoundRequired for two types.
+         * Create a FoundRequired.
          *
-         * @param found the found type
-         * @param required the required type
-         */
-        private FoundRequired(AnnotatedTypeMirror found, AnnotatedTypeMirror required) {
-            this.found =
-                    new Object() {
-                        @Override
-                        public String toString() {
-                            return isVerbose(found, required)
-                                    ? found.toString(true)
-                                    : found.toString();
-                        }
-                    };
-            this.required =
-                    new Object() {
-                        @Override
-                        public String toString() {
-                            return isVerbose(found, required)
-                                    ? required.toString(true)
-                                    : required.toString();
-                        }
-                    };
-        }
-
-        /**
-         * Create a FoundRequired for a type and bounds.
-         *
-         * @param found the found type
-         * @param required the required bounds
-         */
-        private FoundRequired(AnnotatedTypeMirror found, AnnotatedTypeParameterBounds required) {
-            this.found =
-                    new Object() {
-                        @Override
-                        public String toString() {
-                            return isVerbose(found, required)
-                                    ? found.toString(true)
-                                    : found.toString();
-                        }
-                    };
-            this.required =
-                    new Object() {
-                        @Override
-                        public String toString() {
-                            return isVerbose(found, required)
-                                    ? required.toString(true)
-                                    : required.toString();
-                        }
-                    };
-        }
-
-        /**
-         * Create a FoundRequired for a type parameter's own declared upper and lower bounds (see
-         * {@link BaseTypeVisitor.OverrideChecker#isTypeParameterBoundOverrideValid}).
-         *
-         * @param found the found bounds
-         * @param required the required bounds
+         * @param found the found type or bounds
+         * @param required the required type or bounds
+         * @param verboseComputer computes whether the two representations must be verbose to differ
          */
         private FoundRequired(
-                AnnotatedTypeParameterBounds found, AnnotatedTypeParameterBounds required) {
+                VerboseToString found, VerboseToString required, BooleanSupplier verboseComputer) {
+            this.verboseComputer = verboseComputer;
             this.found =
                     new Object() {
                         @Override
                         public String toString() {
-                            return isVerbose(found, required)
-                                    ? found.toString(true)
-                                    : found.toString();
+                            return found.toString(isVerbose());
                         }
                     };
             this.required =
                     new Object() {
                         @Override
                         public String toString() {
-                            return isVerbose(found, required)
-                                    ? required.toString(true)
-                                    : required.toString();
+                            return required.toString(isVerbose());
                         }
                     };
         }
@@ -3988,7 +3912,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * @return a string representation of the two annotations
          */
         public static FoundRequired of(AnnotatedTypeMirror found, AnnotatedTypeMirror required) {
-            return new FoundRequired(found, required);
+            return new FoundRequired(
+                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
         }
 
         /**
@@ -4002,12 +3927,15 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          */
         public static FoundRequired of(
                 AnnotatedTypeMirror found, AnnotatedTypeParameterBounds required) {
-            return new FoundRequired(found, required);
+            return new FoundRequired(
+                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
         }
 
         /**
          * Creates string representations of two {@link AnnotatedTypeParameterBounds}, which are
-         * only verbose if required to differentiate the two.
+         * only verbose if required to differentiate the two. Used for a type parameter's own
+         * declared upper and lower bounds; see {@link
+         * BaseTypeVisitor.OverrideChecker#isTypeParameterBoundOverrideValid}.
          *
          * @param found the found bounds
          * @param required the required bounds
@@ -4015,7 +3943,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          */
         public static FoundRequired of(
                 AnnotatedTypeParameterBounds found, AnnotatedTypeParameterBounds required) {
-            return new FoundRequired(found, required);
+            return new FoundRequired(
+                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3952,8 +3952,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
         /**
          * Create a FoundRequired for two bounds, e.g. a type parameter's own declared upper and
-         * lower bounds (see {@link OverrideChecker#isTypeParameterBoundOverrideValid}), as opposed
-         * to a single type checked against a range.
+         * lower bounds (see {@link
+         * BaseTypeVisitor.OverrideChecker#isTypeParameterBoundOverrideValid}), as opposed to a
+         * single type checked against a range.
          *
          * @param found the found bounds
          * @param required the required bounds

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -4516,9 +4516,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             AnnotatedTypeVariable outerAtv = (AnnotatedTypeVariable) outer;
 
             if (AnnotatedTypes.areCorrespondingTypeVariables(elements, innerAtv, outerAtv)) {
-                return isTypevarUpperBoundContained(innerAtv, outerAtv)
-                        && typeHierarchy.isSubtype(
-                                outerAtv.getLowerBound(), innerAtv.getLowerBound());
+                return isTypevarContained(innerAtv, outerAtv);
             }
         }
 
@@ -4526,26 +4524,27 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     /**
-     * Returns true if {@code inner}'s upper bound is acceptable given {@code outer}'s, for two
-     * corresponding type variables declared by the overriding and overridden methods themselves
-     * (the case {@link #testTypevarContainment} exists to handle).
+     * Returns true if {@code outer} contains {@code inner}, for two corresponding type variables
+     * declared by the overriding and overridden methods themselves (the case {@link
+     * #testTypevarContainment} exists to handle).
      *
      * <p>The default implementation requires {@code inner}'s upper bound to be a subtype of {@code
-     * outer}'s. A checker that separately validates a method's own type-parameter bounds --
-     * elsewhere, e.g. via {@link OverrideChecker#isTypeParameterBoundOverrideValid} -- may override
-     * this to unconditionally return {@code true}, deferring the question entirely to that other
-     * check, which (unlike this one) also covers a type parameter that appears nested inside a
-     * parameter or return type rather than directly, or does not appear in either at all -- so it
-     * is usually the more complete place for a checker with that need to answer this question once,
-     * rather than answering it here too and needing to reconcile the two answers.
+     * outer}'s, and {@code outer}'s lower bound to be a subtype of {@code inner}'s. A checker that
+     * separately validates a method's own type-parameter bounds elsewhere -- e.g. via {@link
+     * OverrideChecker#isTypeParameterBoundOverrideValid} -- may override this to unconditionally
+     * return {@code true}, deferring the question entirely to that other check, which (unlike this
+     * one) also covers a type parameter that appears nested inside a parameter or return type
+     * rather than directly, or does not appear in either at all -- so it is usually the more
+     * complete place for a checker with that need to answer this question once, rather than
+     * answering it here too and needing to reconcile the two answers.
      *
      * @param inner the type variable checked for being contained in {@code outer}
      * @param outer the type variable checked for containing {@code inner}
-     * @return true if {@code inner}'s upper bound is acceptable given {@code outer}'s
+     * @return true if {@code outer} contains {@code inner}
      */
-    protected boolean isTypevarUpperBoundContained(
-            AnnotatedTypeVariable inner, AnnotatedTypeVariable outer) {
-        return typeHierarchy.isSubtype(inner.getUpperBound(), outer.getUpperBound());
+    protected boolean isTypevarContained(AnnotatedTypeVariable inner, AnnotatedTypeVariable outer) {
+        return typeHierarchy.isSubtype(inner.getUpperBound(), outer.getUpperBound())
+                && typeHierarchy.isSubtype(outer.getLowerBound(), inner.getLowerBound());
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3951,10 +3951,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
 
         /**
-         * Create a FoundRequired for two bounds, e.g. a type parameter's own declared upper and
-         * lower bounds (see {@link
-         * BaseTypeVisitor.OverrideChecker#isTypeParameterBoundOverrideValid}), as opposed to a
-         * single type checked against a range.
+         * Create a FoundRequired for a type parameter's own declared upper and lower bounds (see
+         * {@link BaseTypeVisitor.OverrideChecker#isTypeParameterBoundOverrideValid}).
          *
          * @param found the found bounds
          * @param required the required bounds
@@ -4504,47 +4502,20 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     /**
-     * Returns true if both types are type variables and outer contains inner. Outer contains inner
-     * implies: {@literal inner.upperBound <: outer.upperBound outer.lowerBound <:
-     * inner.lowerBound}.
+     * Returns true if {@code inner} and {@code outer} are corresponding type variables declared by
+     * an overriding and an overridden method. Such a pair imposes no constraint of its own here:
+     * the two declarations' bounds are compared once per type parameter, position-independently, by
+     * {@link OverrideChecker#isTypeParameterBoundOverrideValid}.
      *
-     * @return true if both types are type variables and outer contains inner
+     * @param inner the possibly-contained type
+     * @param outer the possibly-containing type
+     * @return true if {@code inner} and {@code outer} are corresponding method type variables
      */
     protected boolean testTypevarContainment(AnnotatedTypeMirror inner, AnnotatedTypeMirror outer) {
-        if (inner.getKind() == TypeKind.TYPEVAR && outer.getKind() == TypeKind.TYPEVAR) {
-            AnnotatedTypeVariable innerAtv = (AnnotatedTypeVariable) inner;
-            AnnotatedTypeVariable outerAtv = (AnnotatedTypeVariable) outer;
-
-            if (AnnotatedTypes.areCorrespondingTypeVariables(elements, innerAtv, outerAtv)) {
-                return isTypevarContained(innerAtv, outerAtv);
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns true if {@code outer} contains {@code inner}, for two corresponding type variables
-     * declared by the overriding and overridden methods themselves (the case {@link
-     * #testTypevarContainment} exists to handle).
-     *
-     * <p>The default implementation requires {@code inner}'s upper bound to be a subtype of {@code
-     * outer}'s, and {@code outer}'s lower bound to be a subtype of {@code inner}'s. A checker that
-     * separately validates a method's own type-parameter bounds elsewhere -- e.g. via {@link
-     * OverrideChecker#isTypeParameterBoundOverrideValid} -- may override this to unconditionally
-     * return {@code true}, deferring the question entirely to that other check, which (unlike this
-     * one) also covers a type parameter that appears nested inside a parameter or return type
-     * rather than directly, or does not appear in either at all -- so it is usually the more
-     * complete place for a checker with that need to answer this question once, rather than
-     * answering it here too and needing to reconcile the two answers.
-     *
-     * @param inner the type variable checked for being contained in {@code outer}
-     * @param outer the type variable checked for containing {@code inner}
-     * @return true if {@code outer} contains {@code inner}
-     */
-    protected boolean isTypevarContained(AnnotatedTypeVariable inner, AnnotatedTypeVariable outer) {
-        return typeHierarchy.isSubtype(inner.getUpperBound(), outer.getUpperBound())
-                && typeHierarchy.isSubtype(outer.getLowerBound(), inner.getLowerBound());
+        return inner.getKind() == TypeKind.TYPEVAR
+                && outer.getKind() == TypeKind.TYPEVAR
+                && AnnotatedTypes.areCorrespondingTypeVariables(
+                        elements, (AnnotatedTypeVariable) inner, (AnnotatedTypeVariable) outer);
     }
 
     /**
@@ -5270,13 +5241,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * relying on that incidentally, since a subclass overriding {@link
          * #isTypeParameterBoundOverrideValid} should not have to also verify that invariant itself.
          *
-         * <p>Called by {@link #checkOverride} strictly after {@link #checkReturn} and {@link
-         * #checkParameters}, which is part of this method's contract, not an incidental
-         * implementation detail: a subclass overriding {@link #isTypeParameterBoundOverrideValid}
-         * may rely on {@link #isParameterOverrideValid} having already run for this
-         * overridden-method pairing by the time it is invoked, for example to avoid reporting a
-         * redundant diagnostic for a type variable it already rejected an occurrence of.
-         *
          * @return true if every type-parameter bound is compatible
          */
         private boolean checkTypeParameterBounds() {
@@ -5308,27 +5272,23 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * on the type variable itself (as in {@code <@A T extends @B Object>}), which applies to
          * the lower bound -- see the manual section "Syntax for upper and lower bounds". An
          * override of this method should compare whichever of the two bounds its type system
-         * attaches enforceable meaning to; the default implementation below does not need either,
-         * since it imposes no constraint at all.
+         * attaches enforceable meaning to.
          *
-         * <p>The default implementation imposes no constraint (always returns true): ordinary Java
-         * override rules do not constrain a generic method's own type-parameter bounds beyond
-         * erasure compatibility, which javac itself already enforces, so two methods can be in a
-         * valid override relationship with unrelated type-parameter bounds (e.g. overriding {@code
-         * <T extends Number> void f(T t)} with {@code <T> void f(T t)} is ordinary, legal Java).
-         * This exists purely as an extension point for a checker whose type system attaches
-         * enforceable meaning to a type parameter's bound -- e.g. one where the bound is a nullness
-         * qualifier, so that a narrower override upper bound would let a caller of the overridden
-         * signature pass a value the override cannot accept, even though nothing about the
-         * parameter or return types where the type variable happens to be used would catch it (it
-         * might not be used in either).
+         * <p>The overriding method's body is type-checked once, generically, against its own
+         * declared bounds: it may consume a value of the type parameter as its upper bound, and
+         * produce one from its lower bound. Both must remain valid for every instantiation the
+         * overridden declaration permits, so the default implementation requires {@code
+         * overriderTypeVar}'s bound range to contain {@code overriddenTypeVar}'s: {@code
+         * overriddenTypeVar}'s upper bound must be a subtype of {@code overriderTypeVar}'s (per
+         * {@link #typeHierarchy}), and {@code overriderTypeVar}'s lower bound must be a subtype of
+         * {@code overriddenTypeVar}'s. This holds regardless of whether, or where, the type
+         * parameter is used in the method's parameter or return types.
          *
-         * <p>Called by {@link #checkTypeParameterBounds}, itself called by {@link #checkOverride}
-         * strictly after {@link #checkReturn} and {@link #checkParameters} have already run for
-         * this overridden-method pairing -- see {@link #checkTypeParameterBounds}'s own javadoc. An
-         * override of this method may rely on that ordering, e.g. to check whether {@link
-         * #isParameterOverrideValid} already rejected an occurrence of {@code overriderTypeVar} and
-         * avoid a redundant second diagnostic for it.
+         * <p>Ordinary Java places no constraint here beyond erasure compatibility, which javac
+         * itself already enforces (in particular, javac requires two overriding declarations'
+         * bounds to be identical up to erasure); this default only rejects an override when a
+         * checker's type system attaches enforceable meaning to a qualifier that differs between
+         * the two bounds.
          *
          * @param overriddenTypeVar the corresponding type parameter of the overridden method
          * @param overriderTypeVar the type parameter of the overriding method
@@ -5336,7 +5296,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          */
         protected boolean isTypeParameterBoundOverrideValid(
                 AnnotatedTypeVariable overriddenTypeVar, AnnotatedTypeVariable overriderTypeVar) {
-            return true;
+            return typeHierarchy.isSubtype(
+                            overriddenTypeVar.getUpperBound(), overriderTypeVar.getUpperBound())
+                    && typeHierarchy.isSubtype(
+                            overriderTypeVar.getLowerBound(), overriddenTypeVar.getLowerBound());
         }
 
         /**
@@ -5367,10 +5330,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             AnnotatedTypeParameterBounds overriddenBounds =
                     new AnnotatedTypeParameterBounds(
                             overriddenTypeVar.getUpperBound(), overriddenTypeVar.getLowerBound());
-            Tree posTree =
-                    overriderTree instanceof MethodTree
-                            ? ((MethodTree) overriderTree).getTypeParameters().get(index)
-                            : overriderTree;
+            // checkTypeParameterBounds returns early for a method reference, so overriderTree is
+            // always a MethodTree here.
+            Tree posTree = ((MethodTree) overriderTree).getTypeParameters().get(index);
 
             if (showchecks) {
                 System.out.printf(
@@ -5456,13 +5418,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * contained by} {@code requiredReturnType}. Mirrors {@link
          * #isParameterOverrideValid(AnnotatedTypeMirror, AnnotatedTypeMirror,
          * AnnotatedTypeMirror)}'s contravariant analogue for parameter types.
-         *
-         * <p>Named {@code requiredReturnType}/{@code actualReturnType} rather than {@code
-         * overriddenReturnType}/{@code overriderReturnType} (the names {@link #checkReturn} itself
-         * uses for the arguments it passes here) specifically so they don't shadow this class's own
-         * {@link #overriddenReturnType}/{@link #overriderReturnType} fields, which happen to hold
-         * the same values for the call {@link #checkReturn} makes but need not for an override that
-         * calls this method with something else.
          *
          * @param requiredReturnType the return type of the overridden method
          * @param actualReturnType the return type of the overriding method

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3868,6 +3868,23 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
 
         /**
+         * Lazily computes and memoizes whether the string representation should be verbose.
+         *
+         * @param foundBounds the found bounds
+         * @param requiredBounds the required bounds
+         * @return true if verbose toString should be used
+         */
+        private boolean isVerbose(
+                AnnotatedTypeParameterBounds foundBounds,
+                AnnotatedTypeParameterBounds requiredBounds) {
+            if (!verboseComputed) {
+                verbose = shouldPrintVerbose(foundBounds, requiredBounds);
+                verboseComputed = true;
+            }
+            return verbose;
+        }
+
+        /**
          * An object whose {@code toString()} method returns the found type's string representation.
          * Evaluated lazily to improve performance.
          */
@@ -3934,6 +3951,36 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
 
         /**
+         * Create a FoundRequired for two bounds, e.g. a type parameter's own declared upper and
+         * lower bounds (see {@link OverrideChecker#isTypeParameterBoundOverrideValid}), as opposed
+         * to a single type checked against a range.
+         *
+         * @param found the found bounds
+         * @param required the required bounds
+         */
+        private FoundRequired(
+                AnnotatedTypeParameterBounds found, AnnotatedTypeParameterBounds required) {
+            this.found =
+                    new Object() {
+                        @Override
+                        public String toString() {
+                            return isVerbose(found, required)
+                                    ? found.toString(true)
+                                    : found.toString();
+                        }
+                    };
+            this.required =
+                    new Object() {
+                        @Override
+                        public String toString() {
+                            return isVerbose(found, required)
+                                    ? required.toString(true)
+                                    : required.toString();
+                        }
+                    };
+        }
+
+        /**
          * Creates string representations of {@link AnnotatedTypeMirror}s which are only verbose if
          * required to differentiate the two types.
          *
@@ -3956,6 +4003,19 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          */
         public static FoundRequired of(
                 AnnotatedTypeMirror found, AnnotatedTypeParameterBounds required) {
+            return new FoundRequired(found, required);
+        }
+
+        /**
+         * Creates string representations of two {@link AnnotatedTypeParameterBounds}, which are
+         * only verbose if required to differentiate the two.
+         *
+         * @param found the found bounds
+         * @param required the required bounds
+         * @return a string representation of the two bounds
+         */
+        public static FoundRequired of(
+                AnnotatedTypeParameterBounds found, AnnotatedTypeParameterBounds required) {
             return new FoundRequired(found, required);
         }
     }
@@ -3991,6 +4051,26 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             return true;
         }
         return containsSameToString(atm, bounds.getUpperBound(), bounds.getLowerBound());
+    }
+
+    /**
+     * Return whether or not the verbose toString should be used when printing two bounds.
+     *
+     * @param bounds1 the first bounds
+     * @param bounds2 the second bounds
+     * @return true iff neither argument contains "@", or there are two annotated types (in either
+     *     argument) such that their toStrings are the same but their verbose toStrings differ
+     */
+    private static boolean shouldPrintVerbose(
+            AnnotatedTypeParameterBounds bounds1, AnnotatedTypeParameterBounds bounds2) {
+        if (!bounds1.toString().contains("@") && !bounds2.toString().contains("@")) {
+            return true;
+        }
+        return containsSameToString(
+                bounds1.getUpperBound(),
+                bounds1.getLowerBound(),
+                bounds2.getUpperBound(),
+                bounds2.getLowerBound());
     }
 
     /**
@@ -5218,8 +5298,18 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
 
         /**
-         * Returns true if {@code overriderTypeVar}'s upper bound is an acceptable override of
-         * {@code overriddenTypeVar}'s upper bound.
+         * Returns true if {@code overriderTypeVar}'s declared bound is an acceptable override of
+         * {@code overriddenTypeVar}'s declared bound.
+         *
+         * <p>"Declared bound" means both {@link AnnotatedTypeVariable#getUpperBound()} and {@link
+         * AnnotatedTypeVariable#getLowerBound()}: ordinary Java syntax only lets a type parameter
+         * declaration write an upper bound (the {@code extends} clause), but the Checker Framework
+         * additionally lets a checker's type system give meaning to the annotation written directly
+         * on the type variable itself (as in {@code <@A T extends @B Object>}), which applies to
+         * the lower bound -- see the manual section "Syntax for upper and lower bounds". An
+         * override of this method should compare whichever of the two bounds its type system
+         * attaches enforceable meaning to; the default implementation below does not need either,
+         * since it imposes no constraint at all.
          *
          * <p>The default implementation imposes no constraint (always returns true): ordinary Java
          * override rules do not constrain a generic method's own type-parameter bounds beyond
@@ -5227,11 +5317,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * valid override relationship with unrelated type-parameter bounds (e.g. overriding {@code
          * <T extends Number> void f(T t)} with {@code <T> void f(T t)} is ordinary, legal Java).
          * This exists purely as an extension point for a checker whose type system attaches
-         * enforceable meaning to that bound -- e.g. one where the bound is a nullness qualifier, so
-         * that a narrower override bound would let a caller of the overridden signature pass a
-         * value the override cannot accept, even though nothing about the parameter or return types
-         * where the type variable happens to be used would catch it (it might not be used in
-         * either).
+         * enforceable meaning to a type parameter's bound -- e.g. one where the bound is a nullness
+         * qualifier, so that a narrower override upper bound would let a caller of the overridden
+         * signature pass a value the override cannot accept, even though nothing about the
+         * parameter or return types where the type variable happens to be used would catch it (it
+         * might not be used in either).
          *
          * <p>Called by {@link #checkTypeParameterBounds}, itself called by {@link #checkOverride}
          * strictly after {@link #checkReturn} and {@link #checkParameters} have already run for
@@ -5267,8 +5357,16 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             if (success && !showchecks) {
                 return;
             }
-            AnnotatedTypeMirror overriderBound = overriderTypeVars.get(index).getUpperBound();
-            AnnotatedTypeMirror overriddenBound = overriddenTypeVars.get(index).getUpperBound();
+            AnnotatedTypeVariable overriderTypeVar = overriderTypeVars.get(index);
+            AnnotatedTypeVariable overriddenTypeVar = overriddenTypeVars.get(index);
+            // isTypeParameterBoundOverrideValid may have compared the upper bound, the lower
+            // bound, or both -- report both here so the message is accurate either way.
+            AnnotatedTypeParameterBounds overriderBounds =
+                    new AnnotatedTypeParameterBounds(
+                            overriderTypeVar.getUpperBound(), overriderTypeVar.getLowerBound());
+            AnnotatedTypeParameterBounds overriddenBounds =
+                    new AnnotatedTypeParameterBounds(
+                            overriddenTypeVar.getUpperBound(), overriddenTypeVar.getLowerBound());
             Tree posTree =
                     overriderTree instanceof MethodTree
                             ? ((MethodTree) overriderTree).getTypeParameters().get(index)
@@ -5288,14 +5386,14 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                         overrider,
                         overriderType,
                         index,
-                        overriderBound.toString(),
+                        overriderBounds,
                         overridden,
                         overriddenType,
                         index,
-                        overriddenBound.toString());
+                        overriddenBounds);
             }
             if (!success) {
-                FoundRequired pair = FoundRequired.of(overriderBound, overriddenBound);
+                FoundRequired pair = FoundRequired.of(overriderBounds, overriddenBounds);
                 checker.reportError(
                         posTree,
                         "override.typaram.invalid",

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3832,22 +3832,18 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     protected static class FoundRequired {
 
         /**
-         * Renders a found or required type or bounds as a string, given whether the rendering
-         * should be verbose. A factory below must implement this as {@code v -> v ?
-         * x.toString(true) : x.toString()}, not {@code x::toString} bound to the {@code
-         * toString(boolean)} overload: for {@link AnnotatedTypeMirror}, the no-argument {@code
-         * toString()} overload additionally resets otherwise-sticky formatter state (such as
-         * whether the current checker's invisible qualifiers print) that {@code toString(false)}
-         * leaves alone, so the two are not interchangeable when not verbose.
+         * Something with a possibly-verbose string representation: an {@link AnnotatedTypeMirror}
+         * or an {@link AnnotatedTypeParameterBounds}, neither of which shares a supertype declaring
+         * {@code toString(boolean)}.
          */
-        private interface VerboseRenderer {
+        private interface VerboseToString {
             /**
-             * Renders the string representation.
+             * Returns this object's string representation.
              *
              * @param verbose if true, the returned representation is verbose
-             * @return the string representation
+             * @return this object's string representation
              */
-            String render(boolean verbose);
+            String toString(boolean verbose);
         }
 
         /** Computes {@link #verbose}; null once {@link #verbose} has been computed. */
@@ -3889,20 +3885,20 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * @param verboseComputer computes whether the two representations must be verbose to differ
          */
         private FoundRequired(
-                VerboseRenderer found, VerboseRenderer required, BooleanSupplier verboseComputer) {
+                VerboseToString found, VerboseToString required, BooleanSupplier verboseComputer) {
             this.verboseComputer = verboseComputer;
             this.found =
                     new Object() {
                         @Override
                         public String toString() {
-                            return found.render(isVerbose());
+                            return found.toString(isVerbose());
                         }
                     };
             this.required =
                     new Object() {
                         @Override
                         public String toString() {
-                            return required.render(isVerbose());
+                            return required.toString(isVerbose());
                         }
                     };
         }
@@ -3917,9 +3913,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          */
         public static FoundRequired of(AnnotatedTypeMirror found, AnnotatedTypeMirror required) {
             return new FoundRequired(
-                    v -> v ? found.toString(true) : found.toString(),
-                    v -> v ? required.toString(true) : required.toString(),
-                    () -> shouldPrintVerbose(found, required));
+                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
         }
 
         /**
@@ -3934,9 +3928,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         public static FoundRequired of(
                 AnnotatedTypeMirror found, AnnotatedTypeParameterBounds required) {
             return new FoundRequired(
-                    v -> v ? found.toString(true) : found.toString(),
-                    v -> v ? required.toString(true) : required.toString(),
-                    () -> shouldPrintVerbose(found, required));
+                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
         }
 
         /**
@@ -3952,9 +3944,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         public static FoundRequired of(
                 AnnotatedTypeParameterBounds found, AnnotatedTypeParameterBounds required) {
             return new FoundRequired(
-                    v -> v ? found.toString(true) : found.toString(),
-                    v -> v ? required.toString(true) : required.toString(),
-                    () -> shouldPrintVerbose(found, required));
+                    found::toString, required::toString, () -> shouldPrintVerbose(found, required));
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -4502,20 +4502,25 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     /**
-     * Returns true if {@code inner} and {@code outer} are corresponding type variables declared by
-     * an overriding and an overridden method. Such a pair imposes no constraint of its own here:
-     * the two declarations' bounds are compared once per type parameter, position-independently, by
-     * {@link OverrideChecker#isTypeParameterBoundOverrideValid}.
+     * Returns true if both types are type variables and outer contains inner. Outer contains inner
+     * implies: {@literal inner.upperBound <: outer.upperBound outer.lowerBound <:
+     * inner.lowerBound}.
      *
-     * @param inner the possibly-contained type
-     * @param outer the possibly-containing type
-     * @return true if {@code inner} and {@code outer} are corresponding method type variables
+     * @return true if both types are type variables and outer contains inner
      */
     protected boolean testTypevarContainment(AnnotatedTypeMirror inner, AnnotatedTypeMirror outer) {
-        return inner.getKind() == TypeKind.TYPEVAR
-                && outer.getKind() == TypeKind.TYPEVAR
-                && AnnotatedTypes.areCorrespondingTypeVariables(
-                        elements, (AnnotatedTypeVariable) inner, (AnnotatedTypeVariable) outer);
+        if (inner.getKind() == TypeKind.TYPEVAR && outer.getKind() == TypeKind.TYPEVAR) {
+            AnnotatedTypeVariable innerAtv = (AnnotatedTypeVariable) inner;
+            AnnotatedTypeVariable outerAtv = (AnnotatedTypeVariable) outer;
+
+            if (AnnotatedTypes.areCorrespondingTypeVariables(elements, innerAtv, outerAtv)) {
+                return typeHierarchy.isSubtype(innerAtv.getUpperBound(), outerAtv.getUpperBound())
+                        && typeHierarchy.isSubtype(
+                                outerAtv.getLowerBound(), innerAtv.getLowerBound());
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -5414,10 +5419,13 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * subtype of {@code requiredReturnType}, or -- as a fallback for corresponding type
          * variables declared by the overriding and overridden methods themselves, where a direct
          * subtype check can fail even though the override is valid -- {@code actualReturnType} must
-         * be {@linkplain #testTypevarContainment(AnnotatedTypeMirror, AnnotatedTypeMirror)
-         * contained by} {@code requiredReturnType}. Mirrors {@link
-         * #isParameterOverrideValid(AnnotatedTypeMirror, AnnotatedTypeMirror,
-         * AnnotatedTypeMirror)}'s contravariant analogue for parameter types.
+         * {@linkplain #testTypevarContainment(AnnotatedTypeMirror, AnnotatedTypeMirror) contain}
+         * {@code requiredReturnType}: the overriding occurrence's bound range must contain the
+         * overridden one's, the same direction {@link
+         * OverrideChecker#isTypeParameterBoundOverrideValid} requires for the type parameter's own
+         * declared bound, and for the same reason -- an override may widen a return occurrence's
+         * upper bound, since its own body cannot manufacture a value outside that wider bound
+         * either.
          *
          * @param requiredReturnType the return type of the overridden method
          * @param actualReturnType the return type of the overriding method
@@ -5428,7 +5436,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             if (typeHierarchy.isSubtype(actualReturnType, requiredReturnType)) {
                 return true;
             }
-            return testTypevarContainment(actualReturnType, requiredReturnType);
+            return testTypevarContainment(requiredReturnType, actualReturnType);
         }
 
         /**

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -5354,8 +5354,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
          * overridden one's, the same direction {@link
          * OverrideChecker#isTypeParameterBoundOverrideValid} requires for the type parameter's own
          * declared bound, and for the same reason -- an override may widen a return occurrence's
-         * upper bound, since its own body cannot manufacture a value outside that wider bound
-         * either.
+         * upper bound, because what a body can manufacture as a fresh value of the type variable is
+         * governed by the occurrence's <em>lower</em> bound, which containment does not let the
+         * override widen. Widening the upper bound only makes the body more conservative about
+         * values it was handed.
          *
          * @param requiredReturnType the return type of the overridden method
          * @param actualReturnType the return type of the overriding method

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -5163,13 +5163,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 // Nothing to check.
                 return true;
             }
-            boolean success = typeHierarchy.isSubtype(overriderReturnType, overriddenReturnType);
-            if (!success) {
-                // If both the overridden method have type variables as return types and both
-                // types were defined in their respective methods then, they can be covariant or
-                // invariant use super/subtypes for the overrides locations
-                success = testTypevarContainment(overriderReturnType, overriddenReturnType);
-            }
+            boolean success = isReturnOverrideValid(overriddenReturnType, overriderReturnType);
 
             // Sometimes the overridden return type of a method reference becomes a captured
             // type variable.  This leads to defaulting that often makes the overriding return type
@@ -5189,6 +5183,38 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
             checkReturnMsg(success);
             return success;
+        }
+
+        /**
+         * Returns true if {@code actualReturnType} is an acceptable override of {@code
+         * requiredReturnType}.
+         *
+         * <p>The default implementation requires covariance: {@code actualReturnType} must be a
+         * subtype of {@code requiredReturnType}, or -- as a fallback for corresponding type
+         * variables declared by the overriding and overridden methods themselves, where a direct
+         * subtype check can fail even though the override is valid -- {@code actualReturnType} must
+         * be {@linkplain #testTypevarContainment(AnnotatedTypeMirror, AnnotatedTypeMirror)
+         * contained by} {@code requiredReturnType}. Mirrors {@link
+         * #isParameterOverrideValid(AnnotatedTypeMirror, AnnotatedTypeMirror,
+         * AnnotatedTypeMirror)}'s contravariant analogue for parameter types.
+         *
+         * <p>Named {@code requiredReturnType}/{@code actualReturnType} rather than {@code
+         * overriddenReturnType}/{@code overriderReturnType} (the names {@link #checkReturn} itself
+         * uses for the arguments it passes here) specifically so they don't shadow this class's own
+         * {@link #overriddenReturnType}/{@link #overriderReturnType} fields, which happen to hold
+         * the same values for the call {@link #checkReturn} makes but need not for an override that
+         * calls this method with something else.
+         *
+         * @param requiredReturnType the return type of the overridden method
+         * @param actualReturnType the return type of the overriding method
+         * @return true if the override is compatible for the return type
+         */
+        protected boolean isReturnOverrideValid(
+                AnnotatedTypeMirror requiredReturnType, AnnotatedTypeMirror actualReturnType) {
+            if (typeHierarchy.isSubtype(actualReturnType, requiredReturnType)) {
+                return true;
+            }
+            return testTypevarContainment(actualReturnType, requiredReturnType);
         }
 
         /**

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -39,6 +39,7 @@ explicit.annotation.ignored=The qualifier %s is ignored in favor of %s. Either d
 
 override.return.invalid=Incompatible return type.%nfound   : %s%nrequired: %s%nConsequence: method in %s%n  %s%ncannot override method in %s%n  %s
 override.param.invalid=Incompatible parameter type for %s.%nfound   : %s%nrequired: %s%nConsequence: method in %s%n  %s%ncannot override method in %s%n  %s
+override.typaram.invalid=Incompatible bound for type parameter %s.%nfound   : %s%nrequired: %s%nConsequence: method in %s%n  %s%ncannot override method in %s%n  %s
 override.receiver.invalid=Incompatible receiver type%nfound   : %s%nrequired: %s%nConsequence: method in %s%n  %s%ncannot override method in %s%n  %s
 methodref.return.invalid=Incompatible return type%nfound   : %s%nrequired: %s%nConsequence: method in %s%n  %s%nis not a valid method reference for method in %s%n  %s
 methodref.param.invalid=Incompatible parameter type for %s%nfound   : %s%nrequired: %s%nConsequence: method in %s%n  %s%nis not a valid method reference for method in %s%n  %s


### PR DESCRIPTION
## Summary

Fixes eisop#1965: a generic method override whose own declared type-parameter
bound differs from the overridden method's is unsound, regardless of whether,
or where, the type parameter is used in the parameter or return types.
Neither `checkParameters` nor `checkReturn` catches this when the type
parameter is unused, or occurs only nested inside another type.

- **`checkTypeParameterBounds`/`isTypeParameterBoundOverrideValid`**: a new
  check, run from `checkOverride` for every type parameter the overriding and
  overridden methods declare in common, independent of where, or whether, the
  type parameter is used in the signature. Reports a mismatch as a new
  `override.typaram.invalid` diagnostic, showing each side's full declared
  bound (upper and lower -- a Checker Framework type parameter can declare a
  meaningful lower bound via the annotation written directly on the type
  variable). The default implementation requires the overriding type
  parameter's bound range to *contain* the overridden one's: the overridden
  upper bound must be a subtype of the overriding upper bound, and the
  overriding lower bound must be a subtype of the overridden lower bound.
  This is sound and position-independent -- an override may widen an upper
  bound or narrow a lower bound regardless of whether the type parameter is
  used as a parameter, a return type, both, or neither, since the override's
  own body is type-checked once against its own declared bound and cannot
  escape it either way.
- **`isReturnOverrideValid`**: extracts `checkReturn()`'s inline comparison
  into an overridable hook, the return-type analogue of the existing
  `isParameterOverrideValid` (added in #1942).
- **`testTypevarContainment`**'s per-occurrence fallback (used by
  `isParameterOverrideValid`/`isReturnOverrideValid` for two corresponding
  type variables) is simplified to check only that the two type variables
  correspond, deferring the actual bound comparison entirely to
  `checkTypeParameterBounds`: that check is a strict superset of what the
  per-occurrence fallback could ever decide, since it also covers a type
  parameter that occurs nested or not at all.

## Test plan

- [x] `:framework:compileJava` clean
- [x] `spotlessApply` (no reformatting needed)
- [x] `requireJavadoc` -- no new hits
- [x] `:framework:test :checker:test` (full suite) green
- [x] New regression-test matrices,
  `checker/tests/nullness/OverrideTypeParamBound.java` and
  `checker/tests/interning/OverrideTypeParamBound.java`, covering every
  combination of which bound differs, in which direction, and how the type
  parameter is used -- including several sound combinations that expect no
  diagnostic, to pin down that the check requires containment, not equality
- [x] `Issue577.java` updated: the same underlying bug is now caught by this
  more precise, dedicated check instead of the old per-occurrence one
- [x] eisop#1965's original repro exercised end-to-end
  (`triggerWidenLowerReturn`/`main` in the new Nullness test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfhc2QA5Lo9A1vkiwT52ov
