### PR TITLE
Reduce a capture variable against its upper bound in type argument inference

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,11 @@ alternative to running it as a standalone annotation processor.  It is published
 `io.github.eisop:framework-errorprone` and requires JDK 21 or later.  See the manual's
 "Error Prone" section.
 
+Type argument inference no longer fails on a `? super` wildcard whose argument mentions
+the inferred type variable through `? extends`, as in
+`Function<? super Set<? extends K>, ?>`.  It reported
+`type.argument.inference.crashed` on code that javac accepts.
+
 The Checker Framework now issues an `annotation.on.supertype` error when an annotation supported by
 the checker is written as a main annotation on the superclass or interface in an `extends` or
 `implements` clause. Annotations on the supertype's type arguments remain permitted. A checker
@@ -755,7 +760,7 @@ eisop#104, eisop#386, eisop#433, eisop#737, eisop#786, eisop#792, eisop#863,
 eisop#949, eisop#1015, eisop#1059, eisop#1074, eisop#1244, eisop#1315,
 eisop#1564, eisop#1592, eisop#1642, eisop#1653, eisop#1735, eisop#1801,
 eisop#1818, eisop#1819, eisop#1861, eisop#1862, eisop#1863, eisop#1865,
-eisop#1887, eisop#1965, eisop#1987, typetools#399, typetools#3203.
+eisop#1887, eisop#1965, eisop#1987, eisop#2032, typetools#399, typetools#3203.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -296,6 +296,14 @@ public class Typing extends TypeConstraint {
             return new Typing(this, S, T.getTypeVarLowerBound(), Kind.SUBTYPE);
         } else if (T.getTypeKind() == TypeKind.WILDCARD && T.isLowerBoundedWildcard()) {
             return new Typing(this, S, T.getWildcardLowerBound(), Kind.SUBTYPE);
+        } else if (S.getTypeKind() == TypeKind.TYPEVAR
+                && TypesUtils.isCapturedTypeVariable(S.getJavaType())) {
+            // JLS 18.2.3 lists only the three cases above and otherwise reduces to false, which is
+            // wrong for a capture variable: the capture of "? extends X" really is a subtype of X.
+            // A type is a subtype of its own upper bound, so it suffices that the bound be one.
+            // This is a sound step, not an equivalence: it can turn a true constraint into a false
+            // one, never the reverse.
+            return new Typing(this, S.getTypeVarUpperBound(), T, Kind.SUBTYPE);
         } else {
             return ConstraintSet.FALSE;
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -299,10 +299,11 @@ public class Typing extends TypeConstraint {
         } else if (S.getTypeKind() == TypeKind.TYPEVAR
                 && TypesUtils.isCapturedTypeVariable(S.getJavaType())) {
             // JLS 18.2.3 lists only the three cases above and otherwise reduces to false, which is
-            // wrong for a capture variable: the capture of "? extends X" really is a subtype of X.
-            // A type is a subtype of its own upper bound, so it suffices that the bound be one.
-            // This is a sound step, not an equivalence: it can turn a true constraint into a false
-            // one, never the reverse.
+            // wrong for a capture variable: by the definition of capture conversion, a captured
+            // type variable is always a subtype of its own upper bound, whichever kind of wildcard
+            // -- "? extends X", "? super X", or unbounded -- it was captured from.  It therefore
+            // suffices for that upper bound to be a subtype of T.  This is a sound step, not an
+            // equivalence: it can turn a true constraint into a false one, never the reverse.
             return new Typing(this, S.getTypeVarUpperBound(), T, Kind.SUBTYPE);
         } else {
             return ConstraintSet.FALSE;

--- a/framework/tests/all-systems/CaptureSubtypeInference.java
+++ b/framework/tests/all-systems/CaptureSubtypeInference.java
@@ -1,0 +1,16 @@
+// Type argument inference used to throw FalseBoundException on a `? super` wildcard whose
+// argument mentions the inferred type variable through `? extends`, and the exception was
+// reported as "type.argument.inference.crashed".  javac accepts this code.
+
+public class CaptureSubtypeInference<T> {
+
+    static <K> Object callee(
+            CaptureSubtypeInference<? super CaptureSubtypeInference<? extends K>> p) {
+        throw new Error();
+    }
+
+    static <K> void caller(
+            CaptureSubtypeInference<? super CaptureSubtypeInference<? extends K>> p) {
+        callee(p);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2032: type argument inference threw `FalseBoundException` on a `? super` wildcard whose argument mentions the inferred type variable through `? extends`, and the exception was reported as `type.argument.inference.crashed` on code that `javac` accepts.

## The constraint

The reduction that failed is

```
capture of ? extends K  <:  K
```

JLS 18.2.3 gives three cases for a subtyping constraint whose right side is a type variable -- an intersection on the left, a lower-bounded type variable on the right, a lower-bounded wildcard on the right -- and otherwise reduces to false. That is wrong for a capture variable: the capture of `? extends K` really is a subtype of `K`, which is why `javac` accepts the code.

`Typing.reduceSubtypeTypeVariable` now reduces such a constraint to one on the capture's upper bound. By the definition of capture conversion, a captured type variable is always a subtype of its own upper bound -- whichever kind of wildcard (`? extends`, `? super`, or unbounded) it was captured from -- so it suffices for that bound to be a subtype of the target. This is a sound step rather than an equivalence: it can turn a true constraint into a false one, never the reverse.

## Effect

Before, on code `javac` compiles:

```
error: [type.argument.inference.crashed] Type argument inference crashed for Crash.callee
  error: An exception occurred:  False bound for: Constraint:
      inference type: capture#837 of ? extends K <: K extends Object Result: FALSE
```

The exception came from `ConstraintSet.reduceOneStep` while building B2, before resolution, so the retry-with-capture in `Resolution` never applied; `DefaultTypeArgumentInference` caught it as a generic `Exception` and reported a crash.

It is not nullness-specific -- `-processor interning` and `-processor regex` failed identically -- and Caffeine's `AsyncCacheLoader.bulk` is a real instance:

```java
static <K extends Object, V extends Object> AsyncCacheLoader<K, V> bulk(
    Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>> mappingFunction) {
  return CacheLoader.bulk(mappingFunction);
}
```

## Testing

New `framework/tests/all-systems/CaptureSubtypeInference.java`, so the construct is exercised under every checker rather than one.

`:framework:test`, `:checker:test`, `:framework:jtregTests` and `:checker:jtregTests` all pass. Verified separately that the original reproduction and the Caffeine shape both compile cleanly under `nullness`, `interning` and `regex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV
