### PR TITLE
Suppress the JRE-version NOTE in EisopCheckerFrameworkPluginTest

### DIFF
--- a/framework-errorprone/src/test/java/org/checkerframework/errorprone/EisopCheckerFrameworkPluginTest.java
+++ b/framework-errorprone/src/test/java/org/checkerframework/errorprone/EisopCheckerFrameworkPluginTest.java
@@ -38,12 +38,16 @@ public class EisopCheckerFrameworkPluginTest {
     /**
      * javac flags Error Prone requires. The --add-exports/--add-opens needed to run in-process are
      * supplied as JVM args by the module's build.gradle (they have no effect as compiler args).
+     * {@code -AnoJreVersionCheck} suppresses the Checker Framework's own NOTE about untested JRE
+     * versions, so that tests asserting an exact diagnostic count do not depend on which JDK runs
+     * the build (CI covers JDKs the Checker Framework does not consider "tested" yet, e.g. 24).
      */
     private static final List<String> BASE_ARGS =
             Arrays.asList(
                     "-XDcompilePolicy=simple",
                     "--should-stop=ifError=FLOW",
-                    "-XDaddTypeAnnotationsToSymbol=true");
+                    "-XDaddTypeAnnotationsToSymbol=true",
+                    "-AnoJreVersionCheck");
 
     /** A helper running the {@code eisopcf} plugin with the Nullness Checker selected. */
     private CompilationTestHelper helper;


### PR DESCRIPTION
## Summary

CI on `eisop/jdk` master is failing under JDK 24: https://github.com/eisop/jdk/actions/runs/34407235291/job/102653035756

```
EisopCheckerFrameworkPluginTest > cleanProgramHasNoDiagnostics FAILED
    Expected no diagnostics produced, but found 1: [Note: The Checker Framework is tested with JDK 8, 11, 17, 21, 25, 26, and 27-EA. You are using version 24.]
    expected: 0
    but was : 1
```

`cleanProgramHasNoDiagnostics` (and other tests in this suite) assert an exact diagnostic count. `SourceChecker.init` unconditionally emits a NOTE when the running JDK isn't in its `supportedJres` list, and JDK 24 isn't on it -- but CI does run this suite under JDK 24 (via `eisop/jdk`'s `cftests-junit on JDK 24` job). This isn't a plugin bug; it's the test asserting an exact count that only holds on a "tested" JDK.

## Fix

Add `-AnoJreVersionCheck` to `BASE_ARGS`, so every helper in the suite suppresses that NOTE, matching how a real invocation would be configured to keep an exact-count assertion stable across JDK versions.

## Testing

- Reproduced against JDK 24-ea locally: 2 of 17 tests failed without the fix, 0 with it.
- Full `:framework-errorprone:test` suite passes on the default JDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV