### PR TITLE
Configure Renovate release cooldown, grouping rules, and dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,10 @@
     "config:base",
     ":automergeDisabled",
     ":automergeRequireAllStatusChecks",
-    "schedule:nonOfficeHours",
-    ":disableDependencyDashboard"
+    "schedule:nonOfficeHours"
   ],
+  "minimumReleaseAge": "7 days",
+  "prConcurrentLimit": 5,
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",
@@ -14,6 +15,27 @@
   ],
   "timezone": "America/Los_Angeles",
   "packageRules": [
+    {
+      "description": "Group all dependency updates in docs/examples into a single PR",
+      "matchFileNames": ["docs/examples/**"],
+      "groupName": "docs/examples dependencies"
+    },
+    {
+      "description": "Group non-major GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "GitHub Actions non-major updates"
+    },
+    {
+      "description": "Do not delay JDK EA builds to avoid downloading superseded/deleted binaries",
+      "matchPackageNames": ["openjdk/jdk"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Do not delay security vulnerability fixes",
+      "matchCategories": ["security"],
+      "minimumReleaseAge": "0 days"
+    },
     {
       "matchPackagePatterns": ["^adoptium/temurin\\d+-binaries$"],
       "ignoreUnstable": false


### PR DESCRIPTION
## Summary

- **7-Day Cooldown (`minimumReleaseAge: 7 days`)**: Introduces a 7-day waiting period for new dependency releases to avoid point-zero bugs, yanked versions, and rapid multi-patch churn.
- **Group `docs/examples` Updates**: Bundles all dependency updates in `docs/examples/` into a single combined PR (`docs/examples dependencies`).
- **Group Non-Major GitHub Actions**: Combines minor and patch version bumps for GitHub Actions into a single PR (`GitHub Actions non-major updates`).
- **Exemptions from Cooldown**:
  - `openjdk/jdk`: Early Access JDK builds are not delayed (`0 days`) so that superseded/deleted download mirrors do not cause CI failures.
  - Security vulnerability fixes (`matchCategories: ["security"]`) are not delayed.
- **Enable Dependency Dashboard & Limit Concurrency**:
  - Removes `:disableDependencyDashboard` so maintainers can view cooldown status and manually trigger PRs when needed.
  - Sets `prConcurrentLimit: 5` to prevent CI congestion.