### PR TITLE
Make `AnnotatedTypeMirror.toString(false)` equivalent to `toString()`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -252,6 +252,15 @@ element-type checks treated as a reference upcast or downcast; the Signedness
 Checker reported `(char) x`, where `x` has type `@Signed int`, as not
 statically verifiable.
 
+`AnnotatedTypeMirror.toString(false)` returns the same string as
+`AnnotatedTypeMirror.toString()`. Verbose printing now only adds detail: it
+never suppresses a detail that the type factory's `AnnotatedTypeFormatter` is
+configured to print. Previously, `toString(false)` forced invisible qualifiers
+and verbose generics off, overriding `-AprintAllQualifiers`,
+`-AprintVerboseGenerics`, and a checker-supplied formatter default; for
+instance, a Units Checker type printed through `toString(false)` lost its
+`@UnknownUnits` qualifier, which `toString()` prints.
+
 **Implementation details:**
 
 `AnnotatedIntersectionType.summarizeBounds` computes the summary described

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFormatter.java
@@ -23,7 +23,10 @@ public interface AnnotatedTypeFormatter {
      * Formats type into a String. Verbose printing shows details, such as invisible annotations,
      * that an implementation's default might omit; it never hides a detail that {@link
      * #format(AnnotatedTypeMirror)} shows. Therefore, {@code format(type, false)} returns the same
-     * string as {@code format(type)}.
+     * string as {@code format(type)}: {@code printVerbose} asks for optional extra detail on top of
+     * {@link #format(AnnotatedTypeMirror)}'s output, not for a specific level of detail in its own
+     * right, so there is no argument that requests less detail than {@link
+     * #format(AnnotatedTypeMirror)} already provides.
      *
      * @param type the type to be converted
      * @param printVerbose whether or not to print verbosely

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFormatter.java
@@ -20,7 +20,10 @@ public interface AnnotatedTypeFormatter {
     public String format(AnnotatedTypeMirror type);
 
     /**
-     * Formats type into a String.
+     * Formats type into a String. Verbose printing shows details, such as invisible annotations,
+     * that an implementation's default might omit; it never hides a detail that {@link
+     * #format(AnnotatedTypeMirror)} shows. Therefore, {@code format(type, false)} returns the same
+     * string as {@code format(type)}.
      *
      * @param type the type to be converted
      * @param printVerbose whether or not to print verbosely

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1003,7 +1003,10 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
      * Returns a possibly-verbose string representation of this type. Verbose printing shows details
      * that {@link #toString()} might omit, such as invisible qualifiers and the bounds of type
      * variables and wildcards; it never omits a detail that {@link #toString()} shows. Therefore,
-     * {@code toString(false)} returns the same string as {@code toString()}.
+     * {@code toString(false)} returns the same string as {@code toString()}: {@code verbose} asks
+     * for optional extra detail on top of {@link #toString()}'s output, not for a specific level of
+     * detail in its own right, so there is no argument that requests less detail than {@link
+     * #toString()} already provides.
      *
      * @param verbose if true, print details that {@link #toString()} might omit
      * @return a possibly-verbose string representation of this type

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -986,12 +986,28 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
         }
     }
 
+    /**
+     * Returns a string representation of this type, using the type factory's {@link
+     * AnnotatedTypeFormatter}. Whether details such as invisible qualifiers appear depends on that
+     * formatter's configuration.
+     *
+     * @return a string representation of this type
+     */
     @SideEffectFree
     @Override
     public final String toString() {
         return atypeFactory.getAnnotatedTypeFormatter().format(this);
     }
 
+    /**
+     * Returns a possibly-verbose string representation of this type. Verbose printing shows details
+     * that {@link #toString()} might omit, such as invisible qualifiers and the bounds of type
+     * variables and wildcards; it never omits a detail that {@link #toString()} shows. Therefore,
+     * {@code toString(false)} returns the same string as {@code toString()}.
+     *
+     * @param verbose if true, print details that {@link #toString()} might omit
+     * @return a possibly-verbose string representation of this type
+     */
     @SideEffectFree
     public final String toString(boolean verbose) {
         return atypeFactory.getAnnotatedTypeFormatter().format(this, verbose);

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -141,13 +141,13 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         protected final boolean defaultInvisiblesSetting;
 
         /**
-         * For a given call to format, this setting specifies whether or not to printInvisibles. If
-         * a user did not specify a printInvisible parameter in the call to format then this value
-         * will equal DefaultAnnotatedTypeFormatter.defaultInvisibleSettings for this object
+         * For a given call to format, this setting specifies whether or not to printInvisibles.
+         * Unless the call to format requested verbose printing, this value equals {@link
+         * #defaultInvisiblesSetting} for this object.
          */
         protected boolean currentPrintInvisibleSetting;
 
-        /** Default value of currentPrintVerboseGenerics. */
+        /** Default value of {@link #currentPrintVerboseGenerics}. */
         protected final boolean defaultPrintVerboseGenerics;
 
         /**
@@ -174,14 +174,21 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
             this.defaultPrintVerboseGenerics = printVerboseGenerics;
             this.currentPrintVerboseGenerics = printVerboseGenerics;
             this.defaultInvisiblesSetting = defaultInvisiblesSetting;
-            this.currentPrintInvisibleSetting = false;
+            this.currentPrintInvisibleSetting = defaultInvisiblesSetting;
             this.currentlyPrintingRaw = false;
         }
 
-        /** Set the current verbose settings to use while printing. */
+        /**
+         * Sets the current verbose settings to use while printing. The settings are never less
+         * verbose than this visitor's defaults, so passing false is equivalent to {@link
+         * #resetPrintVerboseSettings()}.
+         *
+         * @param printVerbose if true, print invisible qualifiers and verbose generics regardless
+         *     of this visitor's defaults
+         */
         protected void setVerboseSettings(boolean printVerbose) {
-            this.currentPrintInvisibleSetting = printVerbose;
-            this.currentPrintVerboseGenerics = printVerbose;
+            this.currentPrintInvisibleSetting = printVerbose || defaultInvisiblesSetting;
+            this.currentPrintVerboseGenerics = printVerbose || defaultPrintVerboseGenerics;
         }
 
         /** Set verbose settings to the default. */


### PR DESCRIPTION
## Summary

`DefaultAnnotatedTypeFormatter.format(type, printVerbose)` set both
`currentPrintInvisibleSetting` and `currentPrintVerboseGenerics` to
`printVerbose` directly, while `format(type)` reset them to the
formatter's own configured defaults (`defaultInvisiblesSetting`/
`defaultPrintVerboseGenerics`, driven by `-AprintAllQualifiers`/
`-AprintVerboseGenerics`, or hardcoded by a checker-supplied formatter
such as `UnitsAnnotatedTypeFormatter`, which always wants invisible
qualifiers printed). The two `AnnotatedTypeMirror.toString()` /
`toString(boolean)` overloads therefore disagreed whenever a formatter's
configured defaults differ from `false`: for a Units Checker type,
`toString()` prints `@UnknownUnits int`, but `toString(false)` printed
plain `int`, silently dropping the qualifier an error message is about.

Found while refactoring an unrelated call site (PR #1961) that computes
its verbose flag rather than always passing a literal `true`/`false`;
every existing caller in this repository passes a literal `true` to
`toString(boolean)`, so no diagnostic text anywhere is affected today,
but the divergence is a real trap for any future caller that computes
the flag the way #1961's did.

`FormattingVisitor.setVerboseSettings` now raises the current settings
rather than overwriting them (`printVerbose || defaultXSetting`), so
they are never less verbose than the formatter's configured defaults.
Verbose printing adds detail; it never removes any -- which is what
every existing caller of `toString(true)` already wants, and makes
`format(type, false)` equivalent to `format(type)`. Javadoc on
`AnnotatedTypeFormatter.format`, `AnnotatedTypeMirror.toString(boolean)`,
and the visitor's settings methods now states this contract.

## Test plan

- [x] `:framework:test` + `:checker:test` (full suites) green
- [x] `:checker:jtregTests` + `:framework:jtregTests` green
- [x] `:checker:exampleTests` green -- this is the target that actually
  exercises `docs/examples/units-extension`, the concrete case this fixes
- [x] `requireJavadoc` -- one fewer hit than `master` (newly documented
  `toString(boolean)`), zero new hits
- [x] `spotlessApply` / `spotlessCheck` clean
- [x] `javadocDoclintAll` clean on touched files
- [x] Confirmed no existing diagnostic text changes anywhere: every
  `AnnotatedTypeFormatter.format(type, boolean)` call site is reachable
  only through `AnnotatedTypeMirror.toString(boolean)`, and every
  in-repo caller of that overload passes a literal `true` -- so the
  only behavior this patch can change is the `false` path, which
  nothing currently calls. Confirmed the actual regression is fixed by
  temporarily reproducing PR #1961's `verbose ? x.toString(true) :
  x.toString()` -> `x.toString(verbose)` change against `master`
  first (reproduces `found: int` instead of `found: @UnknownUnits int`
  in `docs/examples/units-extension`), then confirming this fix
  restores the correct output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfhc2QA5Lo9A1vkiwT52ov
