### PR TITLE
Avoid ShadowJar relocating five annotation-name constants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1596,6 +1596,61 @@ tasks.named('jar') {
 }
 
 /**
+ * Registers a task that fails if any Checker Framework class in a shaded jar contains a string
+ * constant naming a relocated package.
+ *
+ * <p>ShadowJar rewrites string literals as well as type references, so a literal such as
+ * {@code "org.plumelib.options.Option"} silently becomes
+ * {@code "org.checkerframework.org.plumelib.options.Option"} in the shipped jar. When the literal
+ * is a name compared against *user* code -- an annotation the user wrote -- the comparison then
+ * never matches and the feature quietly stops working. The workaround is to split the constant,
+ * as {@code "org.pl".toString() + "umelib.options.Option"}; see NullnessNoInitAnnotatedTypeFactory.
+ *
+ * <p>Only the Checker Framework's own classes are scanned. Relocated third-party classes may
+ * legitimately contain their own relocated names (a logger name, say), and rewriting those is
+ * exactly what relocation is for.
+ *
+ * @param project the project to register the task in
+ * @param jarTasks the shaded jars to scan
+ */
+final createCheckRelocatedStringsTask(Project project, List jarTasks) {
+    project.tasks.register('checkRelocatedStrings') {
+        group = 'Verification'
+        description = 'Fails if a shaded jar has a string constant naming a relocated package.'
+        FileCollection jars = project.files(jarTasks)
+        inputs.files(jars).withPropertyName('shadedJars')
+        doLast {
+            // Dot-form: type descriptors in a class file use '/', so a dotted occurrence of a
+            // relocated package is a string constant.
+            def relocated = ~/org\.checkerframework\.(?:com|org|io|nonapi)\.[A-Za-z0-9_.$]+/
+            def problems = []
+            jars.each { File jar ->
+                new java.util.zip.ZipFile(jar).withCloseable { zf ->
+                    for (entry in Collections.list(zf.entries())) {
+                        if (!entry.name.endsWith('.class')
+                        || entry.name =~ '^org/checkerframework/(com|org|io|nonapi)/') {
+                            continue
+                        }
+                        String bytes = new String(
+                        zf.getInputStream(entry).getBytes(), 'ISO-8859-1')
+                        def matcher = relocated.matcher(bytes)
+                        while (matcher.find()) {
+                            problems << "  ${jar.name}: ${entry.name}: \"${matcher.group()}\""
+                        }
+                    }
+                }
+            }
+            if (!problems.isEmpty()) {
+                throw new GradleException(
+                'ShadowJar relocated a string constant. Split the literal at its source, as\n'
+                + '"org.pl".toString() + "umelib.options.Option", keeping the original in a\n'
+                + 'comment. Offending constants:\n' + problems.unique().join('\n'))
+            }
+        }
+    }
+}
+
+/**
  * Adds the shared pom information to the given publication.
  * @param publication the MavenPublication
  */

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -335,6 +335,12 @@ tasks.named('assemble') {
     dependsOn('checkerJar')
 }
 
+// checker.jar bundles framework, javacutil and dataflow as well, so scanning the two shaded
+// jars this project produces covers every Checker Framework class that gets relocated.
+rootProject.createCheckRelocatedStringsTask(
+project, [tasks.named('shadowJar'), tasks.named('checkerJar')])
+tasks.named('check') { dependsOn 'checkRelocatedStrings' }
+
 artifacts {
     fatJar(tasks.named('shadowJar'))
 }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/builder/LombokSupport.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/builder/LombokSupport.java
@@ -49,6 +49,8 @@ public class LombokSupport implements BuilderFrameworkSupport {
     // class files for its own implementation, to prevent itself from being accidentally
     // added to clients' compile classpaths. This design decision means that it is
     // impossible to depend directly on Lombok internals.
+    // Avoid changes to the string constants by ShadowJar relocate by using "start".toString() +
+    // "rest".  Keep the original string constant in a comment to allow searching for it.
     /** The list of annotations that Lombok treats as non-null. */
     public static final List<String> NONNULL_ANNOTATIONS =
             Collections.unmodifiableList(
@@ -59,9 +61,11 @@ public class LombokSupport implements BuilderFrameworkSupport {
                             "androidx.annotation.NonNull",
                             "androidx.annotation.RecentlyNonNull",
                             "com.android.annotations.NonNull",
-                            "com.google.firebase.database.annotations.NotNull", // Even though it's
-                            // in a database package, it does mean semantically: "Check if never
-                            // null at the language level", and not 'db column cannot be null'.
+                            // Even though it's in a database package, it does mean
+                            // semantically: "Check if never null at the language level", and not
+                            // 'db column cannot be null'.
+                            // "com.google.firebase.database.annotations.NotNull",
+                            "com.go".toString() + "ogle.firebase.database.annotations.NotNull",
                             "com.mongodb.lang.NonNull", // Even though mongo is a DB engine,
                             // this semantically refers to language, not DB table designs (mongo is
                             // a document DB engine, so this isn't surprising perhaps).
@@ -80,7 +84,8 @@ public class LombokSupport implements BuilderFrameworkSupport {
                             "org.checkerframework.checker.nullness.qual.NonNull",
                             "org.checkerframework.checker.nullness.compatqual.NonNullDecl",
                             "org.checkerframework.checker.nullness.compatqual.NonNullType",
-                            "org.codehaus.commons.nullanalysis.NotNull",
+                            // "org.codehaus.commons.nullanalysis.NotNull",
+                            "org.co".toString() + "dehaus.commons.nullanalysis.NotNull",
                             "org.eclipse.jdt.annotation.NonNull",
                             "org.jetbrains.annotations.NotNull",
                             "org.jmlspecs.annotation.NonNull",

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
@@ -225,7 +225,8 @@ public class NullnessNoInitAnnotatedTypeFactory
                     // https://source.chromium.org/chromium/chromium/src/+/main:build/android/java/src/org/chromium/build/annotations/OptimizeAsNonNull.java
                     "org.chromium.build.annotations.OptimizeAsNonNull",
                     // https://janino-compiler.github.io/janino/apidocs/org/codehaus/commons/nullanalysis/NotNull.html
-                    "org.codehaus.commons.nullanalysis.NotNull",
+                    // "org.codehaus.commons.nullanalysis.NotNull",
+                    "org.co".toString() + "dehaus.commons.nullanalysis.NotNull",
                     // https://help.eclipse.org/neon/index.jsp?topic=/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/annotation/NonNull.html
                     // https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tree/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/NonNull.java
                     "org.eclipse.jdt.annotation.NonNull",
@@ -357,7 +358,8 @@ public class NullnessNoInitAnnotatedTypeFactory
                     // https://source.chromium.org/chromium/chromium/src/+/main:build/android/java/src/org/chromium/build/annotations/Nullable.java
                     "org.chromium.build.annotations.Nullable",
                     // https://janino-compiler.github.io/janino/apidocs/org/codehaus/commons/nullanalysis/Nullable.html
-                    "org.codehaus.commons.nullanalysis.Nullable",
+                    // "org.codehaus.commons.nullanalysis.Nullable",
+                    "org.co".toString() + "dehaus.commons.nullanalysis.Nullable",
                     // https://help.eclipse.org/neon/index.jsp?topic=/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/annotation/Nullable.html
                     // https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tree/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/Nullable.java
                     "org.eclipse.jdt.annotation.Nullable",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@ Version 3.49.5-eisop2 (June ?, 2026)
 
 **User-visible changes:**
 
+Fixed five annotation names that ShadowJar rewrote when building `checker.jar`,
+so they never matched the annotations they name. The Nullness Checker now again
+recognizes `org.codehaus.commons.nullanalysis.NotNull` and `.Nullable` as
+aliases, the Called Methods Checker recognizes Lombok's
+`com.google.firebase.database.annotations.NotNull` and
+`org.codehaus.commons.nullanalysis.NotNull`, and whole-program inference again
+honors `@org.plumelib.options.Option`.
+
 The Checker Framework now issues an `annotation.on.supertype` error when an annotation supported by
 the checker is written as a main annotation on the superclass or interface in an `extends` or
 `implements` clause. Annotations on the supertype's type arguments remain permitted. A checker

--- a/framework/src/main/java/org/checkerframework/framework/stub/RemoveAnnotationsForInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/RemoveAnnotationsForInference.java
@@ -558,7 +558,10 @@ public class RemoveAnnotationsForInference {
                 || name.equals("Singleton")
                 || name.equals("javax.inject.Singleton")
                 || name.equals("Option")
-                || name.equals("org.plumelib.options.Option")) {
+                // Avoid changes to the string constant by ShadowJar relocate by using
+                // "start".toString() + "rest".  The original constant is
+                // "org.plumelib.options.Option".
+                || name.equals("org.pl".toString() + "umelib.options.Option")) {
             return Collections.singletonList("allcheckers");
         }
 


### PR DESCRIPTION
ShadowJar rewrites string literals as well as type references, so a constant naming
a package that gets relocated is silently rewritten in `checker.jar`. Where that
constant is a name compared against an annotation in **user** code, the comparison
can then never match, and the feature stops working with no error reported anywhere.

Five live constants were affected. Each was confirmed by running `strings` on the
packaged class in `checker.jar`, which showed the relocated form:

| site | constant | in the shipped jar |
| --- | --- | --- |
| `RemoveAnnotationsForInference:561` | `org.plumelib.options.Option` | `org.checkerframework.org.plumelib...` |
| `LombokSupport:62` | `com.google.firebase.database.annotations.NotNull` | `org.checkerframework.com.google...` |
| `LombokSupport:83` | `org.codehaus.commons.nullanalysis.NotNull` | `org.checkerframework.org.codehaus...` |
| `NullnessNoInit:228` | `org.codehaus.commons.nullanalysis.NotNull` | `org.checkerframework.org.codehaus...` |
| `NullnessNoInit:360` | `org.codehaus.commons.nullanalysis.Nullable` | `org.checkerframework.org.codehaus...` |

User-visible effect: the Nullness Checker silently ignored janino's `@NotNull`/`@Nullable`
aliases, the Called Methods Checker ignored two of Lombok's non-null annotations, and
whole-program inference ignored `@org.plumelib.options.Option`.

`NullnessNoInitAnnotatedTypeFactory` is the telling case: it already applied the
workaround for the `com.google.*` and `org.apache.*` aliases, and missed `org.codehaus.*`
in both the non-null and the nullable list.

All five now use the established `"org.co".toString() + "dehaus..."` form, with the
original constant kept in a comment so it can still be searched for.

### Second commit: a guard

The hazard was documented in the `shadowJar` block's comment, but nothing enforced it,
and it had gone wrong in five places. `createCheckRelocatedStringsTask` scans a shaded jar
for dot-form relocated package names -- type descriptors use `/`, so a dotted occurrence
is a string constant -- and fails with the offending class and constant plus the fix.

Only the Checker Framework's own classes are scanned: a relocated third-party class may
legitimately contain its own relocated name. Wired into `:checker`'s `check` for both
shaded jars it produces; `checker.jar` bundles framework, javacutil and dataflow, so that
covers every Checker Framework class that gets relocated.

### Verification

- `strings` on the repackaged classes: no relocated constants remain, split fragments present
- Negative test: restoring a plain literal fails the build, naming the class and constant
- `:checker:checkNullness`, `:checker:checkSignature` pass
- Both shaded jars scan clean, so there are no pre-existing false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV
