### PR TITLE
Fix Spotless configuration cache error on subproject clean and build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,30 +151,6 @@ tasks.register('installGitHooks', Copy) {
 }
 
 apply plugin: 'com.diffplug.spotless'
-spotless {
-    // Resolve the Spotless plugin dependencies from the buildscript repositories rather than the
-    // project repositories.  That way the spotless plugin does not use the locally built version of
-    // checker-qual as a dependency. Without this, errors like the follow are issued when running
-    // a spotless task without a locally-built version of checker-qual.jar:
-    // Could not determine the dependencies of task ':checker-qual:spotlessCheck'.
-    //  > Could not create task ':checker-qual:spotlessJavaCheck'.
-    //     > Could not create task ':checker-qual:spotlessJava'.
-    //        > File signature can only be created for existing regular files, given:
-    //          .../checker-framework/checker-qual/build/libs/checker-qual-VERSION-SNAPSHOT.jar
-    predeclareDepsFromBuildscript()
-}
-
-spotlessPredeclare {
-    // Put all the formatters that have dependencies here.  Without this, errors like the following
-    // will happen:
-    // Could not determine the dependencies of task ':spotlessCheck'.
-    //  > Could not create task ':spotlessJavaCheck'.
-    //     > Could not create task ':spotlessJava'.
-    //        > Add a step with [com.google.googlejavaformat:google-java-format:1.15.0] into the `spotlessPredeclare` block in the root project.
-    java {
-        googleJavaFormat(versions.googleJavaFormat)
-    }
-}
 
 allprojects { currentProj ->
     // Explicitly propagate root-level ext properties so subproject build scripts

--- a/checker/bin-devel/test-misc.sh
+++ b/checker/bin-devel/test-misc.sh
@@ -53,6 +53,9 @@ git diff --exit-code docs/manual/contributors.tex \
 # Check gradle tasks are configured properly
 ./gradlew tasks
 
+# Check subproject clean and build with configuration cache
+./gradlew :dataflow:clean :dataflow:build --console=plain --warning-mode=all
+
 ## Code style and formatting
 JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//' | sed 's/-beta//')
 if [ "${JAVA_VER}" != "8" ] && [ "${JAVA_VER}" != "11" ]; then


### PR DESCRIPTION
### Summary

Running subproject clean and build tasks together (e.g. `./gradlew :dataflow:clean :dataflow:build`) previously failed during configuration cache serialization with:
```
Configuration cache state could not be cached: field stepsInternalEquality of task :dataflow:spotlessJava of type com.diffplug.gradle.spotless.SpotlessTaskImpl
> Add a step with [com.google.googlejavaformat:google-java-format:1.35.0] into the spotlessPredeclare block in the root project.
```

### Changes
- Removed obsolete `spotlessPredeclare` and `predeclareDepsFromBuildscript` blocks in `build.gradle`, allowing Spotless 8.10.1 to provision formatters cleanly per project without configuration cache serialization conflicts.
- Added a regression test running `./gradlew :dataflow:clean :dataflow:build` in `checker/bin-devel/test-misc.sh`.