### PR TITLE
Make `@AnnotatedFor` repeatable

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
+++ b/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
@@ -73,7 +73,7 @@ public @interface AnnotatedFor {
     @Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
     public static @interface List {
         /**
-         * Return the repeatable annotations.
+         * Returns the repeatable annotations.
          *
          * @return the repeatable annotations
          */

--- a/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
+++ b/checker-qual/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
@@ -2,6 +2,7 @@ package org.checkerframework.framework.qual;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -27,11 +28,21 @@ import java.lang.annotation.Target;
  * applyToSubpackages} field is set to false. Setting it to false does not block an applicable
  * {@code @AnnotatedFor} on an enclosing package.
  *
+ * <p>You may write multiple {@code @AnnotatedFor} annotations at the same location, for example to
+ * give two type systems different {@code applyToSubpackages} settings on one package:
+ *
+ * <pre>
+ * &nbsp; {@literal @}AnnotatedFor(value = "nullness", applyToSubpackages = false)
+ * &nbsp; {@literal @}AnnotatedFor(value = "index", applyToSubpackages = true)
+ * &nbsp; package mypackage;
+ * </pre>
+ *
  * @checker_framework.manual #compiling-libraries Compiling partially-annotated libraries
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
+@Repeatable(AnnotatedFor.List.class)
 public @interface AnnotatedFor {
     /**
      * Returns the type systems for which the class has been annotated. Legal arguments are any
@@ -50,4 +61,22 @@ public @interface AnnotatedFor {
      * @return whether this annotation should be inherited by subpackages
      */
     boolean applyToSubpackages() default true;
+
+    /**
+     * A wrapper annotation that makes the {@link AnnotatedFor} annotation repeatable.
+     *
+     * <p>Programmers generally do not need to write this. It is created by Java when a programmer
+     * writes more than one {@link AnnotatedFor} annotation at the same location.
+     */
+    @Documented
+    @Retention(RetentionPolicy.SOURCE)
+    @Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
+    public static @interface List {
+        /**
+         * Return the repeatable annotations.
+         *
+         * @return the repeatable annotations
+         */
+        AnnotatedFor[] value();
+    }
 }

--- a/checker/jtreg/stubs/annotatedFor/Test.astub
+++ b/checker/jtreg/stubs/annotatedFor/Test.astub
@@ -10,4 +10,10 @@ public class Test<T> {
     public void method2(T t){}
     @AnnotatedFor("nullness")
     public Object method3() {}
+    // Repeated @AnnotatedFor: the first entry names an unrelated checker, so recognizing that
+    // this stub entry also applies to nullness requires checking every entry, not just the
+    // first.
+    @AnnotatedFor("tainting")
+    @AnnotatedFor("nullness")
+    public void method4(T t){}
 }

--- a/checker/jtreg/stubs/annotatedFor/UseTest.java
+++ b/checker/jtreg/stubs/annotatedFor/UseTest.java
@@ -19,5 +19,6 @@ public class UseTest {
         test.method1(null);
         test.method2(null);
         @NonNull Object o = test.method3();
+        test.method4(null);
     }
 }

--- a/checker/jtreg/stubs/annotatedFor/WithStub.out
+++ b/checker/jtreg/stubs/annotatedFor/WithStub.out
@@ -1,3 +1,4 @@
 UseTest.java:19:22: compiler.err.proc.messager: (argument.type.incompatible)
 UseTest.java:20:22: compiler.err.proc.messager: (argument.type.incompatible)
-2 errors
+UseTest.java:22:22: compiler.err.proc.messager: (argument.type.incompatible)
+3 errors

--- a/checker/jtreg/stubs/annotatedFor/WithoutStub.out
+++ b/checker/jtreg/stubs/annotatedFor/WithoutStub.out
@@ -1,2 +1,3 @@
 UseTest.java:19:22: compiler.err.proc.messager: (argument.type.incompatible)
-1 error
+UseTest.java:22:22: compiler.err.proc.messager: (argument.type.incompatible)
+2 errors

--- a/checker/jtreg/stubs/annotatedFor/WithoutStubConservative.out
+++ b/checker/jtreg/stubs/annotatedFor/WithoutStubConservative.out
@@ -1,3 +1,4 @@
 UseTest.java:19:22: compiler.err.proc.messager: (argument.type.incompatible)
 UseTest.java:21:41: compiler.err.proc.messager: (assignment.type.incompatible)
-2 errors
+UseTest.java:22:22: compiler.err.proc.messager: (argument.type.incompatible)
+3 errors

--- a/checker/jtreg/stubs/annotatedForLib/Test.java
+++ b/checker/jtreg/stubs/annotatedForLib/Test.java
@@ -10,4 +10,6 @@ public class Test<T> {
     public Object method3() {
         return "";
     }
+
+    public void method4(T t) {}
 }

--- a/checker/jtreg/subpackages/AnnotatedForRepeatable.java
+++ b/checker/jtreg/subpackages/AnnotatedForRepeatable.java
@@ -1,17 +1,12 @@
 /*
  * @test
  *
- * @summary A checker-qual predating this feature has no AnnotatedFor.List type at all (not just a
- * missing element on an existing type), so the classpath-compatibility check for it must look
- * before calling TreeUtils.getMethod, which throws on a wholly missing type rather than returning
- * null the way TreeUtils.getMethodOrNull does for a missing element on an existing type.
- *
- * Writing two AnnotatedFor annotations at one location -- rather than listing both checkers in
- * one, which value()'s array already supports -- is what needs AnnotatedFor to be Repeatable: it
- * lets two checkers have different applyToSubpackages settings on the same package. javac exposes
- * this as a single AnnotatedFor.List container instead of two bare AnnotatedFor mirrors, so
- * resolving it needs its own List-unpacking step, mirroring how QualifierDefaults already handles
- * DefaultQualifier and DefaultQualifier.List.
+ * @summary Writing two AnnotatedFor annotations at one location -- rather than listing both
+ * checkers in one, which value()'s array already supports -- is what needs AnnotatedFor to be
+ * Repeatable: it lets two checkers have different applyToSubpackages settings on the same
+ * package. javac exposes this as a single AnnotatedFor.List container instead of two bare
+ * AnnotatedFor mirrors, so resolving it needs its own List-unpacking step, mirroring how
+ * QualifierDefaults already handles DefaultQualifier and DefaultQualifier.List.
  *
  * Each compile line below runs one checker at a time against the same two-entry package-info:
  * running two top-level checkers together in one javac invocation is not used here, because doing

--- a/checker/jtreg/subpackages/AnnotatedForRepeatable.java
+++ b/checker/jtreg/subpackages/AnnotatedForRepeatable.java
@@ -1,0 +1,25 @@
+/*
+ * @test
+ *
+ * @summary A checker-qual predating this feature has no AnnotatedFor.List type at all (not just a
+ * missing element on an existing type), so the classpath-compatibility check for it must look
+ * before calling TreeUtils.getMethod, which throws on a wholly missing type rather than returning
+ * null the way TreeUtils.getMethodOrNull does for a missing element on an existing type.
+ *
+ * Writing two AnnotatedFor annotations at one location -- rather than listing both checkers in
+ * one, which value()'s array already supports -- is what needs AnnotatedFor to be Repeatable: it
+ * lets two checkers have different applyToSubpackages settings on the same package. javac exposes
+ * this as a single AnnotatedFor.List container instead of two bare AnnotatedFor mirrors, so
+ * resolving it needs its own List-unpacking step, mirroring how QualifierDefaults already handles
+ * DefaultQualifier and DefaultQualifier.List.
+ *
+ * Each compile line below runs one checker at a time against the same two-entry package-info:
+ * running two top-level checkers together in one javac invocation is not used here, because doing
+ * so has an unrelated, pre-existing behavior where a class already flagged by one checker's error
+ * is not additionally checked by another -- confirmed with two ordinary, unrelated errors and no
+ * AnnotatedFor involved at all. That is orthogonal to what this test checks.
+ *
+ * @compile/fail/ref=AnnotatedForRepeatableNullness.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -AuseConservativeDefaultsForUncheckedCode=source,bytecode repeatable/package-info.java repeatable/InRepeatable.java repeatable/sub/InRepeatableSub.java
+ * @compile/fail/ref=AnnotatedForRepeatableIndex.out -XDrawDiagnostics -processor org.checkerframework.checker.index.IndexChecker -AuseConservativeDefaultsForUncheckedCode=source,bytecode repeatable/package-info.java repeatable/InRepeatable.java repeatable/sub/InRepeatableSub.java
+ */
+public class AnnotatedForRepeatable {}

--- a/checker/jtreg/subpackages/AnnotatedForRepeatableIndex.out
+++ b/checker/jtreg/subpackages/AnnotatedForRepeatableIndex.out
@@ -1,0 +1,7 @@
+InRepeatable.java:22:25: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter i of InRepeatable.takeNonNegative.
+found   : int
+required: @NonNegative int
+InRepeatableSub.java:23:25: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter i of InRepeatableSub.takeNonNegative.
+found   : int
+required: @NonNegative int
+2 errors

--- a/checker/jtreg/subpackages/AnnotatedForRepeatableNullness.out
+++ b/checker/jtreg/subpackages/AnnotatedForRepeatableNullness.out
@@ -1,0 +1,4 @@
+InRepeatable.java:16:21: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter nn of InRepeatable.takeNonNull.
+found   : @Nullable Object
+required: @NonNull Object
+1 error

--- a/checker/jtreg/subpackages/repeatable/InRepeatable.java
+++ b/checker/jtreg/subpackages/repeatable/InRepeatable.java
@@ -1,0 +1,24 @@
+package repeatable;
+
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * The package is written for two checkers at once, each with its own applyToSubpackages: writing
+ * two @AnnotatedFor at the same location (rather than listing both checkers in one) is what
+ * requires @AnnotatedFor to be @Repeatable. Own package: both checkers are always in scope here,
+ * whatever their applyToSubpackages says.
+ */
+public class InRepeatable {
+    void takeNonNull(Object nn) {}
+
+    void nullness(@Nullable Object n) {
+        takeNonNull(n);
+    }
+
+    void takeNonNegative(@NonNegative int i) {}
+
+    void index(int i) {
+        takeNonNegative(i);
+    }
+}

--- a/checker/jtreg/subpackages/repeatable/package-info.java
+++ b/checker/jtreg/subpackages/repeatable/package-info.java
@@ -1,0 +1,5 @@
+@AnnotatedFor(value = "nullness", applyToSubpackages = false)
+@AnnotatedFor(value = "index", applyToSubpackages = true)
+package repeatable;
+
+import org.checkerframework.framework.qual.AnnotatedFor;

--- a/checker/jtreg/subpackages/repeatable/sub/InRepeatableSub.java
+++ b/checker/jtreg/subpackages/repeatable/sub/InRepeatableSub.java
@@ -1,0 +1,25 @@
+package repeatable.sub;
+
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Package repeatable's two @AnnotatedFor entries apply independently: nullness set
+ * applyToSubpackages=false, so this subpackage is out of its scope; index set
+ * applyToSubpackages=true, so this subpackage is still in its scope. Each @compile line below
+ * checks this with one checker at a time, since running both checkers in the same javac invocation
+ * is not how this is exercised here -- see the class comment on the driving test.
+ */
+public class InRepeatableSub {
+    void takeNonNull(Object nn) {}
+
+    void nullness(@Nullable Object n) {
+        takeNonNull(n);
+    }
+
+    void takeNonNegative(@NonNegative int i) {}
+
+    void index(int i) {
+        takeNonNegative(i);
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,17 @@ When the Initialization Checker rejects a method call on a partially-initialized
 now reports `initialization.method.invocation.invalid`, which names the fields that are still
 uninitialized at the call, instead of the framework's `method.invocation.invalid`.
 
+`@AnnotatedFor` is now `@Repeatable`, so it may be written more than once at the same
+location. This lets different type systems be given different `applyToSubpackages`
+settings on one package, which its single `value()` array could not express on its own:
+```java
+@AnnotatedFor(value = "nullness", applyToSubpackages = false)
+@AnnotatedFor(value = "index", applyToSubpackages = true)
+package mypackage;
+```
+Listing multiple checker names in one `@AnnotatedFor`, as before, remains the right choice
+when they should share one `applyToSubpackages` setting.
+
 Two new Maven Central artifacts support writing a custom checker without
 depending on the whole `checker` artifact: `io.github.eisop:framework`, which
 declares its dependencies in its POM, and `io.github.eisop:framework-all`,

--- a/docs/manual/annotating-libraries.tex
+++ b/docs/manual/annotating-libraries.tex
@@ -447,6 +447,18 @@ Because \<@AnnotatedFor> has source retention, a package annotation only
 affects compilation units that are compiled together with its
 \<package-info.java> file.
 
+\<@AnnotatedFor> is repeatable, so it may be written more than once at the
+same location.  This lets different type systems be given different
+\<applyToSubpackages> settings on the same package, as in:
+\begin{alltt}
+  @AnnotatedFor(value = "nullness", applyToSubpackages = false)
+  @AnnotatedFor(value = "regex", applyToSubpackages = true)
+  package mypackage;
+\end{alltt}
+(Listing multiple checker names in one \<@AnnotatedFor>, as at the start of
+this section, remains the right choice when they should share one
+\<applyToSubpackages> setting.)
+
 \begin{sloppypar}
 Whenever you compile a class using the Checker Framework, including when
 using the \<-AuseConservativeDefaultsForUncheckedCode=source,bytecode> command-line

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
@@ -4,7 +4,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.ClassGetName;
 import org.checkerframework.dataflow.cfg.visualize.CFGVisualizer;
-import org.checkerframework.framework.qual.AnnotatedFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -349,10 +348,13 @@ public abstract class BaseTypeChecker extends SourceChecker {
         }
 
         AnnotatedTypeFactory atypeFactory = getTypeFactory();
-        AnnotationMirror annotatedFor = atypeFactory.getDeclAnnotation(elt, AnnotatedFor.class);
-        boolean elementAnnotatedForThisChecker =
-                annotatedFor != null
-                        && atypeFactory.doesAnnotatedForApplyToThisChecker(annotatedFor);
+        boolean elementAnnotatedForThisChecker = false;
+        for (AnnotationMirror annotatedFor : atypeFactory.getAnnotatedForAnnotations(elt)) {
+            if (atypeFactory.doesAnnotatedForApplyToThisChecker(annotatedFor)) {
+                elementAnnotatedForThisChecker = true;
+                break;
+            }
+        }
 
         if (!elementAnnotatedForThisChecker) {
             if (elt.getKind() == ElementKind.PACKAGE) {
@@ -395,13 +397,19 @@ public abstract class BaseTypeChecker extends SourceChecker {
         }
 
         AnnotatedTypeFactory atypeFactory = getTypeFactory();
-        AnnotationMirror annotatedFor = atypeFactory.getDeclAnnotation(pkg, AnnotatedFor.class);
-        boolean result =
-                (annotatedFor != null
-                                && atypeFactory.doesAnnotatedForApplyToThisChecker(annotatedFor)
-                                && atypeFactory.doesAnnotatedForApplyToSubpackages(annotatedFor))
-                        || doesAnnotatedForReachSubpackages(
-                                ElementUtils.parentPackage(pkg, atypeFactory.getElementUtils()));
+        boolean result = false;
+        for (AnnotationMirror annotatedFor : atypeFactory.getAnnotatedForAnnotations(pkg)) {
+            if (atypeFactory.doesAnnotatedForApplyToThisChecker(annotatedFor)
+                    && atypeFactory.doesAnnotatedForApplyToSubpackages(annotatedFor)) {
+                result = true;
+                break;
+            }
+        }
+        if (!result) {
+            result =
+                    doesAnnotatedForReachSubpackages(
+                            ElementUtils.parentPackage(pkg, atypeFactory.getElementUtils()));
+        }
 
         annotatedForReachesSubpackagesCache.put(pkg, result);
         return result;

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -2858,6 +2858,11 @@ public class AnnotationFileParser {
      * Returns true if one of the annotations is {@link AnnotatedFor} and this checker is in its
      * list of checkers. If none of the annotations are {@code AnnotatedFor}, then also return true.
      *
+     * <p>{@code @AnnotatedFor} is {@code @Repeatable}, so {@code annotations} may contain more than
+     * one; unlike javac's own compiled view, JavaParser never collapses repeated annotations into a
+     * single {@code AnnotatedFor.List}, so each instance appears here as its own entry. This
+     * checker is admitted if any instance applies to it.
+     *
      * @param annotations a list of JavaParser annotations
      * @return true if one of the annotations is {@link AnnotatedFor} and its list of checkers does
      *     not contain this checker
@@ -2868,17 +2873,21 @@ public class AnnotationFileParser {
             // TODO: Parse the JDK stubs, but only save the declaration annotations.
             return true;
         }
+        boolean foundAnnotatedFor = false;
         for (AnnotationExpr ae : annotations) {
             if (ae.getNameAsString().equals("AnnotatedFor")
                     || ae.getNameAsString()
                             .equals("org.checkerframework.framework.qual.AnnotatedFor")) {
                 AnnotationMirror af = getAnnotation(ae, allAnnotations);
                 if (atypeFactory.areSameByClass(af, AnnotatedFor.class)) {
-                    return atypeFactory.doesAnnotatedForApplyToThisChecker(af);
+                    foundAnnotatedFor = true;
+                    if (atypeFactory.doesAnnotatedForApplyToThisChecker(af)) {
+                        return true;
+                    }
                 }
             }
         }
-        return true;
+        return !foundAnnotatedFor;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/stub/BinaryStubReader.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/BinaryStubReader.java
@@ -195,13 +195,22 @@ public class BinaryStubReader {
      */
     private static boolean isAnnotatedForThisChecker(
             AnnotationMirrorSet declAnnos, AnnotatedTypeFactory atypeFactory) {
+        // @AnnotatedFor is @Repeatable, so declAnnos can hold more than one -- this parser reads
+        // them from JavaParser source syntax rather than compiled bytecode, so they are never
+        // collapsed into a single AnnotatedFor.List the way javac's own Element view would
+        // collapse them. Applying (rather than the first entry alone) is what matches
+        // AnnotationFileParser.isAnnotatedForThisChecker.
+        boolean foundAnnotatedFor = false;
         for (AnnotationMirror am : declAnnos) {
             if (AnnotationUtils.annotationName(am)
                     == "org.checkerframework.framework.qual.AnnotatedFor") {
-                return atypeFactory.doesAnnotatedForApplyToThisChecker(am);
+                foundAnnotatedFor = true;
+                if (atypeFactory.doesAnnotatedForApplyToThisChecker(am)) {
+                    return true;
+                }
             }
         }
-        return true;
+        return !foundAnnotatedFor;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -825,13 +825,17 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         annotatedForApplyToSubpackagesElement =
                 TreeUtils.getMethodOrNull(
                         AnnotatedFor.class, "applyToSubpackages", 0, processingEnv);
-        // TreeUtils.getMethodOrNull requires the enclosing type to resolve, and throws if it does
-        // not; AnnotatedFor.List is itself the newly-added type here (unlike applyToSubpackages,
-        // an element on a type that already existed), so its absence must be checked first.
+        // AnnotatedFor.List is itself the newly-added type here (unlike applyToSubpackages, an
+        // element on a type that already existed), so it must not be referenced as a class
+        // literal before its absence is checked: evaluating "AnnotatedFor.List.class" resolves
+        // (links) that nested class immediately, throwing NoClassDefFoundError -- defeating the
+        // guard -- if an older checker-qual on the classpath lacks it. Using its canonical name
+        // as a literal string, instead of deriving it from the class, avoids linking it here.
+        @FullyQualifiedName String annotatedForListName = "org.checkerframework.framework.qual.AnnotatedFor.List";
         annotatedForListValueElement =
-                elements.getTypeElement(AnnotatedFor.List.class.getCanonicalName()) == null
+                elements.getTypeElement(annotatedForListName) == null
                         ? null
-                        : TreeUtils.getMethod(AnnotatedFor.List.class, "value", 0, processingEnv);
+                        : TreeUtils.getMethod(annotatedForListName, "value", 0, processingEnv);
         ensuresQualifierExpressionElement =
                 TreeUtils.getMethod(EnsuresQualifier.class, "expression", 0, processingEnv);
         ensuresQualifierListValueElement =

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -213,6 +213,14 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      */
     protected final @Nullable ExecutableElement annotatedForApplyToSubpackagesElement;
 
+    /**
+     * The AnnotatedFor.List.value() field/element, for a location with two or more written
+     * {@code @AnnotatedFor} (which javac collapses into one {@code @AnnotatedFor.List}). Null if
+     * the version of {@code @AnnotatedFor} on the classpath predates the nested {@code List} type,
+     * in which case {@code @AnnotatedFor} could not have been written more than once there.
+     */
+    protected final @Nullable ExecutableElement annotatedForListValueElement;
+
     /** The EnsuresQualifier.expression field/element. */
     protected final ExecutableElement ensuresQualifierExpressionElement;
 
@@ -817,6 +825,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         annotatedForApplyToSubpackagesElement =
                 TreeUtils.getMethodOrNull(
                         AnnotatedFor.class, "applyToSubpackages", 0, processingEnv);
+        // TreeUtils.getMethodOrNull requires the enclosing type to resolve, and throws if it does
+        // not; AnnotatedFor.List is itself the newly-added type here (unlike applyToSubpackages,
+        // an element on a type that already existed), so its absence must be checked first.
+        annotatedForListValueElement =
+                elements.getTypeElement(AnnotatedFor.List.class.getCanonicalName()) == null
+                        ? null
+                        : TreeUtils.getMethod(AnnotatedFor.List.class, "value", 0, processingEnv);
         ensuresQualifierExpressionElement =
                 TreeUtils.getMethod(EnsuresQualifier.class, "expression", 0, processingEnv);
         ensuresQualifierListValueElement =
@@ -6908,6 +6923,38 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
       }
     }
     */
+
+    /**
+     * Returns every {@link AnnotatedFor} annotation written on {@code elt}: the one written on it,
+     * if a single instance was written, or each instance in {@code @AnnotatedFor.List}'s value() if
+     * two or more were written at the same location. {@code @AnnotatedFor} is {@code @Repeatable},
+     * so javac exposes only the {@code .List} container, not the individual mirrors, once there are
+     * two or more.
+     *
+     * @param elt an element
+     * @return an unmodifiable set of the {@link AnnotatedFor} annotations written on {@code elt};
+     *     may be empty
+     */
+    public AnnotationMirrorSet getAnnotatedForAnnotations(Element elt) {
+        AnnotationMirrorSet result = null;
+        AnnotationMirror single = getDeclAnnotation(elt, AnnotatedFor.class);
+        if (single != null) {
+            result = new AnnotationMirrorSet(single);
+        }
+        if (annotatedForListValueElement != null) {
+            AnnotationMirror listAnno = getDeclAnnotation(elt, AnnotatedFor.List.class);
+            if (listAnno != null) {
+                List<AnnotationMirror> repeated =
+                        AnnotationUtils.getElementValueArray(
+                                listAnno, annotatedForListValueElement, AnnotationMirror.class);
+                if (result == null) {
+                    result = new AnnotationMirrorSet();
+                }
+                result.addAll(repeated);
+            }
+        }
+        return result == null ? AnnotationMirrorSet.emptySet() : result.makeUnmodifiable();
+    }
 
     /**
      * Does {@code annotatedForAnno}, which is an {@link


### PR DESCRIPTION
## Summary

`@AnnotatedFor` previously took a single set of checker names and a single
`applyToSubpackages` value, so it could only give one `applyToSubpackages`
setting to a package for all checkers listed in it. Making it `@Repeatable`
lets different type systems be given different `applyToSubpackages` settings
on the same package:

```java
@AnnotatedFor(value = "nullness", applyToSubpackages = false)
@AnnotatedFor(value = "index", applyToSubpackages = true)
package mypackage;
```

Listing multiple checker names in one `@AnnotatedFor`, as before, remains the
right choice when they should share one `applyToSubpackages` setting.

Since `@AnnotatedFor` is now `@Repeatable`, javac exposes only the generated
`AnnotatedFor.List` container -- never the individual mirrors -- once two or
more instances are written at one location.
`AnnotatedTypeFactory.getAnnotatedForAnnotations` unpacks that container,
mirroring how `QualifierDefaults` already handles
`DefaultQualifier`/`DefaultQualifier.List`. `BaseTypeChecker`'s two call
sites are updated to iterate over the (possibly multiple) annotations
instead of assuming there is at most one.

This pairs with the checker-qual copy under `java.base` in the companion
JDK repo: eisop/jdk#142. Both branches are named `annotatedfor-repeatable`
so CI's related-repo checkout matches them automatically.

## Test plan

- [x] `./gradlew :framework:compileJava :checker:compileJava`
- [x] `./gradlew spotlessApply` (no unexpected changes)
- [x] `./gradlew test` (full framework/javacutil/dataflow/checker JUnit suite, all green)
- [x] `./gradlew :checker:jtregTests`, including the new
      `checker/jtreg/subpackages/AnnotatedForRepeatable.java` test, which
      writes two `@AnnotatedFor` at one package location with different
      `applyToSubpackages` settings and checks each checker separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV