### PR TITLE
InferenceResult: fix inaccurate results-map Javadoc

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InferenceResult.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InferenceResult.java
@@ -37,7 +37,11 @@ public class InferenceResult {
 
     /**
      * A mapping from a tree that needs type argument inference to a map from type parameter to its
-     * inferred annotated type argument. If inference failed, this map will be empty.
+     * inferred annotated type argument. Empty when inference {@link #inferenceCrashed()} or {@link
+     * #inferenceBudgetExceeded()}. Otherwise populated with the resolved type arguments, even when
+     * {@link #inferenceFailed()} due to an annotated (qualifier) mismatch: those are the
+     * best-effort arguments Java-level resolution reached before the qualifiers were found
+     * unsatisfiable, not arguments that have been checked against the annotated bounds.
      */
     private final Map<Tree, Map<TypeVariable, AnnotatedTypeMirror>> results;
 
@@ -133,7 +137,11 @@ public class InferenceResult {
 
     /**
      * A mapping from a tree that needs type argument inference to a map from type parameter to its
-     * inferred annotated type argument. If inference failed, this map will be empty.
+     * inferred annotated type argument. Empty when inference {@link #inferenceCrashed()} or {@link
+     * #inferenceBudgetExceeded()}. Otherwise populated with the resolved type arguments, even when
+     * {@link #inferenceFailed()} due to an annotated (qualifier) mismatch: those are the
+     * best-effort arguments Java-level resolution reached before the qualifiers were found
+     * unsatisfiable, not arguments that have been checked against the annotated bounds.
      *
      * @return mapping from a tree that needs type argument inference to a map from type parameter
      *     to its inferred annotated type argument


### PR DESCRIPTION
## Summary

Both the `results` field and `getResults()` in `InferenceResult` claimed "If inference failed, this map will be empty." That's false for the `annoInferenceFailed` case: `InvocationTypeInference.infer` (both the method-invocation and member-reference overloads) always passes the resolved variables to the constructor regardless of `annoInferenceFailed`, so a qualifier-only failure still carries best-effort, Java-resolved type arguments. The map is only actually empty for the two paths that pass `Collections.emptyList()` explicitly: `inferenceCrashed` and `inferenceBudgetExceeded` (both in `DefaultTypeArgumentInference`).

Verified by reading all five call sites that construct `InferenceResult`. No behavioral change — Javadoc only.

Surfaced while analyzing the `type.arguments.not.inferred` cluster; full write-up in a follow-up issue.

## Test plan

- [x] `./gradlew :framework:compileJava` — compiles clean
- [x] `./gradlew :framework:spotlessJavaCheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)