### PR TITLE
Suppress `cast.unsafe` in `Issue6282.java` for MethodHandle nullable returns

### DIFF
--- a/framework/tests/all-systems/Issue6282.java
+++ b/framework/tests/all-systems/Issue6282.java
@@ -11,6 +11,10 @@ public class Issue6282 {
 
     public static void setAccessible(final AccessibleObject accessibleObject) {
         try {
+            // MethodHandle.invokeExact's polymorphic-signature return is @Nullable on an
+            // annotated JDK; this code always throws before returning (see the class comment),
+            // so the cast can never actually unbox a null.
+            @SuppressWarnings("cast.unsafe")
             boolean newFlag = (boolean) setAccessible0_Method.invokeExact(accessibleObject, true);
             assert newFlag;
         } catch (Throwable throwable) {

--- a/framework/tests/all-systems/Issue6282.java
+++ b/framework/tests/all-systems/Issue6282.java
@@ -12,8 +12,8 @@ public class Issue6282 {
     public static void setAccessible(final AccessibleObject accessibleObject) {
         try {
             // MethodHandle.invokeExact's polymorphic-signature return is @Nullable on an
-            // annotated JDK; this code always throws before returning (see the class comment),
-            // so the cast can never actually unbox a null.
+            // annotated JDK. Class initialization calls setAccessible0_Method(), which always
+            // throws, before this line can ever run, so the cast can never actually unbox a null.
             @SuppressWarnings("cast.unsafe")
             boolean newFlag = (boolean) setAccessible0_Method.invokeExact(accessibleObject, true);
             assert newFlag;


### PR DESCRIPTION
## Summary

eisop/jdk#141 annotates `MethodHandle.invokeExact`/`invoke`'s polymorphic-signature return as
`@Nullable Object`. `framework/tests/all-systems/Issue6282.java` casts that return directly to
the primitive `boolean`:

```java
boolean newFlag = (boolean) setAccessible0_Method.invokeExact(accessibleObject, true);
```

Once the return is `@Nullable`, that cast is no longer statically verifiable and the Nullness
Checker reports `cast.unsafe`, which broke `NestedAggregateCheckerTest`, `NullnessTest`, and
`NullnessAssumeInitializedTest` in eisop/jdk#141's CI (they all run the shared `all-systems`
corpus against the JDK's own newly-annotated `java.base`).

## Why suppress rather than expect the diagnostic

`checker/tests/all-systems` is a shared corpus: this repo's own CI runs it against a plain,
unannotated JDK, while eisop/jdk's CI runs the identical file against its own annotated
`java.base`. An expected-diagnostic marker (`// :: warning: (cast.unsafe)`) would only hold in
the latter case and would break this repo's own standalone CI. `Issue6282.java`'s only real
purpose is a WPI-crash regression test (`@SuppressWarnings("ainfertest")`) -- the method always
throws before the cast could ever actually unbox a null -- so suppressing the warning is correct
under both JDKs.

## Testing

Verified with a local `.astub` declaring `invokeExact`'s return `@Nullable`, standing in for the
annotated JDK: the suppression eliminates `cast.unsafe` with the stub active, and the file still
produces zero diagnostics without it (today's plain-JDK case). Full `./gradlew test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV