### PR TITLE
CFGVisualizeLauncher: stop discarding the real exception from javac.compile

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
@@ -260,7 +260,11 @@ public final class CFGVisualizeLauncher {
             System.setErr(new PrintStream(nullOS));
             javac.compile(List.of(l), List.of(clas), List.of(cfgProcessor), List.nil());
         } catch (Throwable e) {
-            // ok
+            // Report to the original stderr, not the one just nulled out above: silently
+            // discarding this exception is what made eisop#849 undiagnosable for two years.
+            err.println("=== CFGVisualizeLauncher: swallowed Throwable from javac.compile ===");
+            e.printStackTrace(err);
+            err.flush();
         } finally {
             System.setErr(err);
         }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
@@ -260,8 +260,8 @@ public final class CFGVisualizeLauncher {
             System.setErr(new PrintStream(nullOS));
             javac.compile(List.of(l), List.of(clas), List.of(cfgProcessor), List.nil());
         } catch (Throwable e) {
-            // Report to the original stderr, not the one just nulled out above: silently
-            // discarding this exception is what made eisop#849 undiagnosable for two years.
+            // Report to the original stderr, not the one just nulled out above, so a genuine
+            // compiler failure is still visible instead of only the generic error below.
             err.println("=== CFGVisualizeLauncher: swallowed Throwable from javac.compile ===");
             e.printStackTrace(err);
             err.flush();


### PR DESCRIPTION
## Summary

`eisop#849` ("internal error in type processor! method typeProcessOver() doesn't get called", intermittent in CI on `:dataflow:busyExpressionTest`) has been open for two years. Two global CI-flag workarounds have each independently made the symptom go away, but nobody has ever seen the actual underlying exception: `generateMethodCFG` redirects `System.err` to a null stream around the whole `javac.compile()` call, then discards any `Throwable` from that call with `catch (Throwable e) { // ok }`.

This PR just stops discarding it — prints the caught `Throwable` (with its full stack trace) to the pre-redirect stderr instead.

## Verification

In an isolated worktree, printing the caught `Throwable` instead of discarding it reproduced the exact CI failure message intermittently by corrupting the test classpath while the forked JVM was running, and surfaced the real cause for that repro: a `NoClassDefFoundError` for a lazily-loaded class, wrapped by javac as a `ClientCodeException`. That confirms `res == null` is a generic "some `Throwable` escaped `javac.compile`" signal, not evidence that the type processor specifically was never invoked — and that printing it is enough to make the next naturally-occurring CI failure diagnosable.

`BasicTypeProcessor.typeProcess`'s own `catch (Throwable)` is deliberately left alone: its only subclass (`CFGProcessor`) is only ever driven through this same redirected call path, so improving its message wouldn't surface anything new here, and `CFGProcessor`'s tree scanner deliberately throws an empty `RuntimeException` to short-circuit compilation once it finds the target method — printing a full stack trace for that on every successful run would be noise, not diagnosis.

## Test plan

- [x] `./gradlew :dataflow:compileJava` — compiles clean
- [x] `./gradlew :dataflow:busyExpressionTest` — passes, no behavior change on the normal path
- [ ] Land this ahead of/alongside any decision on the `speedup-jdk8-citests` line of work, so the next real occurrence of eisop#849 in CI shows the actual exception instead of another opaque data point

🤖 Generated with [Claude Code](https://claude.com/claude-code)