### PR TITLE
Cap forked test JVMs' JIT compiler thread pool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1393,6 +1393,22 @@ subprojects {
                 jvmArgs += compilerArgsForRunningCF
             }
 
+            // Type-checking the test inputs compiles an unusual amount of code -- over 35
+            // checker JUnit suites in one forked test JVM, -XX:+CITime reports 417759
+            // compiled methods and 1132 s of JIT time on Java 8 (36712 methods / 252 s on
+            // Java 11) -- and each forked test JVM sizes its compiler pool from the machine's
+            // CPU count, unaware of the sibling forks.  maxParallelForks below is the CPU
+            // count, so the JIT threads alone oversubscribe the machine several times over
+            // and crowd out the test threads they are compiling for.  Cap the pool at the
+            // tiered-compilation minimum of 2.
+            //
+            // Measured on the NullnessTest/IndexTest/OptionalTest/AnnotatedForNullnessTest/
+            // StubparserNullnessTest subset, medians over >= 2 trials per side, sum of
+            // per-suite times: Java 8 417.6 s -> 268.2 s (-35.8%), Java 11 367.4 s -> 244.4 s
+            // (-33.5%).  With a single fork the effect is smaller but still positive: 35
+            // suites in one Java 8 test JVM on 4 cores, 616.8 s -> 567.2 s (-8.0%).
+            jvmArgs "-XX:CICompilerCount=2"
+
             // maxParallelForks controls the parallelism of a single Test
             // task. --parallel controls parallelism for the entire build.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,15 @@ Further performance improvements relative to the 3.49.5-eisop1 release:
 Several optimizations also reduce GC pressure and remove superlinear behavior,
 improving performance for large (e.g. auto-generated) files.
 
+Each forked test JVM (`./gradlew test`) used to size its JIT compiler thread
+pool from the whole machine's CPU count, regardless of how many other test
+JVMs Gradle was already running concurrently; on typical hardware this
+oversubscribes the machine several times over once more than one fork is
+active. Capping the pool (`-XX:CICompilerCount=2`) cut wall-clock time by
+about a third on a representative subset of checker JUnit suites with
+multiple concurrent forks, and by about 8% even with test execution
+serialized to a single fork.
+
 The annotated JDK is now distributed additionally as a pre-parsed binary file
 (`annotated-jdk.bin.gz`), so checker startup no longer text-parses the JDK
 stubs. The text stubs remain in `checker.jar` as a fallback; they are expected


### PR DESCRIPTION
## Status: not merging — local measurement didn't transfer to real CI (see "CI results" below)

## Summary

Each forked test JVM (`tasks.withType(Test)`, used by `./gradlew test`) sizes its tiered-compilation JIT compiler thread pool from the whole machine's CPU count via JVM ergonomics, with no awareness of how many other test JVMs Gradle is running concurrently. With `maxParallelForks = availableProcessors()`, several forks each spin up several compiler threads sized as if they owned the whole machine, oversubscribing it several times over and crowding out the very test threads those compiles are for.

This workload compiles an unusual amount of code: `-XX:+CITime` over 35 `:checker:test` suites in one forked JVM reports 417,759 compiled methods / 1132s of JIT time on Java 8 (36,712 methods / 252s on Java 11), against 621s/370s of actual test time.

Cap the pool at the tiered-compilation minimum of 2 (1 C1 + 1 C2) threads per forked JVM, applied unconditionally across the JDK matrix (not JDK-8-specific — the mechanism and the measured gain both hold on Java 11 too).

## Local measurements

Representative subset (NullnessTest, IndexTest, OptionalTest, AnnotatedForNullnessTest, StubparserNullnessTest), medians over >= 2 trials per side, sum of per-suite times, on an 8-core dev machine:

| | Baseline | Capped | Δ |
|---|---|---|---|
| Java 8, concurrent forks | 417.6s | 268.2s | **−35.8%** |
| Java 11, concurrent forks | 367.4s | 244.4s | **−33.5%** |
| Java 8, single fork (35 suites, 4 cores) | 616.8s | 567.2s | **−8.0%** |

Rejected alternatives (measured, not assumed):
- `-XX:TieredStopAtLevel=1`: looked free on the short subset (−2%) but is **+13.9%** on the full 35-suite run — the short subset doesn't run long enough to show C2's payoff. `-XX:-TieredCompilation` is +28%.
- `-XX:ReservedCodeCacheSize=1g`: −1.9%, within noise, adds nothing on top of this change.
- Classic CDS for the JDK-8-only `-Xbootclasspath/p:` javac jar: the whole prize is JVM startup (~15ms/JVM) across ~10 test JVMs per CI job — a ~0.01% effect, not worth an archive.

## CI results: the local gain did not transfer

3 CI runs on this PR (rebased on top of #1976's merged `--no-build-cache` fix, so this measures the JIT cap *on top of* restored parallelism, exactly the condition the local "concurrent forks" numbers above were meant to predict). One of the three reruns turned out to be a no-op duplicate of another (identical job timestamps — looks like a "re-run failed jobs" with nothing to rerun), so these are the 3 genuinely independent runs, compared against the `#1976` post-merge 3-run average baseline (18m46s / 14m04s / 12m48s for JDK 8 / 11 / 17):

| Job | Run A | Run B | Run C | Average | vs. #1976 baseline |
|---|---|---|---|---|---|
| JDK 8 junit | 16m02s | 20m12s | 12m31s | 16m15s | −13.4% |
| JDK 11 junit | 16m14s | 14m45s | 12m00s | 14m19s | +1.9% (flat) |
| JDK 17 junit | 16m25s | 15m34s | 13m42s | 15m13s | **+19.0%** |

This does not match the local prediction of −33 to −35% on JDK 8 *and* JDK 11 concurrent-fork workloads: JDK 8 shows a modest gain well short of predicted, JDK 11 is flat, and JDK 17 looks worse. Some of this is very likely the same shared-runner noise `#1976` already showed (a 15m38s–23m15s spread across 3 runs with zero code change between them) rather than a true regression — but there's no clean signal here that the JIT-thread-pool cap is delivering the benefit real CI infrastructure would need to justify adding this flag to every test JVM in the matrix.

**Decision: leave this open, unmerged, as a documented negative-ish result.** The reasoning behind the change is still sound (each fork's compiler pool genuinely doesn't know about its siblings), and the local measurement was real and reproducible — it just didn't clear the bar on the infrastructure that actually matters. Worth revisiting if: real GH-hosted runner CPU/core specs turn out to differ meaningfully from the 8-core dev box this was measured on (a plausible reason the oversubscription math doesn't transfer), or if a larger number of CI runs (beyond the 3 here) shows a clearer signal once averaged past the noise floor.

## Test plan

- [x] Measured locally (JDK 8 and JDK 11, `/usr/lib/jvm/java-{8,11}-openjdk-amd64`) — see "Local measurements"
- [x] 3 independent real CI runs on this PR — see "CI results"; did not confirm the local prediction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
