### PR TITLE
Warn when to use `-AmergeStubsWithSource`; treat declaration annotations and record stubs consistently

### DIFF
--- a/checker/jtreg/stubs/defaultqualinstub/Main.java
+++ b/checker/jtreg/stubs/defaultqualinstub/Main.java
@@ -2,7 +2,7 @@
  * @test
  * @summary Test that the DefaultQualifier in an astub works.
  * @library .
- * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=defaults.astub pck/Defaults.java -Werror
+ * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=defaults.astub -AmergeStubsWithSource pck/Defaults.java -Werror
  */
 
 public class Main {}

--- a/checker/jtreg/stubs/issue1585/Main.java
+++ b/checker/jtreg/stubs/issue1585/Main.java
@@ -5,7 +5,7 @@
  *
  * ParseError.out and UnknownField.out contain expected warnings.
  *
- * @compile/ref=UnknownField.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=UnknownField.astub -Anomsgtext Main.java
+ * @compile/ref=UnknownField.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=UnknownField.astub -AmergeStubsWithSource -Anomsgtext Main.java
  * @compile/ref=ParseError.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=ParseError.astub -Anomsgtext Main.java
  */
 

--- a/checker/jtreg/stubs/issue1987/Lib.astub
+++ b/checker/jtreg/stubs/issue1987/Lib.astub
@@ -1,0 +1,6 @@
+package issue1987;
+
+import org.checkerframework.framework.qual.AnnotatedFor;
+
+@AnnotatedFor("nullness")
+public class Lib {}

--- a/checker/jtreg/stubs/issue1987/Lib.java
+++ b/checker/jtreg/stubs/issue1987/Lib.java
@@ -1,0 +1,7 @@
+package issue1987;
+
+public class Lib {
+    public Object get() {
+        return null;
+    }
+}

--- a/checker/jtreg/stubs/issue1987/Use.java
+++ b/checker/jtreg/stubs/issue1987/Use.java
@@ -1,0 +1,20 @@
+/*
+ * @test
+ * @summary Test case for Issue 1987 https://github.com/eisop/checker-framework/issues/1987
+ *
+ * @compile/fail/ref=WithoutStub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -AuseConservativeDefaultsForUncheckedCode=source Use.java Lib.java
+ * @compile/fail/ref=WithStub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -AuseConservativeDefaultsForUncheckedCode=source -Astubs=Lib.astub Use.java Lib.java
+ * @compile/ref=WithStubAndMerge.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -AuseConservativeDefaultsForUncheckedCode=source -Astubs=Lib.astub -AmergeStubsWithSource Use.java Lib.java
+ */
+
+package issue1987;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
+@AnnotatedFor("nullness")
+public class Use {
+    void f(Lib lib) {
+        @NonNull Object o = lib.get();
+    }
+}

--- a/checker/jtreg/stubs/issue1987/WithStub.out
+++ b/checker/jtreg/stubs/issue1987/WithStub.out
@@ -1,0 +1,4 @@
+- compiler.warn.proc.messager: Lib.astub:(line 5,col 1): stub file provides annotations for source class issue1987.Lib; either remove the class from the stub file, remove the file from -Astubs, or pass -AmergeStubsWithSource to merge them
+Use.java:18:36: compiler.err.proc.messager: (assignment.type.incompatible)
+1 error
+1 warning

--- a/checker/jtreg/stubs/issue1987/WithoutStub.out
+++ b/checker/jtreg/stubs/issue1987/WithoutStub.out
@@ -1,0 +1,2 @@
+Use.java:18:36: compiler.err.proc.messager: (assignment.type.incompatible)
+1 error

--- a/checker/jtreg/stubs/nestedscope/UsesDefinedBy.java
+++ b/checker/jtreg/stubs/nestedscope/UsesDefinedBy.java
@@ -4,7 +4,7 @@
  * declaration annotation's field-access value must resolve even when its scope is itself a field
  * access, not just when the scope is a plain name.
  * @compile DefinedByExample.java
- * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=UsesDefinedBy.astub -AstubWarnIfNotFound -Werror UsesDefinedBy.java
+ * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=UsesDefinedBy.astub -AmergeStubsWithSource -AstubWarnIfNotFound -Werror UsesDefinedBy.java
  */
 
 package nestedscope;

--- a/checker/jtreg/stubs/records/Rec.astub
+++ b/checker/jtreg/stubs/records/Rec.astub
@@ -1,0 +1,5 @@
+package records;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public record Rec(@Nullable Object f) {}

--- a/checker/jtreg/stubs/records/Rec.java
+++ b/checker/jtreg/stubs/records/Rec.java
@@ -1,0 +1,3 @@
+package records;
+
+public record Rec(Object f) {}

--- a/checker/jtreg/stubs/records/Use.java
+++ b/checker/jtreg/stubs/records/Use.java
@@ -1,0 +1,18 @@
+/*
+ * @test
+ * @summary Test that record stubs are ignored for source records unless -AmergeStubsWithSource is passed
+ *
+ * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror Use.java Rec.java
+ * @compile/ref=WithStub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=Rec.astub Use.java Rec.java
+ * @compile/fail/ref=WithStubAndMerge.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=Rec.astub -AmergeStubsWithSource Use.java Rec.java
+ */
+
+package records;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class Use {
+    void g(Rec r) {
+        @NonNull Object o = r.f();
+    }
+}

--- a/checker/jtreg/stubs/records/Use.java
+++ b/checker/jtreg/stubs/records/Use.java
@@ -2,6 +2,7 @@
  * @test
  * @summary Test that record stubs are ignored for source records unless -AmergeStubsWithSource is passed
  *
+ * @requires jdk.version >= 17
  * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Werror Use.java Rec.java
  * @compile/ref=WithStub.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=Rec.astub Use.java Rec.java
  * @compile/fail/ref=WithStubAndMerge.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Anomsgtext -Astubs=Rec.astub -AmergeStubsWithSource Use.java Rec.java

--- a/checker/jtreg/stubs/records/WithStub.out
+++ b/checker/jtreg/stubs/records/WithStub.out
@@ -1,0 +1,2 @@
+- compiler.warn.proc.messager: Rec.astub:(line 5,col 1): stub file provides annotations for source class records.Rec; either remove the class from the stub file, remove the file from -Astubs, or pass -AmergeStubsWithSource to merge them
+1 warning

--- a/checker/jtreg/stubs/records/WithStubAndMerge.out
+++ b/checker/jtreg/stubs/records/WithStubAndMerge.out
@@ -1,2 +1,2 @@
-Use.java:16:32: compiler.err.proc.messager: (assignment.type.incompatible)
+Use.java:17:32: compiler.err.proc.messager: (assignment.type.incompatible)
 1 error

--- a/checker/jtreg/stubs/records/WithStubAndMerge.out
+++ b/checker/jtreg/stubs/records/WithStubAndMerge.out
@@ -1,0 +1,2 @@
+Use.java:16:32: compiler.err.proc.messager: (assignment.type.incompatible)
+1 error

--- a/checker/jtreg/stubs/wildcardimport/WildcardImportScope.java
+++ b/checker/jtreg/stubs/wildcardimport/WildcardImportScope.java
@@ -3,7 +3,7 @@
  * @summary Regression test for AnnotationFileParser.findVariableElement(FieldAccessExpr): a
  * declaration annotation whose value is a field access must resolve when the receiver type is
  * reachable only through a wildcard type import.
- * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=WildcardImportScope.astub -AstubWarnIfNotFound -Werror WildcardImportScope.java
+ * @compile -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=WildcardImportScope.astub -AmergeStubsWithSource -AstubWarnIfNotFound -Werror WildcardImportScope.java
  */
 
 // Class that WildcardImportScope.astub adds a declaration annotation to, using a value that

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/DisbarUseTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/DisbarUseTest.java
@@ -20,6 +20,7 @@ public class DisbarUseTest extends CheckerFrameworkPerDirectoryTest {
                 DisbarUseChecker.class,
                 "disbaruse-records",
                 "-Astubs=tests/disbaruse-records",
+                "-AmergeStubsWithSource",
                 "-AstubWarnIfNotFound");
     }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessStubfileTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/NullnessStubfileTest.java
@@ -23,7 +23,8 @@ public class NullnessStubfileTest extends CheckerFrameworkPerDirectoryTest {
                         "-Astubs=tests/nullness-stubfile/stubfile1.astub:"
                                 + "tests/nullness-stubfile/stubfile2.astub:"
                                 + "tests/nullness-stubfile/requireNonNull.astub:"
-                                + "tests/nullness-stubfile/fakeOverloadOverride.astub"));
+                                + "tests/nullness-stubfile/fakeOverloadOverride.astub"),
+                "-AmergeStubsWithSource");
     }
 
     @Parameters

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserNullnessTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/StubparserNullnessTest.java
@@ -19,7 +19,8 @@ public class StubparserNullnessTest extends CheckerFrameworkPerDirectoryTest {
                 testFiles,
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "stubparser-nullness",
-                "-Astubs=tests/stubparser-nullness");
+                "-Astubs=tests/stubparser-nullness",
+                "-AmergeStubsWithSource");
     }
 
     @Parameterized.Parameters

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,11 @@ text parsing itself does or reports in a way the binary form cannot
 reproduce. See the manual's "Using a binary (pre-parsed) stub file" section
 for details.
 
+Declaration annotations in stub files are no longer merged into classes being
+compiled from source unless `-AmergeStubsWithSource` is supplied, matching the
+behavior for type annotations. The stub parser now warns when a stub file
+provides annotations for a class compiled from source without `-AmergeStubsWithSource`.
+
 `AnnotationFileUtil.allAnnotationFiles(String, AnnotationFileType)` (public
 API in `framework`) was replaced by `resolveAnnotationFileLocation(String)`
 plus `allAnnotationFiles(File, AnnotationFileType)`, needed to look for a
@@ -674,7 +679,7 @@ Other improvements and bug fixes:
 eisop#386, eisop#433, eisop#737, eisop#786, eisop#792, eisop#863, eisop#949, eisop#1015,
 eisop#1074, eisop#1244, eisop#1315, eisop#1564, eisop#1592, eisop#1642,
 eisop#1653, eisop#1735, eisop#1801, eisop#1818, eisop#1819, eisop#1861,
-eisop#1862, eisop#1863, eisop#1865, eisop#1887, eisop#1965.
+eisop#1862, eisop#1863, eisop#1865, eisop#1887, eisop#1965, eisop#1987.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,10 +49,11 @@ text parsing itself does or reports in a way the binary form cannot
 reproduce. See the manual's "Using a binary (pre-parsed) stub file" section
 for details.
 
-Declaration annotations in stub files are no longer merged into classes being
-compiled from source unless `-AmergeStubsWithSource` is supplied, matching the
-behavior for type annotations. The stub parser now warns when a stub file
-provides annotations for a class compiled from source without `-AmergeStubsWithSource`.
+Declaration annotations and record component types in stub files are no longer
+merged into classes being compiled from source unless `-AmergeStubsWithSource`
+is supplied, matching the behavior for other type annotations. The stub parser
+now warns when a stub file provides annotations for a class compiled from source
+without `-AmergeStubsWithSource`.
 
 `AnnotationFileUtil.allAnnotationFiles(String, AnnotationFileType)` (public
 API in `framework`) was replaced by `resolveAnnotationFileLocation(String)`

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -1113,6 +1113,19 @@ public class AnnotationFileParser {
             return null;
         }
 
+        if (warnIfNotFound
+                && fileType.isStub()
+                && fileType != AnnotationFileType.AJAVA_AS_STUB
+                && !mergeStubsWithSource
+                && ElementUtils.isElementFromSourceCode(typeElt)) {
+            warn(
+                    typeDecl,
+                    "stub file provides annotations for source class "
+                            + fqTypeName
+                            + "; either remove the class from the stub file, remove the file from"
+                            + " -Astubs, or pass -AmergeStubsWithSource to merge them");
+        }
+
         List<AnnotatedTypeVariable> typeDeclTypeParameters = null;
         if (typeElt.getKind() == ElementKind.ENUM) {
             if (!(typeDecl instanceof EnumDeclaration)) {

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -5111,7 +5111,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         }
 
         // Add annotations from annotation files.
-        results.addAll(stubTypes.getDeclAnnotations(elt));
+        if (mergeStubsWithSource || !ElementUtils.isElementFromSourceCode(elt)) {
+            results.addAll(stubTypes.getDeclAnnotations(elt));
+        }
         results.addAll(ajavaTypes.getDeclAnnotations(elt));
         if (currentFileAjavaTypes != null) {
             results.addAll(currentFileAjavaTypes.getDeclAnnotations(elt));

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3408,7 +3408,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                     "member %s has type %s of kind %s", member, memberType, memberType.getKind());
         }
 
-        stubTypes.injectRecordComponentType(types, member, memberType);
+        if (mergeStubsWithSource || !ElementUtils.isElementFromSourceCode(member)) {
+            stubTypes.injectRecordComponentType(types, member, memberType);
+        }
 
         return memberType;
     }
@@ -3751,7 +3753,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                         typeVarSubstitutor.substitute(
                                 typeParamToTypeArg, con, typeArguments.typeArgumentsInferred);
 
-        stubTypes.injectRecordComponentType(types, ctor, con);
+        if (mergeStubsWithSource || !ElementUtils.isElementFromSourceCode(ctor)) {
+            stubTypes.injectRecordComponentType(types, ctor, con);
+        }
 
         if (typeArguments.needsDefaultedReturnType) {
             // If inference did not compute a reliable return type, then the return type will not be


### PR DESCRIPTION
### Summary

1. **Guard stub declaration annotations**: In `AnnotatedTypeFactory#getDeclAnnotations()`, only include declaration annotations from `stubTypes` when `mergeStubsWithSource` is set or the element is not from source code (`mergeStubsWithSource || !ElementUtils.isElementFromSourceCode(elt)`). This matches the existing behavior in `fromElement()` and `fromMember()`.
2. **Guard record component stub injection**: In `AnnotatedTypeFactory#applyRecordTypesToAccessors()` and `AnnotatedTypeFactory#constructorFromUse()`, only inject record component types from `stubTypes` when `mergeStubsWithSource` is set or the element is not from source code (`mergeStubsWithSource || !ElementUtils.isElementFromSourceCode(...)`).
3. **Warn on stub overlap with source**: In `AnnotationFileParser#processTypeDecl()`, emit a warning when a stub file provides annotations for a source class and `-AmergeStubsWithSource` is not passed, explaining the three options to resolve it (remove class from stub, remove file from `-Astubs`, or supply `-AmergeStubsWithSource`).
4. **Update tests**: Added `-AmergeStubsWithSource` to `DisbarUseTest`, `StubparserNullnessTest`, `NullnessStubfileTest`, and existing jtreg tests where stubs intentionally annotate source classes.
5. **jtreg tests**:
   - Added test for #1987 in `checker/jtreg/stubs/issue1987/` testing declaration annotations across all three modes (no stubs, stubs without merge, stubs with merge).
   - Added test for records in `checker/jtreg/stubs/records/` testing record component stub injection across all three modes.

Fixes #1987