### PR TITLE
Remove recognition of JSpecify's deprecated org.jspecify.nullness package

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessNoInitAnnotatedTypeFactory.java
@@ -241,9 +241,6 @@ public class NullnessNoInitAnnotatedTypeFactory
                     "org.jmlspecs.annotation.NonNull",
                     // https://github.com/jspecify/jspecify/blob/main/src/main/java/org/jspecify/annotations/NonNull.java
                     "org.jspecify.annotations.NonNull",
-                    // 2022-11-17: Deprecated old package location, remove after some grace period
-                    // https://github.com/jspecify/jspecify/tree/main/src/main/java/org/jspecify/nullness
-                    "org.jspecify.nullness.NonNull",
                     // http://bits.netbeans.org/dev/javadoc/org-netbeans-api-annotations-common/org/netbeans/api/annotations/common/NonNull.html
                     "org.netbeans.api.annotations.common.NonNull",
                     // https://github.com/spring-projects/spring-framework/blob/master/spring-core/src/main/java/org/springframework/lang/NonNull.java
@@ -374,10 +371,6 @@ public class NullnessNoInitAnnotatedTypeFactory
                     "org.jmlspecs.annotation.Nullable",
                     // https://github.com/jspecify/jspecify/blob/main/src/main/java/org/jspecify/annotations/Nullable.java
                     "org.jspecify.annotations.Nullable",
-                    // 2022-11-17: Deprecated old package location, remove after some grace period
-                    // https://github.com/jspecify/jspecify/tree/main/src/main/java/org/jspecify/nullness
-                    "org.jspecify.nullness.Nullable",
-                    "org.jspecify.nullness.NullnessUnspecified",
                     // http://bits.netbeans.org/dev/javadoc/org-netbeans-api-annotations-common/org/netbeans/api/annotations/common/CheckForNull.html
                     "org.netbeans.api.annotations.common.CheckForNull",
                     // http://bits.netbeans.org/dev/javadoc/org-netbeans-api-annotations-common/org/netbeans/api/annotations/common/NullAllowed.html
@@ -455,12 +448,6 @@ public class NullnessNoInitAnnotatedTypeFactory
             AnnotationMirror nullMarkedDefaultQual = nullMarkedDefaultQualBuilder.build();
             addAliasedDeclAnnotation(
                     "org.jspecify.annotations.NullMarked",
-                    DefaultQualifier.class.getCanonicalName(),
-                    nullMarkedDefaultQual);
-
-            // 2022-11-17: Deprecated old package location, remove after some grace period
-            addAliasedDeclAnnotation(
-                    "org.jspecify.nullness.NullMarked",
                     DefaultQualifier.class.getCanonicalName(),
                     nullMarkedDefaultQual);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@ Version 3.49.5-eisop2 (June ?, 2026)
 
 **User-visible changes:**
 
+The Nullness Checker no longer recognizes `org.jspecify.nullness.NonNull`,
+`org.jspecify.nullness.Nullable`, `org.jspecify.nullness.NullnessUnspecified`, or
+`org.jspecify.nullness.NullMarked` -- JSpecify's original, pre-1.0 package, deprecated
+since 2022. Use the `org.jspecify.annotations` package, which JSpecify moved to years
+ago and which the checker has recognized the whole time.
+
 When the Initialization Checker rejects a method call on a partially-initialized receiver, it
 now reports `initialization.method.invocation.invalid`, which names the fields that are still
 uninitialized at the call, instead of the framework's `method.invocation.invalid`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,13 @@ Version 3.49.5-eisop2 (June ?, 2026)
 **User-visible changes:**
 
 The Nullness Checker no longer recognizes `org.jspecify.nullness.NonNull`,
-`org.jspecify.nullness.Nullable`, `org.jspecify.nullness.NullnessUnspecified`, or
-`org.jspecify.nullness.NullMarked` -- JSpecify's original, pre-1.0 package, deprecated
-since 2022. Use the `org.jspecify.annotations` package, which JSpecify moved to years
-ago and which the checker has recognized the whole time.
+`org.jspecify.nullness.Nullable`, or `org.jspecify.nullness.NullMarked` -- JSpecify's
+original, pre-1.0 package, deprecated since 2022. Use the corresponding
+`org.jspecify.annotations` annotation, which JSpecify moved to years ago and which the
+checker has recognized the whole time. The Checker also no longer recognizes
+`org.jspecify.nullness.NullnessUnspecified`, which has no such replacement: JSpecify's
+1.0 release dropped it outright, and `org.jspecify.annotations` has only `NonNull`,
+`Nullable`, `NullMarked`, and `NullUnmarked`.
 
 When the Initialization Checker rejects a method call on a partially-initialized receiver, it
 now reports `initialization.method.invocation.invalid`, which names the fields that are still

