### PR TITLE
Add the framework and framework-all Maven artifacts, and fix the publication setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1623,10 +1623,6 @@ tasks.named('jar') {
 }
 
 /**
- * Adds the shared pom information to the given publication.
- * @param publication the MavenPublication
- */
-/**
  * Adds a runtime dependency on checker-qual to a shaded publication's POM.
  *
  * <p>The shaded artifacts (framework-all, dataflow-shaded, ...) assemble their jar with a custom
@@ -1648,6 +1644,10 @@ final addCheckerQualDependencyToPom(MavenPublication publication, String checker
     }
 }
 
+/**
+ * Adds the shared pom information to the given publication.
+ * @param publication the MavenPublication
+ */
 final sharedPublicationConfiguration(publication) {
     publication.pom {
         url = 'https://eisop.github.io/'

--- a/build.gradle
+++ b/build.gradle
@@ -1708,10 +1708,9 @@ final createCheckRelocatedStringsTask(Project project, List jarTasks) {
  *
  * <p>A Jar task has no {@code base}, {@code version}, {@code buildDir} or {@code status}, so
  * writing one of those inside a task closure resolves against the enclosing Project instead and
- * silently reconfigures the whole subproject. {@code base { archivesName = ... }} inside
- * frameworkAllJar and inside dataflow's shaded-jar factory did exactly that, renaming every
- * archive in those subprojects: framework's own jar was written as framework-all-VERSION.jar and
- * dataflow's as dataflow-errorprone-VERSION.jar. Set {@code archiveBaseName} on the task instead.
+ * silently reconfigures the whole subproject: {@code base { archivesName = ... }} in a Jar task
+ * renames every archive in that subproject, including the project's own jar and sources jar.
+ * Set {@code archiveBaseName} on the task instead.
  *
  * <p>Nothing else catches this. maven-publish names published artifacts from the publication
  * rather than from the file on disk, so every POM and published coordinate stays correct while

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ ext {
         errorprone      : '2.50.0',
         // NOTE: Google Java Format requires JDK 17 or higher as of version 1.25.0.
         googleJavaFormat : '1.35.0',
+        guava           : '33.4.0-jre',
         hashmapUtil     : '0.0.1',
         junit           : '4.13.2',
         lombok          : '1.18.48',
@@ -1132,19 +1133,6 @@ subprojects {
             if (task.name == 'sourcesJar') {
                 task.dependsOn 'generateBinaryStubFiles'
             }
-        }
-    }
-
-    configurations {
-        annotatedGuava
-    }
-
-    dependencies {
-        // TODO: it's a bug that annotatedlib:guava requires the error_prone_annotations dependency.
-        annotatedGuava "com.google.errorprone:error_prone_annotations:${versions.errorprone}"
-        annotatedGuava ('org.checkerframework.annotatedlib:guava:33.1.0.2-jre') {
-            // So long as Guava only uses annotations from checker-qual, excluding it should not cause problems.
-            exclude group: 'org.checkerframework'
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import de.undercouch.gradle.tasks.download.Download
+import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.tasks.testing.TestDescriptor
 import org.gradle.api.tasks.testing.TestListener
 import org.gradle.api.tasks.testing.TestResult
@@ -207,6 +208,24 @@ allprojects { currentProj ->
         // This is to be used to add errorprone to the processorpath of the compile task.  The errorprone
         // configuration can't be used directly because it is marked unresolvable by the errorprone plugin.
         errorProneAnnotationProcessor.extendsFrom(errorprone)
+    }
+
+    // We publish our own qualifiers as io.github.eisop:checker-qual. Several dependencies pull
+    // in typetools' org.checkerframework:checker-qual as well -- guava directly, and plume-util
+    // through hashmap-util -> reflection-util -- which puts two definitions of every
+    // org.checkerframework.checker.*.qual.* class on the classpath, ours and theirs. Those
+    // dependencies use the qualifiers only as annotations, so dropping the artifact costs
+    // nothing and leaves one definition of each.
+    //
+    // Excluding it on the declarable configurations covers our own builds and, because Gradle
+    // has to render a configuration-level exclusion as an <exclusions> block on each dependency
+    // of the generated POM (Maven has no configuration-level equivalent), consumers of our
+    // published artifacts too. Only the checker-qual module is excluded:
+    // org.checkerframework:stubparser is a real dependency of framework.
+    configurations.matching {
+        it.name in ['api', 'implementation', 'compileOnly', 'runtimeOnly']
+    }.configureEach {
+        exclude group: 'org.checkerframework', module: 'checker-qual'
     }
 
     dependencies {
@@ -1169,13 +1188,33 @@ subprojects {
 
     // Shadow 9.x registers a "shadowRuntimeElements" consumable variant for each project.
     // When checker:runtimeClasspath resolves project dependencies (e.g. framework), Gradle may
-    // select shadowRuntimeElements, which points to the shadow JAR (framework-X-all.jar).
+    // select shadowRuntimeElements, which points to the shadow jar (framework-VERSION-all.jar).
     // Change its Usage attribute so it doesn't conflict with standard runtimeElements.
+    //
+    // :checker is exempt: its published `checker` artifact IS the shadow jar, published via
+    // `components.shadow`, whose only runtime variant is shadowRuntimeElements. Renaming that
+    // variant's Usage there would leave the published module metadata with no variant a
+    // consumer can select for java-runtime, which is the failure PR #1822 reported.
     configurations.all {
         if (name == 'shadowRuntimeElements' && project.name != 'checker') {
             attributes {
                 attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "shadow-runtime-elements"))
             }
+        }
+    }
+
+    // Shadow 9.x also adds shadowRuntimeElements to `components.java`. Every publication that
+    // uses `from components.java` (dataflow, javacutil, framework) would therefore advertise
+    // the fat "-all.jar" in its Gradle Module Metadata, under the placeholder Usage set above
+    // that no consumer ever requests -- and really upload that jar, several MB per artifact.
+    // Nothing consumes those: :checker publishes its shadow jar deliberately through
+    // `components.shadow`, and framework-all is its own publication. Drop the variant so each
+    // module's metadata describes only the artifacts we actually intend to ship.
+    afterEvaluate {
+        def javaComponent = components.findByName('java')
+        def shadowRuntime = configurations.findByName('shadowRuntimeElements')
+        if (javaComponent instanceof AdhocComponentWithVariants && shadowRuntime != null) {
+            javaComponent.withVariantsFromConfiguration(shadowRuntime) { it.skip() }
         }
     }
 
@@ -1587,6 +1626,28 @@ tasks.named('jar') {
  * Adds the shared pom information to the given publication.
  * @param publication the MavenPublication
  */
+/**
+ * Adds a runtime dependency on checker-qual to a shaded publication's POM.
+ *
+ * <p>The shaded artifacts (framework-all, dataflow-shaded, ...) assemble their jar with a custom
+ * Shadow task rather than from a Gradle component, so maven-publish has no dependency information
+ * to derive a POM from and generates none. checker-qual is deliberately not bundled -- a consumer
+ * should get one copy of the qualifiers rather than a relocated duplicate -- which makes it the
+ * one dependency these POMs need, so it has to be written by hand.
+ *
+ * @param publication the publication whose POM to add the dependency to
+ * @param checkerQualVersion the checker-qual version to depend on
+ */
+final addCheckerQualDependencyToPom(MavenPublication publication, String checkerQualVersion) {
+    publication.pom.withXml {
+        asNode().appendNode('dependencies').appendNode('dependency')
+        .appendNode('groupId', 'io.github.eisop').parent()
+        .appendNode('artifactId', 'checker-qual').parent()
+        .appendNode('version', checkerQualVersion).parent()
+        .appendNode('scope', 'runtime')
+    }
+}
+
 final sharedPublicationConfiguration(publication) {
     publication.pom {
         url = 'https://eisop.github.io/'

--- a/build.gradle
+++ b/build.gradle
@@ -1218,6 +1218,10 @@ subprojects {
         }
     }
 
+    tasks.matching { it.name == 'check' }.configureEach {
+        dependsOn rootProject.tasks.named('checkTaskClosureScoping')
+    }
+
     if (!project.name.startsWith('checker-qual-android')) {
         tasks.register('tags', Exec) {
             description = 'Create Emacs TAGS table'
@@ -1648,6 +1652,76 @@ final addCheckerQualDependencyToPom(MavenPublication publication, String checker
  * Adds the shared pom information to the given publication.
  * @param publication the MavenPublication
  */
+/**
+ * Registers a task that fails if a task configuration closure configures project-wide state.
+ *
+ * <p>A Jar task has no {@code base}, {@code version}, {@code buildDir} or {@code status}, so
+ * writing one of those inside a task closure resolves against the enclosing Project instead and
+ * silently reconfigures the whole subproject. {@code base { archivesName = ... }} inside
+ * frameworkAllJar and inside dataflow's shaded-jar factory did exactly that, renaming every
+ * archive in those subprojects: framework's own jar was written as framework-all-VERSION.jar and
+ * dataflow's as dataflow-errorprone-VERSION.jar. Set {@code archiveBaseName} on the task instead.
+ *
+ * <p>Nothing else catches this. maven-publish names published artifacts from the publication
+ * rather than from the file on disk, so every POM and published coordinate stays correct while
+ * the on-disk names are wrong -- which is what a downstream globbing build/libs trips over.
+ * Checking the built state at execution time does not work either: the mutation happens when the
+ * offending task is realized, so whether it is visible depends on what else the invocation
+ * realized first. This reads the build scripts, so it is deterministic.
+ *
+ * <p>It is a line scan, not a Groovy parser, so it catches the idiomatic form and not every
+ * possible one. Known blind spots: an explicitly qualified write ({@code project.base { ... }}),
+ * and a closure passed to a task provider held in a variable rather than to
+ * {@code tasks.register}/{@code named} directly.
+ */
+final createCheckTaskClosureScopingTask(Project project) {
+    project.tasks.register('checkTaskClosureScoping') {
+        group = 'Verification'
+        description = 'Fails if a task configuration closure configures project-wide state.'
+        FileCollection buildScripts = project.files(
+        [project.rootProject.buildFile] + project.rootProject.subprojects*.buildFile)
+        inputs.files(buildScripts).withPropertyName('buildScripts')
+        doLast {
+            // Names with no counterpart on Task/Jar, so an assignment or closure binds to the
+            // Project. `group` is deliberately absent: Task has its own.
+            def projectOnly = ~/^\s*(base|version|buildDir|status)\s*(\{|=[^=])/
+            def opensClosure = ~/tasks\.(register|named|withType|create)\b/
+            def problems = []
+            buildScripts.each { File f ->
+                if (!f.isFile()) {
+                    return
+                }
+                int depth = -1
+                String header = ''
+                f.readLines().eachWithIndex { String line, int i ->
+                    if (depth < 0) {
+                        if (opensClosure.matcher(line).find() && line.contains('{')) {
+                            depth = line.count('{') - line.count('}')
+                            header = line.trim()
+                        }
+                        return
+                    }
+                    if (projectOnly.matcher(line).find()) {
+                        problems << "  ${f.name}:${i + 1}: ${line.trim()}\n      inside: ${header}"
+                    }
+                    depth += line.count('{') - line.count('}')
+                    if (depth <= 0) {
+                        depth = -1
+                    }
+                }
+            }
+            if (!problems.isEmpty()) {
+                throw new GradleException(
+                'A task configuration closure configures project-wide state. Set the property on\n'
+                + 'the task instead -- for an archive name, archiveBaseName rather than\n'
+                + '`base { archivesName = ... }`. Offending lines:\n' + problems.join('\n'))
+            }
+        }
+    }
+}
+
+createCheckTaskClosureScopingTask(rootProject)
+
 final sharedPublicationConfiguration(publication) {
     publication.pom {
         url = 'https://eisop.github.io/'

--- a/build.gradle
+++ b/build.gradle
@@ -1184,7 +1184,7 @@ subprojects {
     // select shadowRuntimeElements, which points to the shadow JAR (framework-X-all.jar).
     // Change its Usage attribute so it doesn't conflict with standard runtimeElements.
     configurations.all {
-        if (name == 'shadowRuntimeElements') {
+        if (name == 'shadowRuntimeElements' && project.name != 'checker') {
             attributes {
                 attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "shadow-runtime-elements"))
             }

--- a/checker/bin-devel/test-jspecify-conformance.sh
+++ b/checker/bin-devel/test-jspecify-conformance.sh
@@ -9,7 +9,20 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 source "$SCRIPT_DIR"/clone-related.sh
 
-./gradlew assembleForJavac --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+# Publish this checkout to the local Maven repository, so the conformance project below can
+# resolve it by coordinate. It previously read jars straight out of this checkout's build
+# directories, which depended on framework-test/build/libs holding exactly one jar as a side
+# effect of an unrelated task, and reported a missing one as "package
+# org.checkerframework.framework.test does not exist" rather than as a missing dependency.
+# Javadoc is skipped: nothing here consumes it, and it is slow.
+./gradlew publishToMavenLocal -x javadoc -x allJavadoc --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+
+CF_VERSION="$(./gradlew -q :checker:properties | sed -n 's/^version: //p')"
+if [ -z "${CF_VERSION}" ]; then
+  echo "Could not determine the Checker Framework version; aborting." >&2
+  exit 1
+fi
+echo "Testing jspecify-conformance against io.github.eisop:*:${CF_VERSION}"
 
 "$SCRIPT_DIR/.git-scripts/git-clone-related" eisop jspecify-conformance
 "$SCRIPT_DIR/.git-scripts/git-clone-related" jspecify jspecify
@@ -47,6 +60,6 @@ SETTINGS
   --console=plain --warning-mode=all --init-script /tmp/publish-helper.gradle publishToMavenLocal
 
 cd ../jspecify-conformance
-# This does not use "-PcfVersion=local", because that project does not
-# use the CF gradle plugin.
-./gradlew test --console=plain --warning-mode=all -PcfLocal
+# -PcfVersion makes the project resolve io.github.eisop artifacts at this checkout's version;
+# its repositories list mavenLocal() first, so the artifacts published above are the ones used.
+./gradlew test --console=plain --warning-mode=all -PcfVersion="${CF_VERSION}"

--- a/checker/bin-devel/test-jspecify-conformance.sh
+++ b/checker/bin-devel/test-jspecify-conformance.sh
@@ -10,11 +10,9 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 source "$SCRIPT_DIR"/clone-related.sh
 
 # Publish this checkout to the local Maven repository, so the conformance project below can
-# resolve it by coordinate. It previously read jars straight out of this checkout's build
-# directories, which depended on framework-test/build/libs holding exactly one jar as a side
-# effect of an unrelated task, and reported a missing one as "package
-# org.checkerframework.framework.test does not exist" rather than as a missing dependency.
-# Javadoc is skipped: nothing here consumes it, and it is slow.
+# resolve it by coordinate.  Resolving by coordinate means a missing or mis-scoped artifact
+# fails as a resolution error naming it, rather than as a compilation error in that project's
+# own source.  Javadoc is skipped: nothing here consumes it, and it is slow.
 ./gradlew publishToMavenLocal -x javadoc -x allJavadoc --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 CF_VERSION="$(./gradlew -q :checker:properties | sed -n 's/^version: //p')"
@@ -62,4 +60,7 @@ SETTINGS
 cd ../jspecify-conformance
 # -PcfVersion makes the project resolve io.github.eisop artifacts at this checkout's version;
 # its repositories list mavenLocal() first, so the artifacts published above are the ones used.
+# jspecify-conformance does not use the Checker Framework Gradle plugin and runs the checker off
+# a plain classpath, so it needs the shaded checker.jar; --include-build, which
+# test-templatefora-checker.sh uses, would supply :checker's ordinary jar variant instead.
 ./gradlew test --console=plain --warning-mode=all -PcfVersion="${CF_VERSION}"

--- a/checker/bin-devel/test-templatefora-checker.sh
+++ b/checker/bin-devel/test-templatefora-checker.sh
@@ -9,18 +9,27 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 source "$SCRIPT_DIR"/clone-related.sh
 
+# Publish this checkout to the local Maven repository, so templatefora-checker can resolve it
+# by coordinate.  A checker built on the Checker Framework consumes it as Maven artifacts, the
+# way any other client does, so testing it that way exercises the published POMs: a missing or
+# mis-scoped dependency fails as a resolution error naming the coordinate.  Javadoc is skipped:
+# nothing here consumes it, and it is slow.
+./gradlew publishToMavenLocal -x javadoc -x allJavadoc --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+
+CF_VERSION="$(./gradlew -q :checker:properties | sed -n 's/^version: //p')"
+if [ -z "${CF_VERSION}" ]; then
+  echo "Could not determine the Checker Framework version; aborting." >&2
+  exit 1
+fi
+echo "Testing templatefora-checker against io.github.eisop:*:${CF_VERSION}"
+
 "$SCRIPT_DIR/.git-scripts/git-clone-related" eisop templatefora-checker
 
 cd ../templatefora-checker
 
-# --include-build makes Gradle substitute this checkout's own :checker, :checker-qual, and
-# :framework-test project outputs for the io.github.eisop:checker, :checker-qual, and
-# :framework-test coordinates templatefora-checker's build.gradle declares, automatically:
-# both share the "io.github.eisop" group and matching project/module names, which is all
-# Gradle's composite-build dependency substitution needs. This tests this checkout's own
-# in-progress state, not the last eisop release -- see jspecify-reference-checker's own use of
-# this same mechanism, and its checker-framework/build.gradle "checkerFramework" ext property,
-# for a more elaborate example.
-./gradlew build --console=plain --warning-mode=all --include-build "$CHECKERFRAMEWORK" \
+# -PcfVersion makes templatefora-checker resolve io.github.eisop artifacts at this checkout's
+# version; its repositories consult mavenLocal for that group when the property is set, so the
+# artifacts published above are the ones used.
+./gradlew build --console=plain --warning-mode=all -PcfVersion="${CF_VERSION}" \
   --no-configuration-cache \
   -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -319,6 +319,8 @@ tasks.named('shadowJar') {
     minimize {
         // Keep all classes from checker-qual and checker-util rather than
         // relying on the `api` re-export to protect them from minimize().
+        exclude(dependency('io.github.eisop:checker-qual:.*'))
+        exclude(dependency('io.github.eisop:checker-util:.*'))
         exclude(dependency('org.checkerframework:checker-qual:.*'))
         exclude(dependency('org.checkerframework:checker-util:.*'))
     }

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -268,10 +268,8 @@ tasks.register('checkerJar', ShadowJar) {
     group = 'Build'
     description = "Builds checker-${project.version}.jar with all dependencies except checker-qual and checker-util."
     includeEmptyDirs = false
-    // archiveBaseName, not `base { archivesName = ... }`, which configures the project's
-    // BasePluginExtension and renames every archive in this subproject.  Harmless here only
-    // because the value matches the project name; see dataflow/build.gradle for the same
-    // pattern where it did not.
+    // archiveBaseName sets the name for this task.  `base { archivesName = ... }` would
+    // instead resolve against the project and rename every archive in this subproject.
     archiveBaseName = 'checker'
 
     from shadowJar.source

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -282,6 +282,7 @@ tasks.register('checkerJar', ShadowJar) {
     exclude 'org/checkerframework/**/qual/*'
     exclude 'org/checkerframework/checker/**/util/*'
     relocators = shadowJar.getRelocators()
+
 }
 
 tasks.named('jar') {
@@ -1178,11 +1179,22 @@ final checkerPom(publication) {
 // compile-time, and fails with "no matching variant" -- this is a known
 // Shadow plugin limitation, see https://github.com/GradleUp/shadow/issues/847.
 //
-// Register a `shadowApiElements` configuration that exposes the same
-// shadow jar for compile-time usage, and add it to `components.shadow` as
-// the missing compile-time variant, so the published Gradle Module
-// Metadata has both a runtime and a compile variant pointing at the
-// shadow jar.
+// Register a `shadowApiElements` configuration to supply that missing
+// compile-time variant, and point both variants at `checkerJar`
+// (checker-VERSION.jar) rather than at `shadowJar` (checker-VERSION-all.jar).
+//
+// Both variants must serve checkerJar, because the variants also carry the
+// `shadow` configuration's dependencies on checker-qual and checker-util.
+// shadowJar *bundles* those two, so serving it alongside those dependencies
+// puts every qualifier class on a Gradle consumer's classpath twice -- once
+// inside checker-VERSION-all.jar and once as its own jar -- while a Maven
+// consumer, who gets checker-VERSION.jar from the POM, sees them once.
+// checkerJar excludes checker-qual and checker-util for exactly this reason,
+// so serving it makes the two consumers agree.
+//
+// checker-VERSION-all.jar is still published, as a plain classified artifact
+// outside any variant: it is the self-contained download that
+// docs/manual/external-tools.tex points users at.
 import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
@@ -1194,13 +1206,19 @@ configurations {
     shadowApiElements {
         canBeConsumed = true
         canBeResolved = false
+        // The Shadow plugin makes shadowRuntimeElements extend `shadow`, whose dependencies
+        // (checker-qual, checker-util) are the ones that appear in the POM. The compile-time
+        // variant needs them too: it serves checkerJar, which deliberately excludes those two,
+        // so without this a Gradle consumer compiling against `checker` would have no
+        // qualifier classes on its compile classpath.
+        extendsFrom configurations.shadow
         attributes {
             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.SHADOWED))
         }
-        outgoing.artifact(tasks.named('shadowJar'))
+        outgoing.artifact(tasks.named('checkerJar'))
     }
 }
 
@@ -1220,6 +1238,10 @@ afterEvaluate {
     (components.shadow as AdhocComponentWithVariants).addVariantsFromConfiguration(configurations.shadowApiElements) {
         it.mapToMavenScope('compile')
     }
+
+    // Repoint the Shadow plugin's own runtime variant at checkerJar too; see above.
+    configurations.shadowRuntimeElements.outgoing.artifacts.clear()
+    configurations.shadowRuntimeElements.outgoing.artifact(tasks.named('checkerJar'))
 }
 
 publishing {
@@ -1227,7 +1249,8 @@ publishing {
         checker(MavenPublication) {
             from(components.shadow)
             checkerPom it
-            artifact tasks.named('checkerJar')
+            // checkerJar is the artifact of both variants above, so it needs no entry here.
+            artifact tasks.named('shadowJar')
             artifact tasks.named('allSourcesJar')
             artifact tasks.named('allJavadocJar')
         }

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -35,7 +35,6 @@ tasks.named('sourcesJar') {
 }
 
 configurations {
-    implementation.extendsFrom(annotatedGuava)
     fatJar {
         canBeConsumed = true
         canBeResolved = false
@@ -88,6 +87,7 @@ dependencies {
 
     implementation ("org.plumelib:reflection-util:${versions.reflectionUtil}")
     implementation "org.plumelib:plume-util:${versions.plumeUtil}"
+    implementation "com.google.guava:guava:${versions.guava}"
 
     // Dependencies added to "shadow" appear as dependencies in Maven Central.
     shadow project(':checker-qual')

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -268,9 +268,11 @@ tasks.register('checkerJar', ShadowJar) {
     group = 'Build'
     description = "Builds checker-${project.version}.jar with all dependencies except checker-qual and checker-util."
     includeEmptyDirs = false
-    base {
-        archivesName = 'checker'
-    }
+    // archiveBaseName, not `base { archivesName = ... }`, which configures the project's
+    // BasePluginExtension and renames every archive in this subproject.  Harmless here only
+    // because the value matches the project name; see dataflow/build.gradle for the same
+    // pattern where it did not.
+    archiveBaseName = 'checker'
 
     from shadowJar.source
     configurations = shadowJar.configurations

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -1248,6 +1248,19 @@ afterEvaluate {
     // Repoint the Shadow plugin's own runtime variant at checkerJar too; see above.
     configurations.shadowRuntimeElements.outgoing.artifacts.clear()
     configurations.shadowRuntimeElements.outgoing.artifact(tasks.named('checkerJar'))
+
+    // The java plugin's own variants advertise checker-VERSION-skinny.jar, from the `jar` task
+    // disabled above. That file is never produced, so a build that substitutes this project for
+    // the io.github.eisop:checker coordinate -- any consumer using --include-build -- resolves a
+    // path that does not exist and fails when it loads a class from it. Serve checkerJar, the
+    // artifact this project actually builds, from these variants as well.
+    ['apiElements', 'runtimeElements'].each { variantName ->
+        def variant = configurations.findByName(variantName)
+        if (variant != null) {
+            variant.outgoing.artifacts.clear()
+            variant.outgoing.artifact(tasks.named('checkerJar'))
+        }
+    }
 }
 
 publishing {

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -218,7 +218,7 @@ final dataflowShadedPom(MavenPublication publication, String shadedPkgName) {
                 String.join(System.lineSeparator(),
                 "dataflow-${shadedPkgName} is a dataflow framework based on the javac compiler.",
                 '',
-                'It differs from the org.checkerframework:dataflow artifact in two ways.',
+                'It differs from the io.github.eisop:dataflow artifact in two ways.',
                 "First, the packages in this artifact have been renamed to org.checkerframework.${shadedPkgName}.*.",
                 'Second, unlike the dataflow artifact, this artifact contains the dependencies it requires.')
         licenses {

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -36,9 +36,12 @@ def createDataflowShaded(shadedPkgName) {
         group = 'Build'
         description = "Builds dataflow-${shadedPkgName}.jar."
         includeEmptyDirs = false
-        base {
-            archivesName = "dataflow-${shadedPkgName}"
-        }
+        // archiveBaseName, not `base { archivesName = ... }`: a Jar task has no `base`, so that
+        // closure configures the project's BasePluginExtension and renames every archive in
+        // this subproject.  With this factory called three times, the last call won, and
+        // dataflow's own jar and sources jar were written to dataflow/build/libs as
+        // dataflow-errorprone-VERSION*.jar.
+        archiveBaseName = "dataflow-${shadedPkgName}"
         dependencies {
             exclude(project(':checker-qual'))
         }

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -208,8 +208,7 @@ final dataflowPom(publication) {
  */
 final dataflowShadedPom(MavenPublication publication, String shadedPkgName) {
     rootProject.sharedPublicationConfiguration(publication)
-
-    def ver = version
+    rootProject.addCheckerQualDependencyToPom(publication, version)
 
     publication.artifactId = "dataflow-${shadedPkgName}"
     publication.pom {
@@ -227,15 +226,6 @@ final dataflowShadedPom(MavenPublication publication, String shadedPkgName) {
                 url = 'http://www.gnu.org/software/classpath/license.html'
                 distribution = 'repo'
             }
-        }
-        withXml {
-            // This should just happen automatically, but I can't figure out how to make it happen with
-            // a custom Shadow task.
-            asNode().appendNode('dependencies').appendNode('dependency')
-            .appendNode('groupId', 'io.github.eisop').parent()
-            .appendNode('artifactId', 'checker-qual').parent()
-            .appendNode('version', ver).parent()
-            .appendNode('scope','runtime')
         }
     }
 }

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -36,11 +36,10 @@ def createDataflowShaded(shadedPkgName) {
         group = 'Build'
         description = "Builds dataflow-${shadedPkgName}.jar."
         includeEmptyDirs = false
-        // archiveBaseName, not `base { archivesName = ... }`: a Jar task has no `base`, so that
-        // closure configures the project's BasePluginExtension and renames every archive in
-        // this subproject.  With this factory called three times, the last call won, and
-        // dataflow's own jar and sources jar were written to dataflow/build/libs as
-        // dataflow-errorprone-VERSION*.jar.
+        // archiveBaseName sets the name for this task.  A Jar task has no `base`, so
+        // `base { archivesName = ... }` would resolve against the project and rename every
+        // archive in this subproject; with this factory called once per shaded package, the
+        // last call would decide the name of dataflow's own jar.
         archiveBaseName = "dataflow-${shadedPkgName}"
         dependencies {
             exclude(project(':checker-qual'))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,30 @@ Version 3.49.5-eisop2 (June ?, 2026)
 
 **User-visible changes:**
 
+Two new Maven Central artifacts support writing a custom checker without
+depending on the whole `checker` artifact: `io.github.eisop:framework`, which
+declares its dependencies in its POM, and `io.github.eisop:framework-all`,
+which bundles them (relocated) into a single jar. `io.github.eisop:framework-test`
+now declares its dependency on `framework` and so can be used outside this
+repository. See the "Declaring dependencies for a custom checker" section of
+the manual.
+
+The `framework`, `javacutil` and `dataflow` artifacts no longer publish an
+unusable shadow (`-all.jar`) variant in their Gradle module metadata.
+
+The published artifacts no longer pull in `org.checkerframework:checker-qual`
+transitively (through Guava and plume-util), which previously put a second
+definition of every qualifier on the classpath alongside
+`io.github.eisop:checker-qual`.
+
+Gradle consumers of `io.github.eisop:checker` now resolve `checker-VERSION.jar`,
+the same artifact Maven consumers get from the POM. They previously resolved
+`checker-VERSION-all.jar`, which bundles checker-qual and checker-util while
+also depending on them, so every qualifier class appeared on the classpath
+twice. `checker-VERSION-all.jar` is still published as a classified artifact.
+Accordingly, `checker` now declares checker-qual and checker-util at `compile`
+scope rather than `runtime`, matching the jar it actually ships.
+
 The Checker Framework now issues an `annotation.on.supertype` error when an annotation supported by
 the checker is written as a main annotation on the superclass or interface in an `extends` or
 `implements` clause. Annotations on the supertype's type arguments remain permitted. A checker

--- a/docs/examples/MavenExample-framework-all/pom.xml
+++ b/docs/examples/MavenExample-framework-all/pom.xml
@@ -25,8 +25,7 @@
     </dependency>
     <!-- Annotations from the Checker Framework: nullness, interning, locking, ... -->
     <dependency>
-      <!-- After next release, then: io.github.eisop -->
-      <groupId>org.checkerframework</groupId>
+      <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
       <version>${checkerFrameworkVersion}</version>
     </dependency>
@@ -67,8 +66,7 @@
               <showWarnings>true</showWarnings>
               <annotationProcessorPaths>
                 <path>
-                  <!-- Until next release, then: io.github.eisop -->
-                  <groupId>org.checkerframework</groupId>
+                  <groupId>io.github.eisop</groupId>
                   <artifactId>framework-all</artifactId>
                   <version>${checkerFrameworkVersion}</version>
                 </path>

--- a/docs/examples/publish-smoketest/build.gradle
+++ b/docs/examples/publish-smoketest/build.gradle
@@ -36,8 +36,8 @@ repositories {
 }
 
 // Every artifact this repository publishes. Resolving each one through its published metadata
-// is what catches a POM that has lost a dependency: the `framework` and `javacutil` POMs once
-// silently dropped guava, which left them and framework-all broken at class-load time.
+// is what catches a POM that is missing a dependency the artifact needs at runtime, which no
+// in-repo test can see because none of them run off the published artifacts.
 def publishedArtifacts = [
     'checker',
     'checker-qual',
@@ -164,7 +164,7 @@ tasks.register('verifyResolutions') {
             }
         }
 
-        // javacutil is the other artifact that lost guava from its POM; it is used standalone.
+        // javacutil is published and used standalone, so its POM must stand on its own too.
         def javacutilFiles = resolved['javacutil'].get()
         ['guava', 'plume-util', 'checker-qual'].each {
             if (!javacutilFiles.any { f -> f.startsWith(it) }) {

--- a/docs/examples/publish-smoketest/build.gradle
+++ b/docs/examples/publish-smoketest/build.gradle
@@ -1,8 +1,7 @@
-// Standalone project: simulates an external consumer of the published
-// `checker` artifact, the way https://github.com/eisop/checker-framework/pull/1822
-// described one failing. `checkerVersion` is passed in by
-// test-publish-smoketest.sh, which publishes that exact version to an
-// isolated mavenLocal() right before invoking this build.
+// Standalone project: simulates an external consumer of the published artifacts, the way
+// https://github.com/eisop/checker-framework/pull/1822 described one failing. `checkerVersion`
+// is passed in by test-publish-smoketest.sh, which publishes that exact version to an isolated
+// mavenLocal() right before invoking this build.
 plugins {
     id 'java'
 }
@@ -12,48 +11,175 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-repositories {
-    // The checker, checker-qual, and checker-util artifacts published by
-    // test-publish-smoketest.sh just before this build runs.
-    mavenLocal()
-    mavenCentral()
+def checkerVersion = project.findProperty('checkerVersion')
+if (checkerVersion == null) {
+    throw new GradleException(
+    "checkerVersion project property not set; run via test-publish-smoketest.sh")
 }
 
-configurations {
-    checkerDep {
+repositories {
+    // The artifacts published by test-publish-smoketest.sh just before this build runs.
+    // Restrict the io.github.eisop group to mavenLocal: mavenCentral() below is needed for the
+    // published POMs' external dependencies (plumelib, guava, stubparser), but if it could also
+    // serve io.github.eisop, a *previously released* artifact of the same version would satisfy
+    // resolution and silently mask a broken local publish.
+    mavenLocal {
+        content {
+            includeGroup 'io.github.eisop'
+        }
+    }
+    mavenCentral {
+        content {
+            excludeGroup 'io.github.eisop'
+        }
+    }
+}
+
+// Every artifact this repository publishes. Resolving each one through its published metadata
+// is what catches a POM that has lost a dependency: the `framework` and `javacutil` POMs once
+// silently dropped guava, which left them and framework-all broken at class-load time.
+def publishedArtifacts = [
+    'checker',
+    'checker-qual',
+    'checker-util',
+    'javacutil',
+    'dataflow',
+    'dataflow-shaded',
+    'dataflow-nullaway',
+    'dataflow-errorprone',
+    'framework',
+    'framework-all',
+    'framework-test',
+]
+
+// One resolvable configuration per artifact, each requesting java-runtime explicitly so
+// resolution goes through the published Gradle Module Metadata the way a consumer's would.
+publishedArtifacts.each { artifact ->
+    configurations.create(configurationNameFor(artifact)) {
+        canBeConsumed = false
+        canBeResolved = true
         attributes {
             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
         }
     }
-    frameworkDep {
-        attributes {
-            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        }
-    }
-    frameworkAllDep {
-        attributes {
-            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        }
-    }
+}
+
+/**
+ * Returns the name of the resolvable configuration for an artifact, e.g. "resolveFrameworkAll".
+ *
+ * @param artifact a published artifact name, such as "framework-all"
+ * @return the configuration name for that artifact
+ */
+static String configurationNameFor(String artifact) {
+    return 'resolve' + artifact.split('-').collect { it.capitalize() }.join('')
+}
+
+// A second source set, compiled with framework-all on the annotation processor path.
+sourceSets {
+    frameworkAll
 }
 
 dependencies {
-    def checkerVersion = project.findProperty('checkerVersion')
-    if (checkerVersion == null) {
-        throw new GradleException(
-        "checkerVersion project property not set; run via test-publish-smoketest.sh")
-    }
     implementation "io.github.eisop:checker:${checkerVersion}"
-    checkerDep "io.github.eisop:checker:${checkerVersion}"
-    frameworkDep "io.github.eisop:framework:${checkerVersion}"
-    frameworkAllDep "io.github.eisop:framework-all:${checkerVersion}"
+    publishedArtifacts.each { artifact ->
+        add(configurationNameFor(artifact), "io.github.eisop:${artifact}:${checkerVersion}")
+    }
+
+    frameworkAllCompileOnly "io.github.eisop:checker-qual:${checkerVersion}"
+    frameworkAllAnnotationProcessor "io.github.eisop:framework-all:${checkerVersion}"
 }
 
+// Run a checker that lives in `framework` itself (not in `checker`) out of the published
+// framework-all jar. Merely *resolving* an artifact does not show that it works: framework-all
+// is advertised as self-contained, and a missing bundled dependency only surfaces when its
+// classes are actually loaded. This is what catches framework-all shipping without guava.
+tasks.named('compileFrameworkAllJava') {
+    description = 'Type-checks src/frameworkAll with a checker loaded from the published framework-all jar.'
+    // The Constant Value Checker needs no -Aquals configuration, unlike SubtypingChecker.
+    options.compilerArgs += ['-processor', 'org.checkerframework.common.value.ValueChecker']
+    // A checker reaches into javac's internals, which JDK 9+ does not export by default.
+    options.fork = true
+    options.forkOptions.jvmArgs += [
+        'api', 'code', 'comp', 'file', 'main', 'model', 'processing', 'tree', 'util',
+    ].collect { '--add-exports=jdk.compiler/com.sun.tools.javac.' + it + '=ALL-UNNAMED' }
+}
+
+// Assert what each artifact resolves to, rather than only printing it.
 tasks.register('verifyResolutions') {
-    dependsOn configurations.checkerDep, configurations.frameworkDep, configurations.frameworkAllDep
-    doLast {
-        println "Resolved checker: ${configurations.checkerDep.files*.name}"
-        println "Resolved framework: ${configurations.frameworkDep.files*.name}"
-        println "Resolved framework-all: ${configurations.frameworkAllDep.files*.name}"
+    description = 'Checks that every published artifact resolves, with the dependencies it promises.'
+    def resolved = publishedArtifacts.collectEntries { artifact ->
+        [(artifact): configurations.named(configurationNameFor(artifact))
+            .map { c -> c.files*.name.toSorted() }]
     }
+    def version = checkerVersion
+    doLast {
+        def failures = []
+        resolved.each { artifact, filesProvider ->
+            def files = filesProvider.get()
+            println "${artifact} -> ${files}"
+
+            if (!files.any { it == "${artifact}-${version}.jar".toString() }) {
+                failures << "${artifact}: its own jar is missing from the resolution: ${files}"
+            }
+
+            // Exactly one checker-qual. Guava and plume-util both depend on typetools'
+            // org.checkerframework:checker-qual, which defines the same qualifier classes as
+            // io.github.eisop:checker-qual; both on one classpath is two definitions of every
+            // qualifier, so the POMs exclude it.
+            def strayQuals = files.findAll {
+                it.startsWith('checker-qual-') && it != "checker-qual-${version}.jar".toString()
+            }
+            if (!strayQuals.isEmpty()) {
+                failures << "${artifact}: a second checker-qual on the classpath: ${strayQuals}"
+            }
+        }
+
+        // framework-all bundles everything except checker-qual, so it must bring exactly those
+        // two files; anything more means dependencies leaked into its POM, and anything less
+        // means the fat jar is missing content it promised to bundle.
+        def frameworkAllFiles = resolved['framework-all'].get()
+        def expected = ["checker-qual-${version}.jar", "framework-all-${version}.jar"].toSorted()
+        if (frameworkAllFiles != expected) {
+            failures << "framework-all is meant to be self-contained apart from checker-qual.\n" +
+            "    expected: ${expected}\n    actual:   ${frameworkAllFiles}"
+        }
+
+        // `checker` must resolve to the same jar a Maven consumer gets from the POM, plus
+        // checker-qual and checker-util as separate jars. Serving the fat
+        // checker-VERSION-all.jar here instead would put every qualifier class on the
+        // classpath twice, since that jar bundles the two it also depends on.
+        def checkerFiles = resolved['checker'].get()
+        def expectedChecker = ["checker-${version}.jar", "checker-qual-${version}.jar",
+                               "checker-util-${version}.jar"].toSorted()
+        if (checkerFiles != expectedChecker) {
+            failures << "checker should resolve to its own jar plus checker-qual and " +
+            "checker-util.\n    expected: ${expectedChecker}\n    actual:   ${checkerFiles}"
+        }
+
+        // `framework` is the non-bundled counterpart, so it must declare what it needs.
+        def frameworkFiles = resolved['framework'].get()
+        ['javacutil', 'dataflow', 'checker-qual', 'guava', 'plume-util', 'stubparser'].each {
+            if (!frameworkFiles.any { f -> f.startsWith(it) }) {
+                failures << "the published `framework` POM does not pull in ${it}: ${frameworkFiles}"
+            }
+        }
+
+        // javacutil is the other artifact that lost guava from its POM; it is used standalone.
+        def javacutilFiles = resolved['javacutil'].get()
+        ['guava', 'plume-util', 'checker-qual'].each {
+            if (!javacutilFiles.any { f -> f.startsWith(it) }) {
+                failures << "the published `javacutil` POM does not pull in ${it}: ${javacutilFiles}"
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException(
+            "Published artifact resolution is wrong:\n  " + failures.join("\n  "))
+        }
+    }
+}
+
+tasks.register('smoketest') {
+    description = 'Runs every check in this consumer build.'
+    dependsOn 'compileJava', 'compileFrameworkAllJava', 'verifyResolutions'
 }

--- a/docs/examples/publish-smoketest/build.gradle
+++ b/docs/examples/publish-smoketest/build.gradle
@@ -14,11 +14,27 @@ java {
 
 repositories {
     // The checker, checker-qual, and checker-util artifacts published by
-    // test-publish-smoketest.sh just before this build runs. checker-qual
-    // and checker-util are regular (non-bundled) dependencies of the
-    // published `checker` artifact, so they must be resolvable here too;
-    // neither of them needs anything beyond mavenLocal().
+    // test-publish-smoketest.sh just before this build runs.
     mavenLocal()
+    mavenCentral()
+}
+
+configurations {
+    checkerDep {
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+    }
+    frameworkDep {
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+    }
+    frameworkAllDep {
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+    }
 }
 
 dependencies {
@@ -28,4 +44,16 @@ dependencies {
         "checkerVersion project property not set; run via test-publish-smoketest.sh")
     }
     implementation "io.github.eisop:checker:${checkerVersion}"
+    checkerDep "io.github.eisop:checker:${checkerVersion}"
+    frameworkDep "io.github.eisop:framework:${checkerVersion}"
+    frameworkAllDep "io.github.eisop:framework-all:${checkerVersion}"
+}
+
+tasks.register('verifyResolutions') {
+    dependsOn configurations.checkerDep, configurations.frameworkDep, configurations.frameworkAllDep
+    doLast {
+        println "Resolved checker: ${configurations.checkerDep.files*.name}"
+        println "Resolved framework: ${configurations.frameworkDep.files*.name}"
+        println "Resolved framework-all: ${configurations.frameworkAllDep.files*.name}"
+    }
 }

--- a/docs/examples/publish-smoketest/src/frameworkAll/java/FrameworkAllSmoke.java
+++ b/docs/examples/publish-smoketest/src/frameworkAll/java/FrameworkAllSmoke.java
@@ -1,0 +1,15 @@
+// Compiled with the published `framework-all` artifact on the annotation processor path,
+// running a checker out of it (see ../../../build.gradle). Merely *resolving* framework-all
+// is not enough to show that it works: the artifact is advertised as self-contained, and a
+// missing bundled dependency only surfaces when its classes are actually loaded. Running a
+// real checker loads SourceChecker, GenericAnnotatedTypeFactory and the dataflow machinery,
+// which is what caught framework-all shipping without Guava.
+public class FrameworkAllSmoke {
+    public static int len(String s) {
+        return s.length();
+    }
+
+    public static void main(String[] args) {
+        System.out.println(len("ok"));
+    }
+}

--- a/docs/examples/publish-smoketest/test-publish-smoketest.sh
+++ b/docs/examples/publish-smoketest/test-publish-smoketest.sh
@@ -62,6 +62,6 @@ HOME="${SMOKETEST_HOME}" ./gradlew --console=plain \
 cd "${CONSUMER_DIR}"
 HOME="${SMOKETEST_HOME}" "${REPO_ROOT}/gradlew" --console=plain \
   -PcheckerVersion="${CHECKER_VERSION}" \
-  clean compileJava
+  clean compileJava verifyResolutions
 
-echo "Publish smoke test passed: a Java 8 consumer build resolved and compiled against io.github.eisop:checker:${CHECKER_VERSION}."
+echo "Publish smoke test passed: a Java 8 consumer build resolved and compiled against io.github.eisop:checker:${CHECKER_VERSION}, framework, and framework-all."

--- a/docs/examples/publish-smoketest/test-publish-smoketest.sh
+++ b/docs/examples/publish-smoketest/test-publish-smoketest.sh
@@ -14,6 +14,10 @@
 #   2. The `checker` artifact's published component lacking a compile-time
 #      (java-api) variant, so `compileClasspath` resolution fails with
 #      "No matching variant" even when the JVM version matches.
+#   3. A POM that has lost a dependency it needs at runtime. `framework` and
+#      `javacutil` once dropped guava this way, which broke them and
+#      framework-all at class-load time while every in-repo test still passed,
+#      because the in-repo tests never run off the published artifacts.
 #
 # Publishing goes to an isolated, throwaway Maven-local repository (a fresh
 # $HOME, so `~/.m2/repository` resolves underneath it) rather than the
@@ -46,9 +50,11 @@ if [ -z "${CHECKER_VERSION}" ]; then
 fi
 echo "Publishing and consuming version ${CHECKER_VERSION}"
 
-# Publish exactly the artifacts an external consumer of `checker` resolves:
-# checker itself, plus checker-qual and checker-util, which are declared as
-# regular (non-bundled) dependencies of the published `checker` artifact.
+# Publish exactly the artifacts an external consumer resolves: checker itself,
+# plus checker-qual and checker-util, which are declared as regular (non-bundled)
+# dependencies of the published `checker` artifact. The trailing `publishToMavenLocal`
+# covers every other subproject, which is where framework, framework-all and their
+# own dependencies (javacutil, dataflow) come from.
 HOME="${SMOKETEST_HOME}" ./gradlew --console=plain \
   -x javadoc -x allJavadoc \
   :checker-qual:publishToMavenLocal \
@@ -62,6 +68,8 @@ HOME="${SMOKETEST_HOME}" ./gradlew --console=plain \
 cd "${CONSUMER_DIR}"
 HOME="${SMOKETEST_HOME}" "${REPO_ROOT}/gradlew" --console=plain \
   -PcheckerVersion="${CHECKER_VERSION}" \
-  clean compileJava verifyResolutions
+  clean smoketest
 
-echo "Publish smoke test passed: a Java 8 consumer build resolved and compiled against io.github.eisop:checker:${CHECKER_VERSION}, framework, and framework-all."
+echo "Publish smoke test passed: a Java 8 consumer build resolved every published"
+echo "io.github.eisop artifact at version ${CHECKER_VERSION}, compiled against checker,"
+echo "and ran a checker out of the published framework-all artifact."

--- a/docs/examples/publish-smoketest/test-publish-smoketest.sh
+++ b/docs/examples/publish-smoketest/test-publish-smoketest.sh
@@ -14,10 +14,10 @@
 #   2. The `checker` artifact's published component lacking a compile-time
 #      (java-api) variant, so `compileClasspath` resolution fails with
 #      "No matching variant" even when the JVM version matches.
-#   3. A POM that has lost a dependency it needs at runtime. `framework` and
-#      `javacutil` once dropped guava this way, which broke them and
-#      framework-all at class-load time while every in-repo test still passed,
-#      because the in-repo tests never run off the published artifacts.
+#   3. A published POM that omits a dependency the artifact needs at runtime.
+#      The in-repo test suite cannot see this, because it never runs off the
+#      published artifacts; the failure appears only when a consumer resolves
+#      the POM, or when a bundled jar is missing classes it needs at load time.
 #
 # Publishing goes to an isolated, throwaway Maven-local repository (a fresh
 # $HOME, so `~/.m2/repository` resolves underneath it) rather than the

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -215,21 +215,57 @@ template for a stand-alone repository:
 \url{https://github.com/eisop/templatefora-checker}; at that URL,
 click the ``Use this template'' button.
 
-% You may also wish to consult Section~\ref{creating-testing-framework} for
-% information on testing a checker and
-% Section~\ref{creating-debugging-options} for information on debugging a
-% checker.
+\subsectionAndLabel{Declaring dependencies for a custom checker}{creating-compiling-dependencies}
 
-Once your custom checker is written, using it is very similar to using a
-built-in checker (Section~\ref{running}):
+To compile a custom checker, add the Checker Framework core library and
+qualifier annotations to your project's build file.
+
+In Gradle:
+\begin{Verbatim}
+dependencies {
+    implementation "io.github.eisop:framework:${checkerFrameworkVersion}"
+    implementation "io.github.eisop:checker-qual:${checkerFrameworkVersion}"
+}
+\end{Verbatim}
+
+In Maven:
+\begin{Verbatim}
+<dependencies>
+  <dependency>
+    <groupId>io.github.eisop</groupId>
+    <artifactId>framework</artifactId>
+    <version>${checkerFrameworkVersion}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.github.eisop</groupId>
+    <artifactId>checker-qual</artifactId>
+    <version>${checkerFrameworkVersion}</version>
+  </dependency>
+</dependencies>
+\end{Verbatim}
+
+Alternatively, you can depend on the self-contained
+\<io.github.eisop:framework-all> artifact, which bundles the core framework
+and all of its dependencies (relocated to avoid version conflicts).
+
+To write automated tests for your checker
+(Section~\ref{creating-testing-framework}), also add
+\<io.github.eisop:framework-test> as a test dependency:
+\begin{Verbatim}
+testImplementation "io.github.eisop:framework-test:${checkerFrameworkVersion}"
+\end{Verbatim}
+
+\subsectionAndLabel{Running a custom checker}{creating-running-custom-checker}
+
+Once your custom checker is written and compiled, using it is very similar to
+using a built-in checker (Section~\ref{running}):
 simply pass the fully-qualified name of your \<BaseTypeChecker>
 subclass to the \<-processor> command-line option:
 \begin{alltt}
-  javac -processor \textit{mypackage.MyPropChecker} SourceFile.java
+  javac -processor \textit{mypackage.MyPropChecker} -processorpath \textit{mychecker.jar}:\textit{framework-all.jar} SourceFile.java
 \end{alltt}
-Note that your custom checker's
-\<.class> files must be on the same path (the classpath or processorpath)
-as the Checker Framework.
+Note that your custom checker's \<.class> files must be on the processorpath
+along with \<framework-all.jar> (or \<checker.jar>).
 Invoking a custom checker that builds on
 the Subtyping Checker is slightly different (Section~\ref{subtyping-using}).
 
@@ -2011,8 +2047,9 @@ Section~\ref{stub-troubleshooting} useful.
 \sectionAndLabel{Testing framework}{creating-testing-framework}
 
 The Checker Framework provides a convenient way to write tests for your
-checker.  Each test case is a Java file, with inline indications of what
-errors and warnings (if any) a checker should emit.  An example is
+checker using the \<io.github.eisop:framework-test> library.  Each test case
+is a Java file, with inline indications of what errors and warnings (if any)
+a checker should emit.  An example is
 
 \begin{Verbatim}
 class MyNullnessTest {
@@ -2028,6 +2065,12 @@ class MyNullnessTest {
 When the Nullness Checker is run on the above code, it should produce
 exactly one error, whose message key is \<dereference.of.nullable>, on
 the line following the ``// ::'' comment.
+
+The test classes (subclassing
+\refclass{framework/test}{CheckerFrameworkTest} or
+\refclass{framework/test}{CheckerFrameworkPerFileTest}) compile the test
+inputs and assert that the actual diagnostics match the expected error
+comments.
 
 % Don't repeat the information here, to prevent them from getting out of sync.
 The testing infrastructure is extensively documented in file

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -568,6 +568,15 @@ Alternately, you can get all of the jars mentioned in this section from Maven Ce
 \item \<checker.jar>: \url{https://repo1.maven.org/maven2/io/github/eisop/checker/3.49.5-eisop1/checker-3.49.5-eisop1-all.jar}
 \end{itemize}
 
+Note the \<-all> classifier on that last URL.  On Maven Central,
+\<checker-\emph{version}-all.jar> is the self-contained jar, and it is the one
+that corresponds to \<checker/dist/checker.jar> in the release zip.  The plain
+\<checker-\emph{version}.jar> artifact is \emph{not} self-contained: it omits the
+qualifier and utility classes, declaring \<checker-qual> and \<checker-util> as
+Maven dependencies instead, so on its own it does not work as a processor path.
+Build tools that read the Maven metadata resolve those dependencies for you; a
+manual download does not.
+
 Different arguments to \<javac> are required for JDK 8
 (Section~\ref{javac-jdk8}) and for JDK 9+ (Section~\ref{javac-jdk11}).
 

--- a/framework-test/build.gradle
+++ b/framework-test/build.gradle
@@ -23,13 +23,8 @@ dependencies {
         tagletJdk8Implementation files(toolsJar)
     }
 
-    // BinaryStubDiffChecker (org.checkerframework.framework.stub) type-checks against framework's
-    // internals, but framework is not a published artifact: it is bundled into checker.jar, which
-    // every consumer of framework-test already has on its classpath. compileOnly therefore compiles
-    // against it without putting an unresolvable dependency in framework-test's POM.
-    compileOnly project(':framework')
-
-    testImplementation project(':framework')
+    // BinaryStubDiffChecker (org.checkerframework.framework.stub) type-checks against framework's internals.
+    implementation project(':framework')
 }
 
 // Shadow 9.4.2 eagerly triggers compile tasks for all source sets.

--- a/framework-test/build.gradle
+++ b/framework-test/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    // For the `api` configuration used below: framework-test is a published library whose
+    // public signatures expose framework types.
+    id 'java-library'
+}
+
 sourceSets {
     taglet
     tagletJdk8
@@ -23,8 +29,13 @@ dependencies {
         tagletJdk8Implementation files(toolsJar)
     }
 
-    // BinaryStubDiffChecker (org.checkerframework.framework.stub) type-checks against framework's internals.
-    implementation project(':framework')
+    // BinaryStubDiffChecker (org.checkerframework.framework.stub) type-checks against framework's
+    // internals, and exposes them in its own public signatures -- BinaryStubDiffChecker.run and
+    // diffBuiltinStub both take an AnnotatedTypeFactory. `api`, not `implementation`, so that
+    // framework reaches consumers at compile scope: with `implementation` the POM would declare
+    // it at runtime scope, off a Maven consumer's compile classpath and absent from the
+    // apiElements variant a Gradle consumer resolves.
+    api project(':framework')
 }
 
 // Shadow 9.4.2 eagerly triggers compile tasks for all source sets.

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -344,9 +344,9 @@ tasks.register('frameworkAllJar', ShadowJar) {
     group = 'Build'
     description = "Builds framework-all-${project.version}.jar with all dependencies except checker-qual."
     includeEmptyDirs = false
-    // archiveBaseName, not `base { archivesName = ... }`: `base` resolves to the project's
-    // BasePluginExtension, so setting it here renamed every archive in this subproject --
-    // framework's own jar and sources jar were being written as framework-all-VERSION*.jar.
+    // archiveBaseName sets the name for this task.  `base { archivesName = ... }` would
+    // instead resolve against the project and rename every archive in this subproject,
+    // including framework's own jar and sources jar.
     archiveBaseName = 'framework-all'
     archiveClassifier = ''
     destinationDirectory = layout.buildDirectory.dir('shadow/frameworkAll')

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -119,11 +119,14 @@ dependencies {
     implementation "org.plumelib:hashmap-util:${versions.hashmapUtil}"
     implementation "org.plumelib:plume-util:${versions.plumeUtil}"
     implementation "org.plumelib:reflection-util:${versions.reflectionUtil}"
-    compileOnly "com.google.guava:guava:${versions.guava}"
+    // Guava is used from main sources on unconditional code paths (SourceChecker's
+    // Splitter/ImmutableSet uses and GenericAnnotatedTypeFactory's Ordering uses), so it must
+    // be an `implementation` dependency: it has to appear in this artifact's POM and on
+    // runtimeClasspath, which is what frameworkAllJar is built from.
+    implementation "com.google.guava:guava:${versions.guava}"
     // Add this dependency if needed to debug classpath issues.
     // implementation 'io.github.classgraph:classgraph:4.8.180'
 
-    testImplementation "com.google.guava:guava:${versions.guava}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation project(':framework-test')
     testImplementation sourceSets.testannotations.output
@@ -227,7 +230,7 @@ tasks.named('processResources').configure { dependsOn 'copyAndMinimizeAnnotatedJ
 
 tasks.register('allSourcesJar', Jar) {
     group = 'Build'
-    description = 'Creates a sources jar that includes sources for all Checker Framework classes in framework.jar'
+    description = 'Creates a sources jar with the sources of every class in framework-all.jar'
     destinationDirectory = file("${projectDir}/dist")
     archiveFileName = 'framework-source.jar'
     archiveClassifier = 'sources'
@@ -238,7 +241,7 @@ tasks.register('allSourcesJar', Jar) {
 
 tasks.register('allJavadocJar', Jar) {
     group = 'Build'
-    description = 'Creates javadoc jar include Javadoc for all of the framework'
+    description = 'Creates a javadoc jar with the Javadoc of every class in framework-all.jar'
     def javadocs = [
         ':framework',
         ':dataflow',
@@ -334,6 +337,7 @@ if (skipDelombok) {
 }
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.component.AdhocComponentWithVariants
 
 tasks.register('frameworkAllJar', ShadowJar) {
     dependsOn 'compileJava'
@@ -347,54 +351,60 @@ tasks.register('frameworkAllJar', ShadowJar) {
     destinationDirectory = layout.buildDirectory.dir('shadow/frameworkAll')
 
     from shadowJar.source
+    // runtimeClasspath, so every `implementation` dependency is bundled and relocated.
+    // A dependency declared `compileOnly` would silently be left out; see the guava
+    // comment in the dependencies block above.
     configurations = shadowJar.configurations
-    manifest {
-        attributes('Automatic-Module-Name': 'org.checkerframework.framework')
-    }
-    exclude 'org/checkerframework/**/qual/*'
     relocators = shadowJar.getRelocators()
+    // The manifest (Automatic-Module-Name, Implementation-Version, Bundle-License) comes
+    // from the `tasks.withType(Jar)` block in ../build.gradle, which keys off archiveFileName.
+
+    // checker-qual is a normal published dependency of framework-all (added to its POM in
+    // configureFrameworkPom below), not bundled, so that a consumer gets one copy of the
+    // qualifiers rather than a relocated duplicate.
+    exclude 'org/checkerframework/**/qual/*'
+    // Not inherited from the shadowJar block in ../build.gradle, which configures only the
+    // task named `shadowJar`. Without it this jar ships checker-qual's module descriptor,
+    // which declares `module org.checkerframework.checker.qual` and exports packages the
+    // exclude above has just removed -- a module that does not describe this jar.
+    exclude '**/module-info.class'
+    // jsr305 comes in through guava, and its annotations on the bundled guava classes keep
+    // part of it alive through minimize(). No Checker Framework class references a jsr305
+    // type, so it is not API here -- and shipping it would put `javax.annotation`, a package
+    // shared with JSR-250, unrelocated inside this jar. It cannot be relocated instead: the
+    // Nullness Checker compares user annotations against the literal
+    // "javax.annotation.Nullable", which ShadowJar would rewrite along with the package.
+    dependencies {
+        exclude(dependency('com.google.code.findbugs:jsr305:.*'))
+    }
     minimize()
 }
+
+// `assemble` deliberately does not build frameworkAllJar: it is needed only when publishing,
+// and it costs a full shadow pass. `publish`/`publishToMavenLocal` pick it up through the
+// frameworkAll publication's artifact list. This mirrors the reasoning for allJavadocJar and
+// allSourcesJar, which are likewise kept off `assemble`.
 
 apply from: rootProject.file('gradle-mvn-push.gradle')
 
 /**
- * Configures the POM for framework and framework-all publications.
+ * Configures the parts of the POM that framework and framework-all share.
+ *
  * @param publication the MavenPublication to configure
- * @param isAll true if configuring framework-all, false for framework
+ * @param artifactName the artifact this publication produces, named in the description
+ * @param extraDescriptionLines description lines to append, if any
  */
-final configureFrameworkPom(MavenPublication publication, boolean isAll) {
+final configureFrameworkPom(
+MavenPublication publication, String artifactName, List<String> extraDescriptionLines = []) {
     rootProject.sharedPublicationConfiguration(publication)
-
-    if (isAll) {
-        def ver = version
-        publication.artifactId = 'framework-all'
-        publication.pom {
-            withXml {
-                asNode().appendNode('dependencies').appendNode('dependency')
-                    .appendNode('groupId', 'io.github.eisop').parent()
-                    .appendNode('artifactId', 'checker-qual').parent()
-                    .appendNode('version', ver).parent()
-                    .appendNode('scope', 'runtime')
-            }
-        }
-    } else {
-        publication.from components.java
-        publication.suppressPomMetadataWarningsFor('testFixturesApiElements')
-        publication.suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
-    }
-
     publication.pom {
-        name = isAll
-            ? 'Checker Framework Core Library (including all dependencies)'
-            : 'Checker Framework Core Library'
         description = String.join(System.lineSeparator(),
-                'The Checker Framework enhances Java\'s type system to',
-                'make it more powerful and useful. This lets software developers',
-                'detect and prevent errors in their Java programs.',
-                "The ${isAll ? 'framework-all' : 'framework'} artifact contains the core type checking infrastructure",
-                'and permits you to write your own compiler plug-ins.',
-                *(isAll ? ['Unlike the framework artifact, this artifact contains all its dependencies.'] : []))
+                ['The Checker Framework enhances Java\'s type system to',
+                 'make it more powerful and useful. This lets software developers',
+                 'detect and prevent errors in their Java programs.',
+                 "The ${artifactName} artifact contains the core type checking infrastructure",
+                 'and permits you to write your own compiler plug-ins.']
+                + extraDescriptionLines)
         licenses {
             license {
                 name = 'GNU General Public License, version 2 (GPL2), with the classpath exception'
@@ -405,14 +415,42 @@ final configureFrameworkPom(MavenPublication publication, boolean isAll) {
     }
 }
 
+// src/testFixtures is an internal support library: it exists so that the testchecker sources
+// are shared with :checker's tests (see the java-test-fixtures comment at the top of this file).
+// The java-test-fixtures plugin adds its two variants to `components.java`, which would publish
+// framework-VERSION-test-fixtures.jar and reference it from the Gradle Module Metadata -- an
+// artifact we do not support, invisible to Maven consumers, and describable in a POM only by
+// suppressing the warning that says so. Skip both variants instead.
+afterEvaluate {
+    def javaComponent = components.java as AdhocComponentWithVariants
+    ['testFixturesApiElements', 'testFixturesRuntimeElements'].each { name ->
+        def variant = configurations.findByName(name)
+        if (variant != null) {
+            javaComponent.withVariantsFromConfiguration(variant) { it.skip() }
+        }
+    }
+}
+
 publishing {
     publications {
+        // The ordinary library: the framework classes, with its dependencies declared in the
+        // POM rather than bundled.
         framework(MavenPublication) {
-            configureFrameworkPom(it, false)
+            configureFrameworkPom(it, 'framework')
+            pom.name = 'Checker Framework Core Library'
+            from components.java
         }
 
+        // The self-contained variant: one jar with every dependency bundled and relocated.
+        // It has no Gradle component (its jar is assembled by frameworkAllJar rather than by
+        // a configuration), so there is nothing for Gradle to derive POM dependencies from,
+        // and the single dependency it does have has to be written by hand.
         frameworkAll(MavenPublication) {
-            configureFrameworkPom(it, true)
+            configureFrameworkPom(it, 'framework-all',
+            ['Unlike the framework artifact, this artifact contains all its dependencies.'])
+            pom.name = 'Checker Framework Core Library (including all dependencies)'
+            artifactId = 'framework-all'
+            rootProject.addCheckerQualDependencyToPom(it, version)
             artifact tasks.named('frameworkAllJar')
             artifact tasks.named('allSourcesJar')
             artifact tasks.named('allJavadocJar')

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -344,10 +344,11 @@ tasks.register('frameworkAllJar', ShadowJar) {
     group = 'Build'
     description = "Builds framework-all-${project.version}.jar with all dependencies except checker-qual."
     includeEmptyDirs = false
-    base {
-        archivesName = 'framework-all'
-    }
-    archiveClassifier.set('')
+    // archiveBaseName, not `base { archivesName = ... }`: `base` resolves to the project's
+    // BasePluginExtension, so setting it here renamed every archive in this subproject --
+    // framework's own jar and sources jar were being written as framework-all-VERSION*.jar.
+    archiveBaseName = 'framework-all'
+    archiveClassifier = ''
     destinationDirectory = layout.buildDirectory.dir('shadow/frameworkAll')
 
     from shadowJar.source

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -66,7 +66,8 @@ tasks.named('jar') {
 
 configurations {
     implementation.extendsFrom(stubifierImplementation)
-    implementation.extendsFrom(annotatedGuava)
+    compileOnly.extendsFrom(annotatedGuava)
+    testImplementation.extendsFrom(annotatedGuava)
 
     // Exposes the stubifier tool (JavaStubifier, BinaryStubWriter, BinaryStubFileGenerator)
     // together with its runtime dependencies, for the generateBinaryStubFiles tasks that the
@@ -229,6 +230,7 @@ tasks.register('allSourcesJar', Jar) {
     description = 'Creates a sources jar that includes sources for all Checker Framework classes in framework.jar'
     destinationDirectory = file("${projectDir}/dist")
     archiveFileName = 'framework-source.jar'
+    archiveClassifier = 'sources'
     from (project(':framework').sourceSets.main.java,
             project(':dataflow').sourceSets.main.allJava,
             project(':javacutil').sourceSets.main.allJava)
@@ -249,6 +251,7 @@ tasks.register('allJavadocJar', Jar) {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     destinationDirectory = file("${projectDir}/dist")
     archiveFileName = 'framework-javadoc.jar'
+    archiveClassifier = 'javadoc'
     from javadocs.collect {
         it.map { jd ->
             jd.destinationDir
@@ -328,4 +331,96 @@ if (skipDelombok) {
         args 'delombok', srcJava, '-d', srcDelomboked, '-c', delombokClasspath.asPath
     }
     tasks.named('test').configure { dependsOn 'delombok' }
+}
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+tasks.register('frameworkAllJar', ShadowJar) {
+    dependsOn 'compileJava'
+    group = 'Build'
+    description = "Builds framework-all-${project.version}.jar with all dependencies except checker-qual."
+    includeEmptyDirs = false
+    base {
+        archivesName = 'framework-all'
+    }
+    archiveClassifier.set('')
+    destinationDirectory = layout.buildDirectory.dir('shadow/frameworkAll')
+
+    from shadowJar.source
+    configurations = shadowJar.configurations
+    manifest {
+        attributes('Automatic-Module-Name': 'org.checkerframework.framework')
+    }
+    exclude 'org/checkerframework/**/qual/*'
+    relocators = shadowJar.getRelocators()
+    minimize()
+}
+
+apply from: rootProject.file('gradle-mvn-push.gradle')
+
+/**
+ * Configures the POM for framework and framework-all publications.
+ * @param publication the MavenPublication to configure
+ * @param isAll true if configuring framework-all, false for framework
+ */
+final configureFrameworkPom(MavenPublication publication, boolean isAll) {
+    rootProject.sharedPublicationConfiguration(publication)
+
+    if (isAll) {
+        def ver = version
+        publication.artifactId = 'framework-all'
+        publication.pom {
+            withXml {
+                asNode().appendNode('dependencies').appendNode('dependency')
+                    .appendNode('groupId', 'io.github.eisop').parent()
+                    .appendNode('artifactId', 'checker-qual').parent()
+                    .appendNode('version', ver).parent()
+                    .appendNode('scope', 'runtime')
+            }
+        }
+    } else {
+        publication.from components.java
+        publication.suppressPomMetadataWarningsFor('testFixturesApiElements')
+        publication.suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
+    }
+
+    publication.pom {
+        name = isAll
+            ? 'Checker Framework Core Library (including all dependencies)'
+            : 'Checker Framework Core Library'
+        description = String.join(System.lineSeparator(),
+                'The Checker Framework enhances Java\'s type system to',
+                'make it more powerful and useful. This lets software developers',
+                'detect and prevent errors in their Java programs.',
+                "The ${isAll ? 'framework-all' : 'framework'} artifact contains the core type checking infrastructure",
+                'and permits you to write your own compiler plug-ins.',
+                *(isAll ? ['Unlike the framework artifact, this artifact contains all its dependencies.'] : []))
+        licenses {
+            license {
+                name = 'GNU General Public License, version 2 (GPL2), with the classpath exception'
+                url = 'http://www.gnu.org/software/classpath/license.html'
+                distribution = 'repo'
+            }
+        }
+    }
+}
+
+publishing {
+    publications {
+        framework(MavenPublication) {
+            configureFrameworkPom(it, false)
+        }
+
+        frameworkAll(MavenPublication) {
+            configureFrameworkPom(it, true)
+            artifact tasks.named('frameworkAllJar')
+            artifact tasks.named('allSourcesJar')
+            artifact tasks.named('allJavadocJar')
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.framework
+    sign publishing.publications.frameworkAll
 }

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -66,8 +66,6 @@ tasks.named('jar') {
 
 configurations {
     implementation.extendsFrom(stubifierImplementation)
-    compileOnly.extendsFrom(annotatedGuava)
-    testImplementation.extendsFrom(annotatedGuava)
 
     // Exposes the stubifier tool (JavaStubifier, BinaryStubWriter, BinaryStubFileGenerator)
     // together with its runtime dependencies, for the generateBinaryStubFiles tasks that the
@@ -121,9 +119,11 @@ dependencies {
     implementation "org.plumelib:hashmap-util:${versions.hashmapUtil}"
     implementation "org.plumelib:plume-util:${versions.plumeUtil}"
     implementation "org.plumelib:reflection-util:${versions.reflectionUtil}"
+    compileOnly "com.google.guava:guava:${versions.guava}"
     // Add this dependency if needed to debug classpath issues.
     // implementation 'io.github.classgraph:classgraph:4.8.180'
 
+    testImplementation "com.google.guava:guava:${versions.guava}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation project(':framework-test')
     testImplementation sourceSets.testannotations.output

--- a/javacutil/build.gradle
+++ b/javacutil/build.gradle
@@ -7,8 +7,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.google.guava:guava:${versions.guava}"
-    testImplementation "com.google.guava:guava:${versions.guava}"
+    // Guava is used from main sources on unconditional code paths (SystemUtil's Splitter
+    // fields are initialized at class load), so it must be an `implementation` dependency:
+    // it has to appear in this artifact's POM and on runtimeClasspath, which is what the
+    // shadow jars are built from.
+    implementation "com.google.guava:guava:${versions.guava}"
     implementation project(':checker-qual')
 
     // This is used by org.checkerframework.javacutil.TypesUtils.isImmutableTypeInJdk.

--- a/javacutil/build.gradle
+++ b/javacutil/build.gradle
@@ -7,7 +7,8 @@ repositories {
 }
 
 configurations {
-    implementation.extendsFrom(annotatedGuava)
+    compileOnly.extendsFrom(annotatedGuava)
+    testImplementation.extendsFrom(annotatedGuava)
 }
 
 dependencies {

--- a/javacutil/build.gradle
+++ b/javacutil/build.gradle
@@ -6,12 +6,9 @@ repositories {
     mavenCentral()
 }
 
-configurations {
-    compileOnly.extendsFrom(annotatedGuava)
-    testImplementation.extendsFrom(annotatedGuava)
-}
-
 dependencies {
+    compileOnly "com.google.guava:guava:${versions.guava}"
+    testImplementation "com.google.guava:guava:${versions.guava}"
     implementation project(':checker-qual')
 
     // This is used by org.checkerframework.javacutil.TypesUtils.isImmutableTypeInJdk.


### PR DESCRIPTION
Publishes the Checker Framework's core library to Maven Central as two new artifacts, so a
custom checker can be written without depending on the whole `checker` artifact, and makes
`framework-test` usable outside this repository.

## What this adds

**`io.github.eisop:framework`** — the core type-checking infrastructure, with its
dependencies declared in the POM.

**`io.github.eisop:framework-all`** — the same classes with every dependency bundled and
relocated into one self-contained jar (apart from `checker-qual`, which stays a normal
dependency so a consumer gets one copy of the qualifiers rather than a relocated duplicate).
Built by a new `frameworkAllJar` Shadow task, published with the combined sources and
Javadoc of `framework`, `dataflow` and `javacutil`.

**`io.github.eisop:framework-test`** now declares its dependency on `framework`, so it can
be consumed outside this build. It previously used `compileOnly`, on the reasoning that
framework was not a published artifact — which this PR changes.

**Manual documentation** — a new "Declaring dependencies for a custom checker" section in
`creating-a-checker.tex` with Gradle and Maven snippets for `framework`, `framework-all` and
`framework-test`, plus a "Running a custom checker" section that corrects the `-processorpath`
guidance. `MavenExample-framework-all` moves from the `org.checkerframework` placeholder to
the real `io.github.eisop` coordinates.

**Guava modernization** — replaces the `org.checkerframework.annotatedlib:guava` fork and its
bespoke `annotatedGuava` configuration with upstream `com.google.guava:guava`. This is
deliberate. The cost is bounded to this repository's own self-checking: annotated Guava
carried annotations for eight type systems (`@Pure`/`@SideEffectFree`, index, signedness,
value, ...), upstream Guava carries nullness only, and only the 14 files here that call Guava
are affected. Users are unaffected — they supply their own Guava. Measured: `checkNullness`,
`checkInterning`, `checkPurity` and `checkSignature` all still pass, with
`-AwarnUnneededSuppressions` on.

**POM/metadata tidying** — corrects the `dataflow-*` POM descriptions to name the
`io.github.eisop:dataflow` artifact, and adds the EISOP coordinates to `checker`'s
`shadowJar` minimize excludes alongside the legacy `org.checkerframework` ones.

## Fixes found while reviewing the above

**`framework-all` did not work at all.** Guava had been made `compileOnly` in `javacutil` and
`framework`, but it is used from main sources on unconditional paths — `SystemUtil`'s
`Splitter` fields initialize at class load, `SourceChecker` uses `Splitter`/`ImmutableSet`,
`GenericAnnotatedTypeFactory` uses `Ordering`. A `compileOnly` dependency is on neither
`runtimeClasspath` nor the POM, so `framework-all` shipped **zero** Guava classes and died on
first class load with `NoClassDefFoundError: .../common/base/Splitter` at
`SystemUtil.<clinit>`; the `framework` POM omitted Guava; and **`javacutil`, already on Maven
Central, regressed** — its POM declared `annotatedlib:guava` before, and nothing after.

**Duplicate `checker-qual`.** Guava and plume-util both pull in typetools'
`org.checkerframework:checker-qual`, so consumers resolved two definitions of every qualifier.
The old `annotatedGuava` configuration excluded it; removing that configuration dropped the
exclusion. Restored as one rule.

**A stray fat jar per artifact.** `from components.java` picks up Shadow's
`shadowRuntimeElements`, so `framework`, `javacutil` and `dataflow` each advertised a 6.9 MB
`-all.jar` in their module metadata under a Usage no consumer requests — and uploaded it.
Pre-existing for javacutil and dataflow. The `java-test-fixtures` variants were published the
same way, with `suppressPomMetadataWarningsFor` silencing the warning that said so.

**`checker` gave Gradle and Maven different jars.** Its variants served
`checker-VERSION-all.jar` while the POM offered `checker-VERSION.jar`; the variants also
declare checker-qual and checker-util, which that fat jar bundles, so Gradle consumers got
every qualifier class twice. Both variants now serve `checkerJar`.

**`framework-test` scope.** `BinaryStubDiffChecker.run` takes an `AnnotatedTypeFactory`, so
framework is part of its public API — `api`, not `implementation`.

## For review: a deliberate scope change

`checker` now declares checker-qual and checker-util at **`compile`** scope rather than
`runtime`. This follows from giving the compile-time variant the same dependencies as the
runtime one; without that, a Gradle consumer compiling against `checker` would have no
qualifier classes, since `checker-VERSION.jar` excludes them. It matches the jar actually
shipped and what `framework`, `dataflow`, `checker-util` and `framework-test` already declare,
but it does widen the published contract.

## The smoke test now catches this class of bug

It previously resolved three artifacts and asserted nothing, so it could not have caught the
Guava regression. It now resolves **all eleven** published artifacts, asserts each brings its
own jar and exactly one checker-qual, and **runs the Constant Value Checker out of the
published `framework-all`** — resolving an artifact does not show that it works. Reverting
Guava to `compileOnly` now fails it with `NoClassDefFoundError` rather than passing.

The conformance job also moves off `-PcfLocal`, which read jars out of this checkout's build
directories, onto `publishToMavenLocal` + `-PcfVersion`. Needs
eisop/jspecify-conformance#167, on a matching branch name so `git-clone-related` picks it up.

## Verification

- `assemble`, `assembleForJavac`, `:framework-test:build`
- the publish smoke test, including the negative test above
- `checkNullness`/`checkSignature`/`checkPurity`/`checkInterning` on the affected projects
- POMs and module metadata inspected directly for all twelve publications
- the full jspecify conformance suite against a locally published build
- `manual.pdf` builds

`alltests` has not been run; CI covers the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Started with Antigravity and then finished with Claude.