### PR TITLE
Do not pull Spark's transitive tree onto the test classpath

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -115,7 +115,18 @@ dependencies {
     testImplementation 'org.jspecify:jspecify:1.0.1'
     // To test for an obscure crash in CFG construction for try-with-resources;
     // see https://github.com/typetools/checker-framework/issues/6396
-    testImplementation 'org.apache.spark:spark-sql_2.12:3.3.2'
+    // Declared non-transitively, with only the artifacts SparkSession's own signature needs
+    // on the classpath: spark-core for org.apache.spark.internal.Logging and scala-library
+    // for scala.Serializable.  Spark's full transitive tree is ~100 jars (ZooKeeper, Avro,
+    // Netty, Jackson, Protobuf, ...) that appear in no published artifact but do generate
+    // Dependabot alerts, and none of them is needed to compile this one test.
+    // For checker/tests/index/JavaxAnnotationNonnegative.java, which names
+    // javax.annotation.Nonnegative.  Previously this arrived only through Spark's transitive
+    // tree, so the test depended on a jar nothing declared.
+    testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
+    testImplementation('org.apache.spark:spark-sql_2.12:3.3.2') { transitive = false }
+    testImplementation('org.apache.spark:spark-core_2.12:3.3.2') { transitive = false }
+    testImplementation 'org.scala-lang:scala-library:2.12.15'
 
     // Required for checker/tests/index-initializedfields/RequireJavadoc.java
     if (isJava8) {

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -113,6 +113,10 @@ dependencies {
     testImplementation 'org.apiguardian:apiguardian-api:1.1.2'
     // For tests that use JSpecify annotations
     testImplementation 'org.jspecify:jspecify:1.0.1'
+    // For checker/tests/index/JavaxAnnotationNonnegative.java, which names
+    // javax.annotation.Nonnegative.  Previously this arrived only through Spark's transitive
+    // tree, so the test depended on a jar nothing declared.
+    testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
     // To test for an obscure crash in CFG construction for try-with-resources;
     // see https://github.com/typetools/checker-framework/issues/6396
     // Declared non-transitively, with only the artifacts SparkSession's own signature needs
@@ -120,12 +124,9 @@ dependencies {
     // for scala.Serializable.  Spark's full transitive tree is ~100 jars (ZooKeeper, Avro,
     // Netty, Jackson, Protobuf, ...) that appear in no published artifact but do generate
     // Dependabot alerts, and none of them is needed to compile this one test.
-    // For checker/tests/index/JavaxAnnotationNonnegative.java, which names
-    // javax.annotation.Nonnegative.  Previously this arrived only through Spark's transitive
-    // tree, so the test depended on a jar nothing declared.
-    testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
-    testImplementation('org.apache.spark:spark-sql_2.12:3.3.2') { transitive = false }
-    testImplementation('org.apache.spark:spark-core_2.12:3.3.2') { transitive = false }
+    def sparkVersion = '3.3.2'
+    testImplementation("org.apache.spark:spark-sql_2.12:${sparkVersion}") { transitive = false }
+    testImplementation("org.apache.spark:spark-core_2.12:${sparkVersion}") { transitive = false }
     testImplementation 'org.scala-lang:scala-library:2.12.15'
 
     // Required for checker/tests/index-initializedfields/RequireJavadoc.java


### PR DESCRIPTION
## Summary

41 of the 54 open Dependabot alerts come from one line in `checker/build.gradle`:

```gradle
testImplementation 'org.apache.spark:spark-sql_2.12:3.3.2'
```

It exists for a single test, `checker/tests/resourceleak/SparkSessionCFGCrash.java`, which pins a CFG-construction crash (typetools#6396) and needs nothing from Spark but the `SparkSession` type. Declaring it normally brings roughly 100 further jars along.

## Why the alerts look worse than they are

None of those jars is in any published artifact -- `runtimeClasspath` for `checker`, `framework`, `checker-qual`, `checker-util`, `javacutil`, `dataflow`, `framework-test` and `framework-errorprone` contains none of the alerted packages. But Gradle's dependency submission reports no scope (every alert has `scope: null`), so Dependabot raises test-only advisories against the repository as though it shipped them.

The two packages that *are* on a published classpath are not vulnerable at the versions we ship: protobuf-java 4.33.2 against advisories fixed in 3.16.1/3.16.3/3.25.5, and guava 32.x/33.x against advisories fixed in 24.1.1/32.0.0. The vulnerable copies -- protobuf 3.x and guava 16.0.1 -- exist only under Spark on the test classpath.

## The change

```gradle
testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
testImplementation('org.apache.spark:spark-sql_2.12:3.3.2') { transitive = false }
testImplementation('org.apache.spark:spark-core_2.12:3.3.2') { transitive = false }
testImplementation 'org.scala-lang:scala-library:2.12.15'
```

`spark-core` and `scala-library` are named because `SparkSession`'s own signature references `org.apache.spark.internal.Logging` and `scala.Serializable`; declaring spark-sql fully non-transitively fails to compile with `cannot access scala.Serializable`.

`jsr305` is a separate finding this surfaced. `checker/tests/index/JavaxAnnotationNonnegative.java` names `javax.annotation.Nonnegative`, and that jar was reaching the test classpath **only** through Spark's transitive tree -- so the test depended on something nothing declared. Removing Spark's tree broke `IndexTest` until it was declared explicitly.

## Effect

The test classpath drops from 425 entries to 114. 41 alerts are cleared -- 2 critical, 18 high, 20 medium, 1 low -- including both criticals (ZooKeeper CVE-2023-44981, Avro CVE-2024-47561), and all of Netty, Protobuf, log4j, Snappy, lz4, Avro, ZooKeeper, Ivy, gson, aircompressor and commons-compress. The three guava alerts go too, since `guava:16.0.1` leaves the classpath.

The 13 that remain are also test- or build-only: jackson via the AWS SDK test dependency, spark-core itself, commons-lang3 via `org.plumelib:options`, and jgit from the Spotless plugin at 7.7.1 (outside that advisory's `< 6.10.1` range).

## Testing

`:checker:test` passes in full, `ResourceLeakTest` and `IndexTest` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV