### PR TITLE
typeinference8: charge resolution and substitution work against the inference budget

### DIFF
--- a/.claude/skills/cf-performance/gen-shapes.py
+++ b/.claude/skills/cf-performance/gen-shapes.py
@@ -20,6 +20,17 @@ Shapes (which machinery each stresses):
   repeat       R methods x D calls to the SAME method/receiver      (methodAsMemberOf element caching)
   tryfin       R methods x D nested try/finally                     (CFG finally duplication)
   loops        R methods x D nested for-loops                       (dataflow fixpoint over back-edges)
+  fbound       D mutually F-bounded interfaces I1..ID (Ii's bound mentions T1..Ti) + R calls to a
+               generic factory method returning ID<?,...,?> (D wildcards) with no explicit type
+               witness -- self-bounded/F-bounded generics with mutual dependencies among the
+               inference variables, the shape javac.comp.Infer's own worklist and CF's
+               typeinference8 (Resolution#resolve/resolveWithCapture, incorporateToFixedPoint) both
+               have to solve together. Modeled on Guava's MapMakerInternalMap<K,V,E extends
+               InternalEntry<K,V,E>,S extends Segment<K,V,E,S>> (which is D=2 with an extra K,V
+               pair) -- ordinary use of that class does NOT exercise typeinference8 at all (0
+               self-time samples over 7800 on the real 625-file Guava module); this isolates the
+               specific shape (many MUTUALLY bounded inference variables resolved via one wildcarded
+               generic call) that a size sweep can check for super-linear cost in D.
 
 Found (June 2026): `cond` is severe super-linear (28 GB at D=160; #602 conditional non-caching);
 `inherit` is quadratic (asSuper depth). `repeat`/`tryfin`/`loops` are linear; `chain`/`switchc`
@@ -148,6 +159,30 @@ def loops(d, r):
     return "\n".join(out) + "\n"
 
 
+def fbound(d, r):
+    out = []
+    for i in range(1, d + 1):
+        params = ", ".join(
+            f"T{j} extends I{j}<{', '.join('T' + str(k) for k in range(1, j + 1))}>"
+            for j in range(1, i + 1)
+        )
+        out.append(f"interface I{i}<{params}> {{}}")
+    targs = ", ".join(
+        f"T{j} extends I{j}<{', '.join('T' + str(k) for k in range(1, j + 1))}>"
+        for j in range(1, d + 1)
+    )
+    wargs = ", ".join("?" for _ in range(d))
+    out.append("class Factory {")
+    out.append('    @SuppressWarnings("nullness")')
+    out.append(f"    static <{targs}> I{d}<{wargs}> create() {{ return null; }}")
+    out.append("}")
+    out.append("class Big {")
+    for k in range(r):
+        out.append(f"    void fb_{k}() {{ var s = Factory.create(); }}")
+    out.append("}")
+    return "\n".join(out) + "\n"
+
+
 SHAPES = {
     "control": control,
     "cond": cond,
@@ -157,6 +192,7 @@ SHAPES = {
     "repeat": repeat,
     "tryfin": tryfin,
     "loops": loops,
+    "fbound": fbound,
 }
 
 if __name__ == "__main__":

--- a/checker/tests/inference-budget/InferenceWorkBudgetFBound.java
+++ b/checker/tests/inference-budget/InferenceWorkBudgetFBound.java
@@ -106,4 +106,28 @@ public class InferenceWorkBudgetFBound {
         // :: error: (type.argument.inference.budget)
         Factory.create();
     }
+
+    // The same shape with a chain of only 6.  The counts that scale with the *number* of inference
+    // variables (the charges in Resolution#resolveSmallestSet and
+    // VariableBounds#doApplyInstantiationsToBounds) stay under this directory's small budget at
+    // this length; it exceeds the budget only because InferenceType#applyInstantiations also
+    // charges the SIZE of the instantiations it substitutes, which doubles with each variable
+    // resolved.  Keep this method: without that charge the chain below is not abandoned.
+    static class ShorterFactory {
+        static <
+                        T1 extends I1<T1>,
+                        T2 extends I2<T1, T2>,
+                        T3 extends I3<T1, T2, T3>,
+                        T4 extends I4<T1, T2, T3, T4>,
+                        T5 extends I5<T1, T2, T3, T4, T5>,
+                        T6 extends I6<T1, T2, T3, T4, T5, T6>>
+                I6<?, ?, ?, ?, ?, ?> create() {
+            return null;
+        }
+    }
+
+    void sixMutuallyFBoundedTypeParameters() {
+        // :: error: (type.argument.inference.budget)
+        ShorterFactory.create();
+    }
 }

--- a/checker/tests/inference-budget/InferenceWorkBudgetFBound.java
+++ b/checker/tests/inference-budget/InferenceWorkBudgetFBound.java
@@ -104,6 +104,6 @@ public class InferenceWorkBudgetFBound {
 
     void tooManyMutuallyFBoundedTypeParameters() {
         // :: error: (type.argument.inference.budget)
-        var s = Factory.create();
+        Factory.create();
     }
 }

--- a/checker/tests/inference-budget/InferenceWorkBudgetFBound.java
+++ b/checker/tests/inference-budget/InferenceWorkBudgetFBound.java
@@ -1,0 +1,109 @@
+// Regression test for the inference work budget catching a bound set of many mutually F-bounded
+// type parameters, resolved together by one wildcarded generic invocation with no explicit type
+// witness (e.g. `MapMakerInternalMap<K, V, E extends InternalEntry<K, V, E>, S extends
+// Segment<K, V, E, S>>`'s own factory method, modeled here with a chain of I1..I10, each Ii's
+// bound mentioning T1..Ti). Before recordIncorporationWork was also charged in
+// Resolution#resolveSmallestSet (JLS 18.4 resolution),
+// VariableBounds#doApplyInstantiationsToBounds's
+// already-resolved fast path (which still applies constraints), and
+// InferenceType#applyInstantiations (substitution back into a type's structure), this shape's cost
+// was invisible to the budget: it ran for many seconds (worse for more mutually dependent type
+// parameters) rather than being abandoned. This directory runs with a small
+// -AinferenceWorkBudget=2000 (see InferenceBudgetTest), so a chain of only 10 mutually F-bounded
+// type parameters already exceeds it, instead of needing the ~16+ that reach the default budget.
+//
+// See fbound in .claude/skills/cf-performance/gen-shapes.py for the generator that found this
+// (sweep D, the chain length, to reproduce the super-linear cost this budget now bounds).
+public class InferenceWorkBudgetFBound {
+
+    interface I1<T1 extends I1<T1>> {}
+
+    interface I2<T1 extends I1<T1>, T2 extends I2<T1, T2>> {}
+
+    interface I3<T1 extends I1<T1>, T2 extends I2<T1, T2>, T3 extends I3<T1, T2, T3>> {}
+
+    interface I4<
+            T1 extends I1<T1>,
+            T2 extends I2<T1, T2>,
+            T3 extends I3<T1, T2, T3>,
+            T4 extends I4<T1, T2, T3, T4>> {}
+
+    interface I5<
+            T1 extends I1<T1>,
+            T2 extends I2<T1, T2>,
+            T3 extends I3<T1, T2, T3>,
+            T4 extends I4<T1, T2, T3, T4>,
+            T5 extends I5<T1, T2, T3, T4, T5>> {}
+
+    interface I6<
+            T1 extends I1<T1>,
+            T2 extends I2<T1, T2>,
+            T3 extends I3<T1, T2, T3>,
+            T4 extends I4<T1, T2, T3, T4>,
+            T5 extends I5<T1, T2, T3, T4, T5>,
+            T6 extends I6<T1, T2, T3, T4, T5, T6>> {}
+
+    interface I7<
+            T1 extends I1<T1>,
+            T2 extends I2<T1, T2>,
+            T3 extends I3<T1, T2, T3>,
+            T4 extends I4<T1, T2, T3, T4>,
+            T5 extends I5<T1, T2, T3, T4, T5>,
+            T6 extends I6<T1, T2, T3, T4, T5, T6>,
+            T7 extends I7<T1, T2, T3, T4, T5, T6, T7>> {}
+
+    interface I8<
+            T1 extends I1<T1>,
+            T2 extends I2<T1, T2>,
+            T3 extends I3<T1, T2, T3>,
+            T4 extends I4<T1, T2, T3, T4>,
+            T5 extends I5<T1, T2, T3, T4, T5>,
+            T6 extends I6<T1, T2, T3, T4, T5, T6>,
+            T7 extends I7<T1, T2, T3, T4, T5, T6, T7>,
+            T8 extends I8<T1, T2, T3, T4, T5, T6, T7, T8>> {}
+
+    interface I9<
+            T1 extends I1<T1>,
+            T2 extends I2<T1, T2>,
+            T3 extends I3<T1, T2, T3>,
+            T4 extends I4<T1, T2, T3, T4>,
+            T5 extends I5<T1, T2, T3, T4, T5>,
+            T6 extends I6<T1, T2, T3, T4, T5, T6>,
+            T7 extends I7<T1, T2, T3, T4, T5, T6, T7>,
+            T8 extends I8<T1, T2, T3, T4, T5, T6, T7, T8>,
+            T9 extends I9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> {}
+
+    interface I10<
+            T1 extends I1<T1>,
+            T2 extends I2<T1, T2>,
+            T3 extends I3<T1, T2, T3>,
+            T4 extends I4<T1, T2, T3, T4>,
+            T5 extends I5<T1, T2, T3, T4, T5>,
+            T6 extends I6<T1, T2, T3, T4, T5, T6>,
+            T7 extends I7<T1, T2, T3, T4, T5, T6, T7>,
+            T8 extends I8<T1, T2, T3, T4, T5, T6, T7, T8>,
+            T9 extends I9<T1, T2, T3, T4, T5, T6, T7, T8, T9>,
+            T10 extends I10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> {}
+
+    static class Factory {
+        static <
+                        T1 extends I1<T1>,
+                        T2 extends I2<T1, T2>,
+                        T3 extends I3<T1, T2, T3>,
+                        T4 extends I4<T1, T2, T3, T4>,
+                        T5 extends I5<T1, T2, T3, T4, T5>,
+                        T6 extends I6<T1, T2, T3, T4, T5, T6>,
+                        T7 extends I7<T1, T2, T3, T4, T5, T6, T7>,
+                        T8 extends I8<T1, T2, T3, T4, T5, T6, T7, T8>,
+                        T9 extends I9<T1, T2, T3, T4, T5, T6, T7, T8, T9>,
+                        T10 extends I10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
+                I10<?, ?, ?, ?, ?, ?, ?, ?, ?, ?> create() {
+            return null;
+        }
+    }
+
+    void tooManyMutuallyFBoundedTypeParameters() {
+        // :: error: (type.argument.inference.budget)
+        var s = Factory.create();
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -262,6 +262,17 @@ extends Segment<K, V, E, S>>` -- could take many seconds or effectively hang
 the compiler with none of that work counted against the budget, so the
 budget never aborted it.
 
+Substituting a resolved instantiation back into a type's structure is now
+charged against `-AinferenceWorkBudget` for the *size* of the instantiations
+substituted, not only for how many there are. With mutually F-bounded type
+parameters each instantiation embeds a copy of every earlier one, so the
+instantiations double in size with each variable resolved while their number
+grows only linearly; counting only the number let such a chain run for
+minutes before the budget noticed. On a chain of 12 mutually F-bounded type
+parameters this cuts a 40-repetition compile from 200 GB of allocation to
+9.8 GB; the largest charge measured on real code is 1941 units (Guava, with
+the Nullness Checker), against the default budget of 10000.
+
 **Implementation details:**
 
 `AnnotatedIntersectionType.summarizeBounds` computes the summary described

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -252,6 +252,16 @@ element-type checks treated as a reference upcast or downcast; the Signedness
 Checker reported `(char) x`, where `x` has type `@Signed int`, as not
 statically verifiable.
 
+The `-AinferenceWorkBudget` work budget now also counts JLS 18.4 variable
+resolution and substitution back into a type's structure, not just JLS 18.3
+bound incorporation. A generic invocation resolving many mutually dependent
+inference variables together -- for example, many mutually F-bounded type
+parameters resolved by one wildcarded generic invocation, the shape of
+Guava's `MapMakerInternalMap<K, V, E extends InternalEntry<K, V, E>, S
+extends Segment<K, V, E, S>>` -- could take many seconds or effectively hang
+the compiler with none of that work counted against the budget, so the
+budget never aborted it.
+
 **Implementation details:**
 
 `AnnotatedIntersectionType.summarizeBounds` computes the summary described

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1672,6 +1672,55 @@ triggered without deep nesting.
   two regression tests; `checker/tests/nullness/Java8InferenceWorklistStress.java` exercises the
   worklist's dependency tracking across interacting inference features under strict mode.
 
+### Java 8 type-argument inference: resolution and substitution work untracked (August 2026)
+
+Found via a new `gen-shapes.py` shape, `fbound`: `D` mutually F-bounded interfaces `I1..ID` (`Ii`'s
+own bound mentions `T1..Ti`, generalizing Guava's `MapMakerInternalMap<K, V, E extends
+InternalEntry<K, V, E>, S extends Segment<K, V, E, S>>` to more than two mutually dependent
+type parameters) resolved by one generic factory call with no explicit type witness, returning
+`ID<?,...,?>`. Size-swept: allocation 694 MB → 11.8 GB → 200 GB at `D` = 4/8/12 (`sweep.sh fbound
+40 4 8 12`); `D` = 16 ran 40+ minutes without finishing (killed) — none of it tripped
+`-AinferenceWorkBudget`'s abort. Live JFR at `D` = 16 (`jcmd JFR.dump` mid-run) found the dominant
+cost had shifted away from `typeinference8`'s own frames entirely, into
+`AnnotatedTypeScanner`/`IdentityHashMap` churn (`IdentityHashMap.resize`/`put`/`get` ~40% combined)
+under `InferenceType#applyInstantiations`'s substitution — none of which was charged against
+`recordIncorporationWork`.
+
+Real Guava (`MapMakerInternalMap`'s actual `E`/`S` pair, `D` = 2 in this shape's terms) shows **0**
+`typeinference8` self-time samples over 7800 `ExecutionSample`s on the full 625-file module — this
+is not a real-code regression, it took a deliberately adversarial `D` to reach.
+
+**Fix: three additional `recordIncorporationWork` charges**, closing gaps `git blame` traces back to
+#1829's original instrumentation (which only charged `VariableBounds#doApplyInstantiationsToBounds`'s
+main path):
+1. That method's already-resolved (`allBoundsProper`) fast path still calls
+   `constraints.applyInstantiations()` but returned before the charge — now charges
+   `constraints.size()`.
+2. `Resolution#resolveSmallestSet` (JLS 18.4 resolution — a distinct phase from JLS 18.3
+   incorporation) had no charge of its own, despite copying the whole `BoundSet`
+   (`saveBounds`/`restore`) on every attempt — now charges `as.size()` (the variable set being
+   resolved) per attempt.
+3. `InferenceType#applyInstantiations`'s substitution back into a type's structure (the
+   `AnnotatedTypeScanner`-heavy cost above) had no charge — now charges `map.size()`.
+
+**Verified working, not just plausible:** `checker/tests/inference-budget/InferenceWorkBudgetFBound.java`
+(`D` = 10, same directory's `-AinferenceWorkBudget=2000`) throws `type.argument.inference.budget` in
+~2 s; confirmed via `git stash` that the identical file does *not* trip the budget (exits 0) on the
+pre-fix code. Guava re-check: unchanged wall clock (~7-8 s), zero new budget-exceeded errors, same 20
+pre-existing unrelated classpath errors.
+
+**Still open, for a future session:** `D` ≳ 13 still does not trip the budget in a reasonable time
+even with all three charges (confirmed no `recordIncorporationWork` calls occur within the first 20 s
+at `D` = 15/16/18 — the true dominant cost at that scale is further upstream than any of the three
+sites above, plausibly in constraint-set construction/reduction before incorporation or resolution
+ever starts). The three fixes above catch real, previously-silent cases (verified up to `D` ≈ 10-13)
+but do not close the gap completely at the most extreme synthetic end. Also open: a `-AinferenceWorkBudget`-unlimited
+peak-work measurement on the same Guava/Nullness workload this session found **0** (vs. #1829's
+documented 994) — not yet reconciled; may be a difference between this session's raw `-proc:only`
+`javac` invocation (missing two unrelated Guava source files, 20 classpath errors) and whatever
+harness #1829 used, or may indicate the peak-work figure needs re-measuring on today's code before
+being cited again (see "re-trace before planning" above).
+
 ### `AnnotatedTypeFactory.isFromByteCode` caching (July 2026)
 
 PR #1868 (three days prior, `Use ElementUtils.isElementFromSourceCode and deprecate

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1709,17 +1709,106 @@ main path):
 pre-fix code. Guava re-check: unchanged wall clock (~7-8 s), zero new budget-exceeded errors, same 20
 pre-existing unrelated classpath errors.
 
-**Still open, for a future session:** `D` ≳ 13 still does not trip the budget in a reasonable time
-even with all three charges (confirmed no `recordIncorporationWork` calls occur within the first 20 s
-at `D` = 15/16/18 — the true dominant cost at that scale is further upstream than any of the three
-sites above, plausibly in constraint-set construction/reduction before incorporation or resolution
-ever starts). The three fixes above catch real, previously-silent cases (verified up to `D` ≈ 10-13)
-but do not close the gap completely at the most extreme synthetic end. Also open: a `-AinferenceWorkBudget`-unlimited
+**Still open at the time of that entry:** `D` ≳ 13 still did not trip the budget in a reasonable time
+even with all three charges. The hypothesis recorded here — that the true dominant cost at that scale
+is in constraint-set construction/reduction before incorporation or resolution ever starts — was
+**refuted**; see the next entry for what it actually is. Also open: a `-AinferenceWorkBudget`-unlimited
 peak-work measurement on the same Guava/Nullness workload this session found **0** (vs. #1829's
 documented 994) — not yet reconciled; may be a difference between this session's raw `-proc:only`
 `javac` invocation (missing two unrelated Guava source files, 20 classpath errors) and whatever
 harness #1829 used, or may indicate the peak-work figure needs re-measuring on today's code before
-being cited again (see "re-trace before planning" above).
+being cited again (see "re-trace before planning" above). *(Resolved by the next entry's
+instrumentation: with all three charges above in place the peak on Guava/Nullness is 1196 units, in
+line with #1829's 994; the "0" was a measurement artifact.)*
+
+### Mutually F-bounded generics: the exponential is an ATM-representation cost, not an inference cost (August 2026)
+
+Follow-up to the entry above, which left "why doesn't the budget trip at `D` ≳ 13" open and guessed
+constraint-set construction/reduction. **That guess is wrong.** Measured, on today's code:
+
+**1. The cost is exponential, not high-degree polynomial.** One `fbound` problem (`gen-shapes.py D
+--shape fbound --reps 1`, Nullness, `-proc:only`) takes 2.2 / 4.4 / 11.0 / 20.3 / 40.1 / 88.3 s at
+`D` = 8/10/12/13/14/15 — a clean factor of ~2 per `+1` in `D`. Plain `javac` on the same files:
+0.5 / 0.6 / 1.0 / 2.2 s at `D` = 12/15/18/20.
+
+**2. The reason: the Checker Framework materializes javac's *shared* type graph as an exponentially
+large `AnnotatedTypeMirror` tree.** Instrumenting the resolved instantiations (identity-memoized node
+counts of both the `AnnotatedTypeMirror` and its underlying javac `TypeMirror`) gives, per `D`:
+
+| `D` | ATM tree nodes | ATM *distinct* nodes | javac tree nodes | javac *distinct* nodes |
+| --- | --- | --- | --- | --- |
+| 6  | 96   | 96   | 368   | 24 |
+| 8  | 384  | 384  | 1792  | 32 |
+| 10 | 768  | 768  | 3904  | 36 |
+| 12 | 6144 | 6144 | 38912 | 48 |
+
+javac's own `Type` graph stays **linear** in `D` (its capture variables' bounds reference each other
+by identity, so it is a DAG); the ATM mirror of it has `tree == distinct`, i.e. it is a fully
+expanded tree of `3·2^(D-1)` distinct objects. `TypeVariableSubstitutor.substituteTypeVariable`
+deep-copies the argument at *every* use, so each round of resolution replaces a shared node by a
+private copy: the probe shows a bound go from `tree=190/distinct=94` to `tree=190/distinct=142`
+across one `InferenceType#applyInstantiations`, and to `190/190` after the next. That is where the
+doubling comes from, and it is why *everything downstream* (validation, subtyping, `deepCopy`,
+`hashCode`) is exponential too: at `D` = 14 a JFR profile attributes 91.7% of samples to
+`AnnotatedTypeVariable/AnnotatedDeclaredType.accept` and only **9.07%** to
+`DefaultTypeArgumentInference.inferTypeArgs`; `ConstraintSet`/`Typing` reduction — the hypothesized
+culprit — is under **0.6%** inclusive.
+
+**3. Most of the `fbound` cost is not inference at all; it is the *declarations*.** Generating the
+same file with `--reps 0` (the `I1..ID` interface declarations and the factory method, but **no**
+call, hence no type-argument inference whatsoever) costs 2.5 / 4.8 / 14.3 / **63.0** s at
+`D` = 10/12/14/16 — versus 64.0 s for the full file. Type-checking a chain of mutually F-bounded
+type *parameter bounds* is by itself exponential in the chain length, because `BaseTypeValidator`
+and `AnnotatedTypeCopier` walk the same expanded ATM tree. No inference work budget can bound that,
+because no inference happens.
+
+**Fix shipped for the part a budget *can* bound:** `InferenceType#applyInstantiations` now charges
+the **size** of each instantiation it substitutes (`Java8InferenceContext#typeSize`, a linear
+identity-memoized component count), not only `map.size()`. That is the one quantity that tracks the
+doubling; the other charge sites all scale with the *number* of inference variables, which grows only
+linearly in `D`. Effect (`sweep.sh fbound 40 4 8 12`, deterministic allocation):
+
+| `D` | before | after |
+| --- | --- | --- |
+| 4  |    673 MB |   684 MB |
+| 8  |  11772 MB |  4831 MB |
+| 12 | 200165 MB |  9776 MB |
+
+The marginal Δalloc/Δ`D` goes from 2.84 M → 48.2 M KB/unit (exponential) to 1.06 M → 1.27 M KB/unit
+(flat). Single-problem wall clock at `D` = 14 drops 40.1 s → 16.3 s and at `D` = 16 189.4 s → 64.0 s,
+and inference falls to **0.34%** inclusive at `D` = 16 — i.e. the residual is entirely item 3 above.
+The budget now aborts the chain from `D` = 8 up (charge 13032 at `D` = 8, 50814 at `D` = 10, against
+the 10000 default).
+
+**Sizing the charge (the addressable-fraction check).** Over 63,396 substitutions on Guava's 625-file
+module the largest instantiation is **34** ATM nodes, and over ~75,000 substitutions in the whole
+`:checker:test` corpus it is **54**. Worst *per-problem* total charge: **1941** (Guava) and **2086**
+(`:checker:test`, excluding the two tests that deliberately exceed the budget), against the 10000
+default — about 5× headroom, down from ~8× before. Guava re-checked on both sides: identical 1228
+errors / 89 warnings / **zero** budget-exceeded errors, wall clock 77.7 s → 77.1 s (median of 3).
+
+**What a real fix would need, and why it was not attempted.** The exponential is a representation
+choice: an `AnnotatedTypeMirror` graph could mirror javac's DAG (the framework already builds
+*cyclic* ATMs — `InferenceFactory#createFreshTypeVariable` self-substitutes a captured type variable
+into its own bound, and `AnnotatedTypeScanner`/`AnnotatedTypeCopier` already carry `visitedNodes` /
+`originalToCopy` identity maps precisely so cycles and sharing survive). Making substitution share
+instead of copy would collapse `3·2^(D-1)` nodes to `O(D)`. But `substituteTypeVariable`'s copy is
+load-bearing: two occurrences of the same type variable (`Map<T,T>`) must be independently
+annotatable, and every consumer of an inferred type — defaulting, flow refinement, viewpoint
+adaptation, the annotators — mutates ATMs in place. Sharing them is the exact aliasing hazard PR
+#1798 spent a program on (see "Removing a defensive copy"). Any real fix has to make the *shared*
+subterm immutable (or copy-on-write) first, and it has to fix ATM *construction*
+(`AnnotatedDeclaredType#getTypeArguments` builds a fresh ATM per javac type argument, with no
+identity memo — that is what expands the declaration-side DAG in item 3), not just substitution.
+That is a framework-wide representation change, not a `typeinference8` change.
+
+**Is it worth doing?** On the evidence above, not for this shape: the deepest mutually F-bounded
+chain in real code is `D` = 2 (`MapMakerInternalMap`), the largest instantiation actually built by
+Guava or by the whole checker test corpus is 34-54 nodes (`D` ≈ 5 equivalent), and the exponential
+only becomes visible at `D` ≥ 10. The budget now aborts the inference half from `D` = 8, and the
+declaration half is bounded by how deep a chain a human or generator would write. Re-open this only
+if a real project shows a deep mutually F-bounded chain, or if the ATM immutability work makes
+sharing cheap for other reasons.
 
 ### `AnnotatedTypeFactory.isFromByteCode` caching (July 2026)
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/ConstraintSet.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/ConstraintSet.java
@@ -144,6 +144,15 @@ public class ConstraintSet implements ReductionResult {
     }
 
     /**
+     * Returns the number of constraints in this set.
+     *
+     * @return the number of constraints in this set
+     */
+    public int size() {
+        return list.size();
+    }
+
+    /**
      * Removes and returns the first constraint that was added to this set.
      *
      * @return first constraint that was added to this set

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -328,15 +328,29 @@ public class InferenceType extends AbstractType {
 
         Map<TypeVariable, AnnotatedTypeMirror> mapping = new LinkedHashMap<>();
 
+        // The substitution below replaces every use of an instantiated variable by a deep copy of
+        // that variable's instantiation, so its cost is proportional to the SIZE of those
+        // instantiations, not to how many there are. That distinction matters: with mutually
+        // F-bounded type parameters, the instantiation of the i'th variable embeds a copy of the
+        // instantiation of each earlier one, so the structures double in size with each variable
+        // resolved and the substitution's cost is exponential in the length of the F-bound chain
+        // while `map.size()` -- charged above and by the other call sites -- stays linear in it.
+        // Charging the instantiation sizes here is what lets the budget abandon such a chain; see
+        // fbound in .claude/skills/cf-performance/gen-shapes.py.
+        int substitutionWork = 0;
         for (Variable alpha : instantiations) {
             AnnotatedTypeMirror instantiation =
                     alpha.getBounds().getInstantiation().getAnnotatedType();
             context.typeFactory.initializeAtm(instantiation);
             mapping.put(alpha.getJavaType(), instantiation);
+            substitutionWork += context.typeSize(instantiation);
         }
         if (map.isEmpty()) {
             return this;
         }
+        // Charge before substituting, so that a substitution over an already-huge structure is
+        // abandoned rather than merely detected after the fact.
+        context.recordIncorporationWork(substitutionWork);
 
         AnnotatedTypeMirror newType = typeFactory.getTypeVarSubstitutor().substitute(mapping, type);
         return createIgnoreInstantiated(

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -299,6 +299,15 @@ public class InferenceType extends AbstractType {
 
     @Override
     public AbstractType applyInstantiations() {
+        // Charge this against the inference problem's budget. The substitution below deep-copies
+        // and re-substitutes into `type`'s full structure via TypeVarSubstitutor -- unlike the
+        // per-bound-list count VariableBounds#doApplyInstantiationsToBounds charges, this cost
+        // scales with the SIZE of the type structure being substituted into, not just the number
+        // of bounds. For deeply mutually-dependent inference variables (e.g. many mutually
+        // F-bounded type parameters), repeated substitution can build an exponentially larger
+        // structure each time with no work otherwise counted against the budget.
+        context.recordIncorporationWork(map.size());
+
         List<TypeVariable> typeVariables = new ArrayList<>();
         List<TypeMirror> arguments = new ArrayList<>();
         List<Variable> instantiations = new ArrayList<>();

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
@@ -564,7 +564,11 @@ public class VariableBounds {
             // (ProperType.applyInstantiations() is the identity) and the changed-gated
             // instantiation detection below cannot fire. Skip re-scanning the bounds of this
             // fully-resolved variable -- the dominant cost of the incorporation fixpoint on large
-            // problems. Constraints are still applied.
+            // problems. Constraints are still applied, so charge for that: this fast path bypasses
+            // the recordIncorporationWork call below, so without a charge here a bound set with a
+            // large constraint set and many already-proper variables could apply those constraints
+            // an unbounded number of times with no work ever counted against the budget.
+            context.recordIncorporationWork(constraints.size());
             constraints.applyInstantiations();
             return false;
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Java8InferenceContext.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Java8InferenceContext.java
@@ -85,13 +85,25 @@ public class Java8InferenceContext {
             Collections.newSetFromMap(new IdentityHashMap<>());
 
     /**
-     * Maximum amount of bound-incorporation work (sum of bound-list sizes visited by {@link
-     * org.checkerframework.framework.util.typeinference8.types.VariableBounds#applyInstantiationsToBounds})
-     * permitted for a single inference problem before inference is abandoned.
+     * Maximum amount of work permitted for a single inference problem before inference is
+     * abandoned. This totals work from all three phases of JLS 18 that {@link
+     * #recordIncorporationWork} is charged against: bound incorporation to a fixed point (JLS 18.3,
+     * the sum of bound-list sizes visited by {@link
+     * org.checkerframework.framework.util.typeinference8.types.VariableBounds#applyInstantiationsToBounds},
+     * including its already-resolved fast path, which still applies constraints and so is charged
+     * for the size of the constraint set), variable resolution (JLS 18.4, charged per attempt in
+     * {@link org.checkerframework.framework.util.typeinference8.util.Resolution#resolveSmallestSet}
+     * for the size of the variable set being resolved), and substitution of a resolved
+     * instantiation back into a type's structure ({@link
+     * org.checkerframework.framework.util.typeinference8.types.InferenceType#applyInstantiations}).
      *
-     * <p>Incorporating bounds to a fixed point (JLS 18.3) is roughly cubic in the nesting depth of
-     * a generic invocation, so a single deeply nested (often machine-generated) invocation can take
-     * many seconds. This bound caps that work: when it is exceeded an {@link
+     * <p>Incorporating bounds to a fixed point is roughly cubic in the nesting depth of a generic
+     * invocation, and resolving many mutually dependent inference variables together (e.g. many
+     * mutually F-bounded type parameters resolved by one wildcarded generic invocation) is worse,
+     * so a single pathological (often machine-generated, but see {@code fbound} in {@code
+     * .claude/skills/cf-performance/gen-shapes.py} for a hand-written shape that reaches it) can
+     * otherwise take many seconds or effectively hang the compiler. This bound caps that work: when
+     * it is exceeded an {@link
      * org.checkerframework.framework.util.typeinference8.util.InferenceBudgetExceededError} is
      * thrown and inference falls back to a sound, conservative result. The largest work measured on
      * hand-written code is 994 units (Guava, with the Nullness Checker); this value keeps roughly

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Java8InferenceContext.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Java8InferenceContext.java
@@ -8,6 +8,8 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.util.typeinference8.InvocationTypeInference;
 import org.checkerframework.framework.util.typeinference8.types.InferenceFactory;
 import org.checkerframework.framework.util.typeinference8.types.ProperType;
@@ -95,22 +97,26 @@ public class Java8InferenceContext {
      * {@link org.checkerframework.framework.util.typeinference8.util.Resolution#resolveSmallestSet}
      * for the size of the variable set being resolved), and substitution of a resolved
      * instantiation back into a type's structure ({@link
-     * org.checkerframework.framework.util.typeinference8.types.InferenceType#applyInstantiations}).
+     * org.checkerframework.framework.util.typeinference8.types.InferenceType#applyInstantiations},
+     * charged both for the number of inference variables and for the size of the instantiations
+     * being substituted).
      *
      * <p>Incorporating bounds to a fixed point is roughly cubic in the nesting depth of a generic
      * invocation, and resolving many mutually dependent inference variables together (e.g. many
-     * mutually F-bounded type parameters resolved by one wildcarded generic invocation) is worse,
-     * so a single pathological (often machine-generated, but see {@code fbound} in {@code
+     * mutually F-bounded type parameters resolved by one wildcarded generic invocation) is worse:
+     * there each variable's instantiation embeds a copy of every earlier one, so the instantiations
+     * double in size with each variable resolved. So a single pathological invocation (often
+     * machine-generated, but see {@code fbound} in {@code
      * .claude/skills/cf-performance/gen-shapes.py} for a hand-written shape that reaches it) can
      * otherwise take many seconds or effectively hang the compiler. This bound caps that work: when
      * it is exceeded an {@link
      * org.checkerframework.framework.util.typeinference8.util.InferenceBudgetExceededError} is
      * thrown and inference falls back to a sound, conservative result. The largest work measured on
-     * hand-written code is 994 units (Guava, with the Nullness Checker); this value keeps roughly
-     * an order of magnitude of headroom over that, so it does not affect realistic programs while
-     * still abandoning a pathological invocation in roughly 3 seconds rather than 5. Override with
-     * {@code -AinferenceWorkBudget=N} (raise it for legitimate machine-generated code that hits
-     * it).
+     * real code is 1941 units (Guava, with the Nullness Checker) and 2086 units over the whole
+     * {@code :checker:test} corpus; this value keeps roughly five times that headroom, so it does
+     * not affect realistic programs while still abandoning a pathological invocation after at most
+     * a few seconds. Override with {@code -AinferenceWorkBudget=N} (raise it for legitimate
+     * machine-generated code that hits it).
      */
     public static final int MAX_INCORPORATION_WORK = 10_000;
 
@@ -151,6 +157,58 @@ public class Java8InferenceContext {
                         RuntimeException.class, env.getTypeUtils(), env.getElementUtils());
         this.inferenceTypeFactory = new InferenceFactory(this);
         this.object = inferenceTypeFactory.getObject();
+    }
+
+    /**
+     * Counts the components of an {@link org.checkerframework.framework.type.AnnotatedTypeMirror},
+     * for {@link #typeSize}. A shared or recursive component is descended into only once, so the
+     * scan is linear in the type's structure even when that structure is a cycle or a shared graph.
+     *
+     * <p>This scanner is stateful, so it is not reentrant; annotation processing is
+     * single-threaded, and the framework keeps static scanners elsewhere for the same reason (see
+     * {@code AnnotatedTypeMirror}'s hash-code visitor and equality comparer).
+     */
+    private static final class TypeSizeScanner extends AnnotatedTypeScanner<Void, Void> {
+
+        /** The number of components counted by the scan in progress. */
+        private int size = 0;
+
+        /** Creates a TypeSizeScanner. */
+        TypeSizeScanner() {
+            super();
+        }
+
+        /**
+         * Returns the number of components in {@code type}.
+         *
+         * @param type the type to measure
+         * @return the number of components in {@code type}
+         */
+        int measure(AnnotatedTypeMirror type) {
+            size = 0;
+            visit(type);
+            return size;
+        }
+
+        @Override
+        protected Void scan(AnnotatedTypeMirror type, Void p) {
+            size++;
+            return super.scan(type, p);
+        }
+    }
+
+    /** Counts the components of a type; see {@link #typeSize}. */
+    private static final TypeSizeScanner TYPE_SIZE_SCANNER = new TypeSizeScanner();
+
+    /**
+     * Returns the number of components of {@code type}, an estimate of the cost of copying or
+     * substituting into it.
+     *
+     * @param type the type to measure
+     * @return the number of components of {@code type}
+     */
+    public int typeSize(AnnotatedTypeMirror type) {
+        return TYPE_SIZE_SCANNER.measure(type);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Resolution.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Resolution.java
@@ -184,6 +184,16 @@ public class Resolution {
      */
     private BoundSet resolveSmallestSet(Set<Variable> as, BoundSet boundSet) {
         assert !boundSet.containsFalse();
+        // Charge this attempt against the inference problem's budget. resolveSmallestSet is JLS
+        // 18.4 resolution, a distinct phase from the bound-incorporation fixed point (JLS 18.3)
+        // that recordIncorporationWork's other call site
+        // (VariableBounds#doApplyInstantiationsToBounds)
+        // tracks; resolution has its own cost (the BoundSet copy/save/restore below, plus
+        // resolveWithoutCapture/resolveWithCapture) that is not otherwise charged, so a bound set
+        // with many mutually dependent variables (e.g. deeply mutually F-bounded type parameters)
+        // could otherwise resolve the same, or a growing, smallest-dependency set repeatedly with
+        // no work ever counted against the budget.
+        context.recordIncorporationWork(as.size());
 
         if (boundSet.containsCapture(as)) {
             BoundSet resolvedBounds = resolveWithoutCapture(as, boundSet);


### PR DESCRIPTION
## Summary

`-AinferenceWorkBudget`'s `recordIncorporationWork` only charged `VariableBounds#doApplyInstantiationsToBounds`'s main path (JLS 18.3 bound incorporation). A generic invocation resolving many mutually dependent inference variables together -- e.g. many mutually F-bounded type parameters resolved by one wildcarded generic invocation, the shape of Guava's `MapMakerInternalMap<K, V, E extends InternalEntry<K, V, E>, S extends Segment<K, V, E, S>>` generalized past its own two mutually dependent type parameters -- could run for many seconds, or effectively hang the compiler, with none of that work counted against the budget.

Found via a new `gen-shapes.py` `fbound` shape (`.claude/skills/cf-performance/`, this repo's own perf-investigation tooling): sweeping `D` (the number of mutually F-bounded type parameters) showed allocation growing 694 MB -> 11.8 GB -> 200 GB at `D` = 4/8/12, and `D` = 16 ran 40+ minutes without finishing before being killed -- none of it ever tripped the budget.

Two commits:

**1. Charge three previously-uncounted sites** (`VariableBounds#doApplyInstantiationsToBounds`'s already-resolved fast path, `Resolution#resolveSmallestSet`'s JLS 18.4 resolution, `InferenceType#applyInstantiations`'s substitution) by count -- number of constraints/variables/type-variables involved. This closes the three gaps above, but a chain of `D` >~ 13 mutually F-bounded type parameters still didn't trip the budget in reasonable time even with all three counted.

**2. Charge substitution by size, not count, and explain why (1) didn't fully close the gap.** `InferenceType#applyInstantiations` replaces every use of an instantiated variable with a deep copy of its instantiation, so the cost is proportional to the instantiation's *size*, not the number of variables. With mutually F-bounded type parameters the two diverge exponentially: each instantiation embeds a copy of every earlier one, so instantiations double in size while their count grows only linearly. Measured: the resolved instantiation reaches 6144 `AnnotatedTypeMirror` nodes at chain length 12, while the corresponding javac `Type` graph -- a DAG, not a tree -- has only 48 distinct nodes; charging only counts, the budget reached just 4368/10000 at that length and never aborted. Charging the component count of each instantiation (a linear, identity-memoized scan) instead: allocation on a `D` = 4/8/12 sweep goes 673/11772/200165 MB -> 684/4831/9776 MB, and a single `D` = 16 problem drops from 189.4 s to 64.0 s.

That remaining 64.0 s is not inference, and this commit tracks down exactly what it is rather than leaving it open: compiling the same declarations with no generic invocation at all (no inference at all) costs 63.0 s of that 64.0 s, because the Checker Framework materializes javac's *shared* type graph as a fully-expanded `AnnotatedTypeMirror` tree -- `3*2^(D-1)` distinct nodes where javac's own DAG stays linear in `D`. No inference work budget can bound that, because no inference happens; it's a representation cost in `AnnotatedDeclaredType#getTypeArguments`/substitution sharing, not in `typeinference8`. `docs/developer/performance-notes.md` records why a real fix (sharing instead of copying) isn't attempted here: it would require making shared ATM subterms immutable or copy-on-write first (the exact aliasing hazard #1798 addressed for a different case), and isn't justified by real code -- the deepest mutually F-bounded chain anywhere in Guava or this repo's own test corpus is `D` = 2, and the largest instantiation actually built (Guava, 625 files) is 34 ATM nodes, equivalent to `D` ~= 5.

## Test plan

- [x] `./gradlew :framework:test :checker:test :javacutil:test :dataflow:test` -- BUILD SUCCESSFUL
- [x] `./gradlew :checker:test --tests "*InferenceBudgetTest*"` -- `InferenceWorkBudget.java` and the new `InferenceWorkBudgetFBound.java` pass
- [x] Confirmed via `git stash` that each new regression case fails to trip the budget on the pre-fix code and does trip it after, for both commits independently -- proves each fix, not pre-existing behavior
- [x] Real Guava (625 files, Nullness Checker), re-checked after both commits: identical 1228 errors / 89 warnings, zero budget-exceeded errors, 77.1 s vs. 77.7 s median wall clock (3 runs)
- [x] Whole `:checker:test` corpus's largest per-problem charge: 2086 units (excluding the two tests that deliberately exceed the budget), against the 10000 default
- [x] Merged `master` (now including #1961, a large, unrelated `BaseTypeVisitor.java` change) with one clean CHANGELOG conflict; `:framework:test :checker:test` reconfirmed green after the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfhc2QA5Lo9A1vkiwT52ov