--- a/docs/manual/nullness-checker.tex
+++ b/docs/manual/nullness-checker.tex
@@ -210,10 +210,9 @@ command-line option.)
 \item
   If you supply the \code{-Amode=jspecify} command-line option, then the Nullness
   Checker behaves as JSpecify specifies:  it checks only code in the scope of a
-  corresponding \code{@AnnotatedFor}, treats \code{@NullMarked} as a defaulting
-  annotation (both \code{org.jspecify.annotations.NullMarked} and the legacy
-  \code{org.jspecify.nullness.NullMarked}), and performs neither initialization
-  checking nor map-key checking, neither of which JSpecify specifies.
+  corresponding \code{@AnnotatedFor}, treats \code{org.jspecify.annotations.NullMarked}
+  as a defaulting annotation, and performs neither initialization checking nor
+  map-key checking, neither of which JSpecify specifies.
   This is a shorthand for \code{-AonlyAnnotatedFor -AassumeInitialized
   -AassumeKeyFor}.  Each of those is an on/off flag with no negative form, so there is
   currently no way to enable this mode but turn one of them back off.
@@ -221,7 +220,7 @@ command-line option.)
 \item
   \label{nullness-jspecifyNullMarkedAlias}%
   If you supply the \code{-AjspecifyNullMarkedAlias=false} command-line option, then the
-  checker will not treat \code{org.jspecify.nullness.NullMarked} as a defaulting
+  checker will not treat \code{org.jspecify.annotations.NullMarked} as a defaulting
   annotation. By default the \code{NullMarked} annotation is recognized.
 \end{itemize}
 
@@ -1140,7 +1139,6 @@ Section~\ref{declaration-annotations-moved}.
  ~org.jetbrains.annotations.NotNull~ \\ \hline
  ~org.jmlspecs.annotation.NonNull~ \\ \hline
  ~org.jspecify.annotations.NonNull~ \\ \hline
- ~org.jspecify.nullness.NonNull~ \\ \hline
  ~org.netbeans.api.annotations.common.NonNull~ \\ \hline
  ~org.springframework.lang.NonNull~ \\ \hline
  ~reactor.util.annotation.NonNull~ \\ \hline
@@ -1214,8 +1212,6 @@ $\Rightarrow$
  ~org.jetbrains.annotations.UnknownNullability~ \\ \hline
  ~org.jmlspecs.annotation.Nullable~ \\ \hline
  ~org.jspecify.annotations.Nullable~ \\ \hline
- ~org.jspecify.nullness.Nullable~ \\ \hline
- ~org.jspecify.nullness.NullnessUnspecified~ \\ \hline
  ~org.netbeans.api.annotations.common.CheckForNull~ \\ \hline
  ~org.netbeans.api.annotations.common.NullAllowed~ \\ \hline
  ~org.netbeans.api.annotations.common.NullUnknown~ \\ \hline


### PR DESCRIPTION
Requested during review of #1304, which was about to add a fourth instance of this same pattern for a brand-new alias (see that PR: the `@AnnotatedFor` alias no longer adds an `org.jspecify.nullness.NullMarked` variant of itself, since this PR removes the pattern instead of extending it).

## What this removes

Three places in `NullnessNoInitAnnotatedTypeFactory`, each marked `2022-11-17: Deprecated old package location, remove after some grace period`:

- `org.jspecify.nullness.NonNull` (type-use alias for `@NonNull`)
- `org.jspecify.nullness.Nullable` and `org.jspecify.nullness.NullnessUnspecified` (type-use aliases for `@Nullable`; both were listed under the one comment, and `NullnessUnspecified` has no `org.jspecify.annotations` counterpart at all)
- `org.jspecify.nullness.NullMarked` (declaration alias for `@DefaultQualifier`)

JSpecify moved to `org.jspecify.annotations` years ago (that package is unaffected and remains fully recognized). No file under `checker/tests`, `checker/jtreg`, `framework/tests`, or `framework/jtreg` names the old package, so nothing exercised this beyond the grace-period comment itself.

## Testing

`NullnessNullMarkedTest` and `NullnessTest` pass. Manual builds cleanly with the updated wording (two paragraphs plus two alias-table rows). Verified by grep that no reference to `org.jspecify.nullness` remains anywhere under `checker/` or `framework/` (the one historical mention, in the 3.21.3-eisop1 changelog section from 2022, is left untouched as released history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV