### PR TITLE
CI: test templatefora-checker against this checkout, not last release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           - 'daikon-part2'
           - 'jspecify-conformance'
           - 'jspecify-reference-checker'
+          - 'templatefora-checker'
           - 'misc'
         # Keep in sync with env.PRIMARY_JDK.
         java_version: [21]
@@ -233,6 +234,7 @@ jobs:
           - {script: 'misc',            java: {version: '26'}}
           - {script: 'jspecify-conformance', java: {version: '26'}}
           - {script: 'jspecify-reference-checker', java: {version: '26'}}
+          - {script: 'templatefora-checker', java: {version: '26'}}
           # Daikon produces 'this-escape' warnings in JDK 22+. Only JDK 17.
           - {script: 'daikon-part1',    java: {version: '17'}}
           - {script: 'daikon-part2',    java: {version: '17'}}

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ ext {
     plumeScriptsHome = "${project(':checker').projectDir}/bin-devel/.plume-scripts"
     htmlToolsHome = "${project(':checker').projectDir}/bin-devel/.html-tools"
     doLikeJavacHome = "${project(':checker').projectDir}/bin/.do-like-javac"
-    templateforaCheckerDir = "${parentDir}/templatefora-checker"
     demosDir = "${parentDir}/checker-framework.demos"
 
     javadocMemberLevel = JavadocMemberLevel.PROTECTED
@@ -1072,12 +1071,6 @@ tasks.register('getHtmlTools', CloneTask) {
 tasks.register('getDoLikeJavac', CloneTask) {
     url.set('https://github.com/opprop/do-like-javac.git')
     directory.set(file(doLikeJavacHome))
-    outputs.upToDateWhen { false }
-}
-
-tasks.register('getTemplateforaChecker', CloneTask) {
-    url.set('https://github.com/eisop/templatefora-checker.git')
-    directory.set(file(templateforaCheckerDir))
     outputs.upToDateWhen { false }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,15 @@ switch (JavaVersion.current()) {
 // Provider<String> whose value becomes a configuration-cache input, and feeding the derived
 // Provider into 'into' lets the destination resolve lazily without mutating shared project state
 // at execution time.
+//
+// workingDir is set explicitly, not left to default to the process's own CWD: when this project
+// is used as an --include-build (e.g. templatefora-checker's or jspecify-reference-checker's own
+// CI, testing against this checkout), the process CWD is the *including* build's directory, not
+// this one -- without it, `git worktree list` here listed the including build's worktree instead,
+// installing these hooks into that unrelated repository's .git/hooks (confirmed by reproducing it
+// with a real --include-build run).
 def gitHooksDir = providers.exec {
+    workingDir(layout.projectDirectory)
     commandLine 'git', 'worktree', 'list'
 }.standardOutput.asText.map { String worktreeList ->
     worktreeList.substring(0, worktreeList.indexOf(' ')) + '/.git/hooks'

--- a/checker/bin-devel/test-misc.sh
+++ b/checker/bin-devel/test-misc.sh
@@ -15,10 +15,6 @@ PLUME_SCRIPTS="$SCRIPT_DIR/.plume-scripts"
 "$GIT_SCRIPTS/git-clone-related" eisop checker-framework.demos
 ./gradlew :checker:demosTests --console=plain --warning-mode=all
 
-## Checker Framework templatefora-checker
-"$GIT_SCRIPTS/git-clone-related" eisop templatefora-checker
-./gradlew :checker:templateforaCheckerTests --console=plain --warning-mode=all
-
 status=0
 
 ## Javadoc documentation

--- a/checker/bin-devel/test-templatefora-checker.sh
+++ b/checker/bin-devel/test-templatefora-checker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+# set -o verbose
+set -o xtrace
+export SHELLOPTS
+echo "SHELLOPTS=${SHELLOPTS}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+source "$SCRIPT_DIR"/clone-related.sh
+
+"$SCRIPT_DIR/.git-scripts/git-clone-related" eisop templatefora-checker
+
+cd ../templatefora-checker
+
+# --include-build makes Gradle substitute this checkout's own :checker, :checker-qual, and
+# :framework-test project outputs for the io.github.eisop:checker, :checker-qual, and
+# :framework-test coordinates templatefora-checker's build.gradle declares, automatically:
+# both share the "io.github.eisop" group and matching project/module names, which is all
+# Gradle's composite-build dependency substitution needs. This tests this checkout's own
+# in-progress state, not the last eisop release -- see jspecify-reference-checker's own use of
+# this same mechanism, and its checker-framework/build.gradle "checkerFramework" ext property,
+# for a more elaborate example.
+./gradlew build --console=plain --warning-mode=all --include-build "$CHECKERFRAMEWORK" \
+  --no-configuration-cache \
+  -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -459,21 +459,6 @@ tasks.register('demosTests') {
     }
 }
 
-tasks.register('templateforaCheckerTests') {
-    dependsOn('assembleForJavac', ':getTemplateforaChecker')
-    group = 'Verification'
-    description = 'Test that the templatefora-checker is working as expected.'
-    def injected = project.objects.newInstance(InjectedExecOps)
-    def templateforaDir = file(rootProject.templateforaCheckerDir)
-
-    doLast {
-        injected.execOps.exec {
-            workingDir = templateforaDir
-            commandLine "./gradlew", "build"
-        }
-    }
-}
-
 tasks.register('allNullnessTests', Test) {
     group = 'Verification'
     description = 'Run all JUnit tests for the Nullness Checker.'


### PR DESCRIPTION
## Summary

- `templateforaCheckerTests` (in `test-misc.sh`) cloned `templatefora-checker` and ran its own `./gradlew build` unmodified, which resolves `io.github.eisop:checker`/`:checker-qual` from Maven Central — always the last eisop release, never this checkout's own in-progress state. A change here that broke the reference template checker would only be caught after release, not on the PR that introduced it.
- Adds `test-templatefora-checker.sh`, a dedicated CI script mirroring `test-jspecify-reference-checker.sh`: it clones `templatefora-checker` (preferring a branch matching this one, via `git-clone-related`, same as jspecify's script) and runs its build with `--include-build "$CHECKERFRAMEWORK"`. Gradle's composite-build dependency substitution automatically swaps in this checkout's own `:checker`, `:checker-qual`, and `:framework-test` project outputs for the matching `io.github.eisop:*` coordinates — both share the group and project names, which is all it needs; no changes to templatefora-checker's own `build.gradle` are required.
- Wired into `ci.yml`'s `remainder` and `integration-jdks` matrices alongside `jspecify-reference-checker`, which already uses this same pattern.
- Removes `templateforaCheckerTests`, `getTemplateforaChecker`, and `templateforaCheckerDir` (`checker/build.gradle`, `build.gradle`): nothing else referenced them, and the new script does not need a Gradle `CloneTask` for its own clone either — `test-jspecify-reference-checker.sh` doesn't use one.
- Fixes a real bug found while testing this: `installGitHooks`'s `git worktree list` had no explicit `workingDir`, so it inherited the Gradle process's own CWD. Under `--include-build`, that CWD is the *including* build's directory, not this one — this repo's own hooks were being installed into the unrelated including repository's `.git/hooks` instead. Reproduced and fixed by pinning `workingDir` to `layout.projectDirectory`.

## Test plan

- [x] Verified with a real composite build against a local `templatefora-checker` checkout on its current `master` (now on Gradle 9.7.1, after [eisop/templatefora-checker#24](https://github.com/eisop/templatefora-checker/pull/24)): compiles and tests successfully, exercising this checkout's own `:checker:generateBinaryStubFiles` and `:checker:checkerJar` as part of resolving the substituted dependencies.
- [x] Verified `installGitHooks` installs correctly both under `--include-build` (hooks land only in the including build's own `.git/hooks`, never the included one's) and in the ordinary case.
- [x] `./gradlew assemble`, `spotlessApply`, `shfmt`/`shellcheck` on the new/changed scripts: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)