### PR TITLE
Ship only what the shaded jars need

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1176,6 +1176,22 @@ subprojects {
 
         exclude '**/module-info.class'
 
+        // Guava depends on jsr305, and 784 of the bundled Guava classes carry its annotations,
+        // which keeps part of it alive through minimize(). No Checker Framework class
+        // references any jsr305 type, so it is not part of our API -- only annotation metadata
+        // on relocated internals. Leaving it in would ship `javax.annotation`, a package we
+        // share with JSR-250, unrelocated inside our jars, where it can collide with a
+        // consumer's own. Relocating it instead is not an option: the Nullness Checker
+        // compares *user* annotations against the literals "javax.annotation.Nullable",
+        // ".Nonnull" and ".CheckForNull", which ShadowJar would rewrite along with the package.
+        //
+        // It stays on the compile classpath, where javac needs javax.annotation.meta.When to
+        // read Guava's annotations -- without it, `-Werror` fails on
+        // "unknown enum constant When.UNKNOWN".
+        dependencies {
+            exclude(dependency('com.google.code.findbugs:jsr305:.*'))
+        }
+
         minimize()
     }
 

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -281,7 +281,31 @@ tasks.register('checkerJar', ShadowJar) {
     }
     exclude 'org/checkerframework/**/qual/*'
     exclude 'org/checkerframework/checker/**/util/*'
+    // Not inherited from the shadowJar block in ../build.gradle, which configures only the
+    // task named `shadowJar`. Without it the published checker artifact ships checker-qual's
+    // module descriptor, declaring `module org.checkerframework.checker.qual` and exporting
+    // the qual packages the exclude above has just removed.
+    exclude '**/module-info.class'
+    // Not inherited either; see the same exclusion in ../build.gradle's shadowJar block.
+    dependencies {
+        exclude(dependency('com.google.code.findbugs:jsr305:.*'))
+    }
     relocators = shadowJar.getRelocators()
+
+    // Same reachability root as shadowJar's: BinaryStubFileGenerator is a build-time main class
+    // with no caller, so minimize() would prune it, and the stubifier tool is meant to ship in
+    // checker.jar for external checkers (see the stubifierToolForShadow configuration above).
+    // Registering the classesDir as a root keeps all three tool classes unconditionally.
+    // This appends to sourceSetsClassesDirs rather than adding a second entry to
+    // `configurations`, which would corrupt minimize()'s analysis for the whole jar; see the
+    // comment on shadowJar's own copy of this, and commit 8396efab63.
+    sourceSetsClassesDirs.from(project.configurations.stubifierToolForShadow.filter { it.isDirectory() })
+
+    // Without this the published artifact ships ~1240 classes, about 2 MB, that nothing in it
+    // can reach -- shadowJar has always minimized, and this jar differs from it only by the
+    // deliberately excluded checker-qual and checker-util classes, which are declared as
+    // dependencies instead.
+    minimize()
 }
 
 tasks.named('jar') {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,21 @@ Version 3.49.5-eisop2 (June ?, 2026)
 
 **User-visible changes:**
 
+The published `checker` artifact is about 2 MB smaller. It was the only shaded
+jar built without `minimize()`, so it shipped roughly 1240 classes that nothing
+in it could reach.
+
+The published `checker` artifact no longer contains a `module-info.class`. It
+was checker-qual's module descriptor, declaring a module whose exported
+packages the artifact does not contain.
+
+The shaded jars no longer bundle jsr305's `javax.annotation` classes. Those are
+annotation metadata on relocated Guava internals, not part of the Checker
+Framework's API, and shipping them unrelocated put a package shared with
+JSR-250 on consumers' classpaths. Recognition of `javax.annotation.Nullable`,
+`@Nonnull` and `@CheckForNull` in user code is unaffected; those are read from
+the user's own classpath.
+
 The Checker Framework now issues an `annotation.on.supertype` error when an annotation supported by
 the checker is written as a main annotation on the superclass or interface in an `extends` or
 `implements` clause. Annotations on the supertype's type arguments remain permitted. A checker


### PR DESCRIPTION
Three fixes to what the shaded jars *contain*, split out from #2013 (which covers
publication metadata) because these change the jars users actually run and are the
clean revert target if anything misbehaves.

All three are verified against `dist/checker.jar` -- the artifact the test suite
already runs against.

### `checkerJar` was the only shaded jar not minimized

`shadowJar` has always called `minimize()`; `checkerJar`, which produces the published
`checker` artifact, never did. Nothing documents the difference; the task predates eisop.

| | size | classes |
| --- | --- | --- |
| without `minimize()` | 10.5 MB | 3932 |
| with `minimize()` | 8.5 MB | 2694 |

About 2 MB, 19%, of classes nothing in the artifact can reach.

Safety here is not an argument from first principles: with minimize on, this jar's class
set becomes **exactly** that of `dist/checker.jar`, minus the checker-qual and checker-util
classes it deliberately excludes and declares as dependencies. (The one apparent gap,
`I18nFormatUtil`, is matched by the `checker/**/util/*` exclude and ships in `checker-util`.)

Plain `minimize()` did drop one class it should not have: `BinaryStubFileGenerator`, a
build-time main class with no caller that `checker/build.gradle` ships deliberately "for
external checkers to build their own binary annotated JDK or .astub files against".
`shadowJar` already guards it by registering the stubifier classesDir as a reachability
root; `checkerJar` now does the same.

### `checkerJar` shipped a wrong module descriptor

It lacked `shadowJar`'s `module-info.class` exclusion, so the published artifact carried
checker-qual's descriptor: it declared `module org.checkerframework.checker.qual` while
excluding every package that module exports. A module descriptor that does not describe
its jar breaks JPMS consumers.

### jsr305 dropped from the bundle

Guava depends on it, and 784 of the bundled Guava classes carry `@CheckForNull`, which
keeps part of jsr305 alive through `minimize()` -- that annotation is itself annotated
`@Nonnull` and `@TypeQualifierNickname`, pulling in the `meta/*` closure. Of the 1043
Checker Framework classes in `checker.jar`, **zero** reference any jsr305 type, so it is
not part of our API -- only annotation metadata on relocated internals. Shipping it put
`javax.annotation`, a package shared with JSR-250, unrelocated inside our jars.

Relocating instead is not an option, and `javax.annotation`'s absence from the relocate
list is load-bearing: the Nullness, Index and Value checkers compare user annotations
against the literals `"javax.annotation.Nullable"`, `".Nonnull"`, `".CheckForNull"` and
`".Nonnegative"`, which ShadowJar would rewrite along with the package -- the same defect
as #2012.

It stays on the compile classpath. Excluding it there first was wrong and
`:framework:checkNullness` caught it: javac needs `javax.annotation.meta.When` to read
Guava's annotations, and `-Werror` fails on `unknown enum constant When.UNKNOWN`.

jsr305 remains an ordinary transitive dependency of `framework`, `javacutil` and `dataflow`
through guava; for a non-bundled artifact that is normal resolution, not a package
smuggled inside a jar.

### Verification

- Eight checkers (nullness, index, formatter, resourceleak, optional, interning, signature,
  regex) each load and report diagnostics when run out of the minimized jar -- the case that
  would fail if minimize had pruned something reached only reflectively
- All 19 stubifier tool classes still present; 0 jsr305 and 0 `module-info.class`
- `checker/bin/javac` still reports `dereference.of.nullable` end-to-end
- jsr305 `@Nullable`/`@Nonnull` in *user* code still recognized, read from the user's classpath
- `assemble`, `assembleForJavac`, `:checker:checkNullness`

`alltests` has not been run, and nothing in CI exercises the published `checkerJar` beyond
the publish smoke test, so this one is gated on CI rather than on local proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV
