### PR TITLE
Resolve the pinned JDK EA build against EA or GA download paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ permissions:
 env:
   PRIMARY_JDK: "21"
   USE_BAZEL_VERSION: "9.2.0"
-  # JDK 27 early-access build; bump when a new EA build is published.
+  # Pinned pre-release JDK build, from jdk.java.net. Renovate bumps JDK_EA_BUILD;
+  # JDK_EA_MAJOR changes by hand when the next feature release opens.
   JDK_EA_MAJOR: "27"
-  JDK_EA_BUILD: "34"
+  JDK_EA_BUILD: "35"
 
 jobs:
   # Basic sanity tests on the primary JDK.
@@ -172,14 +173,57 @@ jobs:
           java-version: ${{ matrix.java.version }}
           distribution: 'zulu'
 
+      # A pre-release build lives on one of two download paths, depending on how
+      # far through its release cycle it is, so resolve the pinned build against
+      # both rather than assuming either.
+      #
+      # Do not replace this with `website:`/`release:`/`version:`, which lets
+      # `oracle-actions/setup-java` resolve the build. Passing a build-specific
+      # `version: 27-ea+NN` (what #1620 replaced) fails with `No URI mapped for
+      # key` as soon as a newer build lands, because that action's mapping lists
+      # only the current build. Passing no version tracks whatever build is
+      # current, which is what the pin exists to prevent.
+      - name: Resolve pinned JDK ${{ env.JDK_EA_MAJOR }} build ${{ env.JDK_EA_BUILD }}
+        id: ea-jdk
+        if: ${{ matrix.java.version == env.JDK_EA_MAJOR }}
+        env:
+          MAJOR: ${{ env.JDK_EA_MAJOR }}
+          BUILD: ${{ env.JDK_EA_BUILD }}
+        run: |
+          ea="https://download.java.net/java/early_access/jdk${MAJOR}/${BUILD}/GPL/openjdk-${MAJOR}-ea+${BUILD}_linux-x64_bin.tar.gz"
+          if curl -sfI "$ea" > /dev/null; then
+            # Early-access builds stay downloadable long after they stop being
+            # current, so this covers the whole early-access phase.
+            echo "Resolved build ${BUILD} on the early-access path."
+            echo "uri=$ea" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Once a release reaches its release-candidate phase, its builds move to
+          # a path containing a hash that the build number cannot yield, so read
+          # the URI off the release page instead of constructing it.
+          page="https://jdk.java.net/${MAJOR}/"
+          pattern="https://download\.java\.net/java/GA/jdk${MAJOR}/[0-9a-f]+/[0-9]+/GPL/openjdk-${MAJOR}_linux-x64_bin\.tar\.gz"
+          uri=$(curl -sf "$page" | grep -oE "$pattern" | sort -u | head -n 1) || true
+          if [ -z "$uri" ]; then
+            echo "::error::JDK ${MAJOR} build ${BUILD} is not on the early-access path, and ${page} lists no linux-x64 release-candidate archive. Check that page and update JDK_EA_MAJOR/JDK_EA_BUILD."
+            exit 1
+          fi
+          # That page only ever shows the current build, so confirm it is the
+          # pinned one instead of silently testing whatever has replaced it.
+          found=$(printf '%s' "$uri" | sed -E 's#.*/[0-9a-f]+/([0-9]+)/GPL/.*#\1#')
+          if [ "$found" != "$BUILD" ]; then
+            echo "::error::Pinned JDK ${MAJOR} build ${BUILD} is no longer available: it is not on the early-access path, and ${page} now offers build ${found}. Superseded release-candidate builds are not retained, so set JDK_EA_BUILD to ${found}."
+            exit 1
+          fi
+          echo "Resolved build ${BUILD} on the release-candidate path."
+          echo "uri=$uri" >> "$GITHUB_OUTPUT"
+
       - name: Set up early-access JDK ${{ env.JDK_EA_MAJOR }}
         if: ${{ matrix.java.version == env.JDK_EA_MAJOR }}
         uses: oracle-actions/setup-java@v1
         with:
-          # Pin EA builds by direct archive URI.
-          # If the URI stops working, check for the updated pattern here:
-          # https://github.com/oracle-actions/setup-java/blob/main/jdk.java.net-uri.properties
-          uri: ${{ format('https://download.java.net/java/early_access/jdk{0}/{1}/GPL/openjdk-{0}-ea+{1}_linux-x64_bin.tar.gz', env.JDK_EA_MAJOR, env.JDK_EA_BUILD) }}
+          # Resolved above; the action still verifies the archive's checksum.
+          uri: ${{ steps.ea-jdk.outputs.uri }}
           install-as-version: ${{ env.JDK_EA_MAJOR }}
 
       - name: Pin Gradle to JDK ${{ env.PRIMARY_JDK }} via gradle.properties


### PR DESCRIPTION
The `Set up early-access JDK 27` step built the download URI from `JDK_EA_MAJOR`/`JDK_EA_BUILD`, a template that only covers the early-access path. When a release reaches its release-candidate phase its builds move to a path containing a hash that the build number cannot yield, so the constructed URI 404s.

`oracle-actions/setup-java` writes the response body to the archive without checking the status code, so the 404 page is stored as the archive and the only error raised is the missing sibling `.sha256`: `Checksum verification failed, deleting cached archive`. That names neither the cause nor a remedy. It is what #1960 hits.

### The fix

A preceding step resolves the pinned build against both paths:

1. Try the early-access URI. Early-access archives stay downloadable long after they stop being current, so this covers the whole early-access phase.
2. Otherwise read the release-candidate URI off `https://jdk.java.net/{major}/`, and **check the build number in the resolved URI against the pin** — that page only ever shows the current build, so accepting it blindly would silently test something other than what is pinned.
3. Otherwise fail with an explicit message naming the build to move to.

The pin and the Renovate flow are unchanged.

Verified by running the step's exact `run:` body, extracted from the YAML, under `bash -e` against the live endpoints:

| pinned build | outcome |
|---|---|
| 34 | resolved on the early-access path |
| 35 | resolved on the release-candidate path |
| 36 (does not exist) | exit 1, `Pinned JDK 27 build 36 is no longer available … set JDK_EA_BUILD to 35.` |

### Why not let the action resolve the build

Both resolver forms are broken today, checked against the live mapping with the action's own `Download.java`:

| form | result |
|---|---|
| `version: 27-ea+34` (master's pin, the form #1620 replaced) | `No URI mapped for key: 27,27-ea+34,linux,x64` |
| `version: 27-ea+35` (#1960's bump, same form) | `No URI mapped for key: 27,27-ea+35,linux,x64` |
| no `version:` | resolves, but tracks whatever build is current — which is what the pin exists to prevent |

The action's mapping lists only the current build and prunes build-specific keys.

### Scope of the problem

Direct-URI pinning has been in place since #1620 (2026-04-04) and carried 16 Renovate bumps, builds ~17 through 34, without a failure. Build 35 is the first failure, and it is structural: it happens once per release cycle, at the early-access to release-candidate transition. `JDK_EA_BUILD` is bumped to 35 here, which is what exercises the new fallback.

One limitation is worth recording: a *superseded* release-candidate build is not recoverable from anywhere — only build 35 resolves under its hash (32, 33, 34, 36 are all 404), `jdk.java.net/27/` shows only the current build, and `jdk.java.net/archive/` holds GA releases only (no jdk27 entries). So if a Renovate PR pinning a release-candidate build sits unreviewed until the next build lands, it will fail — loudly and with instructions now, rather than with a checksum error.

`zulu` still offers JDK 27 only as beta builds (newest b32, older than the b35 release candidate), so JDK 27 cannot yet move to the plain `actions/setup-java` list used by JDK 26 and below.

#1960 is subsumed by this PR and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfhc2QA5Lo9A1vkiwT52ov