### PR TITLE
Fix a shadowed `@DefaultQualifier` being lost for deeper subpackages

### DIFF
--- a/checker/jtreg/subpackages/DefaultQualifierNested.java
+++ b/checker/jtreg/subpackages/DefaultQualifierNested.java
@@ -6,8 +6,10 @@
  * default of NonNull that does not apply to subpackages. Package dq.sub's own elements correctly
  * see NonNull (shadowing is not in question), but package dq.sub.deep must still see dq's
  * Nullable default -- nothing there shadows it, and dq.sub's non-propagating shadow must not
- * remove it for deeper packages, only for dq.sub itself.
+ * remove it for deeper packages, only for dq.sub itself. Conversely, package dq.prop shadows dq
+ * with a FIELD default of NonNull that does apply to subpackages (applyToSubpackages = true), and
+ * dq.prop.deep must see dq.prop's NonNull default.
  *
- * @compile/fail/ref=DefaultQualifierNested.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker dq/package-info.java dq/sub/package-info.java dq/InDq.java dq/sub/InDqSub.java dq/sub/deep/Deep.java
+ * @compile/fail/ref=DefaultQualifierNested.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker dq/package-info.java dq/sub/package-info.java dq/prop/package-info.java dq/InDq.java dq/sub/InDqSub.java dq/sub/deep/Deep.java dq/prop/deep/DeepProp.java
  */
 public class DefaultQualifierNested {}

--- a/checker/jtreg/subpackages/DefaultQualifierNested.java
+++ b/checker/jtreg/subpackages/DefaultQualifierNested.java
@@ -1,0 +1,13 @@
+/*
+ * @test
+ * @summary eisop#2037: a DefaultQualifier is lost for deeper subpackages when an intervening
+ * package shadows it (same location, same qualifier hierarchy) and sets applyToSubpackages =
+ * false. Package dq sets a FIELD default of Nullable; package dq.sub shadows it with a FIELD
+ * default of NonNull that does not apply to subpackages. Package dq.sub's own elements correctly
+ * see NonNull (shadowing is not in question), but package dq.sub.deep must still see dq's
+ * Nullable default -- nothing there shadows it, and dq.sub's non-propagating shadow must not
+ * remove it for deeper packages, only for dq.sub itself.
+ *
+ * @compile/fail/ref=DefaultQualifierNested.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker dq/package-info.java dq/sub/package-info.java dq/InDq.java dq/sub/InDqSub.java dq/sub/deep/Deep.java
+ */
+public class DefaultQualifierNested {}

--- a/checker/jtreg/subpackages/DefaultQualifierNested.out
+++ b/checker/jtreg/subpackages/DefaultQualifierNested.out
@@ -1,4 +1,7 @@
 InDq.java:8:9: compiler.err.proc.messager: [dereference.of.nullable] dereference of possibly-null reference f
 InDqSub.java:10:12: compiler.err.proc.messager: [initialization.field.uninitialized] the default constructor does not initialize field f
 Deep.java:13:9: compiler.err.proc.messager: [dereference.of.nullable] dereference of possibly-null reference f
-3 errors
+DeepProp.java:14:13: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
+found   : @Nullable NullType
+required: @NonNull Object
+4 errors

--- a/checker/jtreg/subpackages/DefaultQualifierNested.out
+++ b/checker/jtreg/subpackages/DefaultQualifierNested.out
@@ -1,0 +1,4 @@
+InDq.java:8:9: compiler.err.proc.messager: [dereference.of.nullable] dereference of possibly-null reference f
+InDqSub.java:10:12: compiler.err.proc.messager: [initialization.field.uninitialized] the default constructor does not initialize field f
+Deep.java:13:9: compiler.err.proc.messager: [dereference.of.nullable] dereference of possibly-null reference f
+3 errors

--- a/checker/jtreg/subpackages/dq/InDq.java
+++ b/checker/jtreg/subpackages/dq/InDq.java
@@ -1,0 +1,10 @@
+package dq;
+
+/** Package dq's own FIELD default (Nullable) applies directly here. */
+public class InDq {
+    Object f;
+
+    void use() {
+        f.toString();
+    }
+}

--- a/checker/jtreg/subpackages/dq/package-info.java
+++ b/checker/jtreg/subpackages/dq/package-info.java
@@ -1,0 +1,6 @@
+@DefaultQualifier(value = Nullable.class, locations = TypeUseLocation.FIELD)
+package dq;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;

--- a/checker/jtreg/subpackages/dq/prop/deep/DeepProp.java
+++ b/checker/jtreg/subpackages/dq/prop/deep/DeepProp.java
@@ -1,0 +1,16 @@
+package dq.prop.deep;
+
+/**
+ * When an intervening package (dq.prop) shadows an enclosing package (dq)'s FIELD default with its
+ * own FIELD default that has applyToSubpackages = true, that nearer default must win for deeper
+ * subpackages as well: this class must be defaulted with dq.prop's FIELD default (NonNull), not
+ * dq's (Nullable).
+ */
+public class DeepProp {
+    Object f = new Object();
+
+    void use() {
+        f.toString();
+        f = null;
+    }
+}

--- a/checker/jtreg/subpackages/dq/prop/package-info.java
+++ b/checker/jtreg/subpackages/dq/prop/package-info.java
@@ -1,0 +1,9 @@
+@DefaultQualifier(
+        value = NonNull.class,
+        locations = TypeUseLocation.FIELD,
+        applyToSubpackages = true)
+package dq.prop;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;

--- a/checker/jtreg/subpackages/dq/sub/InDqSub.java
+++ b/checker/jtreg/subpackages/dq/sub/InDqSub.java
@@ -1,0 +1,11 @@
+package dq.sub;
+
+/**
+ * Package dq.sub's own FIELD default (NonNull, applyToSubpackages = false) shadows package dq's
+ * FIELD default (Nullable) here. This is unchanged by fixing eisop#2037: shadowing for a package's
+ * own elements is not in question, only whether a shadowed default still propagates to deeper
+ * subpackages that this package's own default does not reach.
+ */
+public class InDqSub {
+    Object f;
+}

--- a/checker/jtreg/subpackages/dq/sub/deep/Deep.java
+++ b/checker/jtreg/subpackages/dq/sub/deep/Deep.java
@@ -1,0 +1,15 @@
+package dq.sub.deep;
+
+/**
+ * eisop#2037: package dq.sub's FIELD default (NonNull) shadows package dq's FIELD default
+ * (Nullable) at dq.sub itself, and does not apply to subpackages -- but that must not remove dq's
+ * own default for deeper subpackages, which nothing here shadows. This class must be defaulted with
+ * dq's FIELD default (Nullable), not dq.sub's (NonNull), and not neither.
+ */
+public class Deep {
+    Object f;
+
+    void use() {
+        f.toString();
+    }
+}

--- a/checker/jtreg/subpackages/dq/sub/package-info.java
+++ b/checker/jtreg/subpackages/dq/sub/package-info.java
@@ -1,0 +1,9 @@
+@DefaultQualifier(
+        value = NonNull.class,
+        locations = TypeUseLocation.FIELD,
+        applyToSubpackages = false)
+package dq.sub;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,13 @@ Version 3.49.5-eisop2 (June ?, 2026)
 
 **User-visible changes:**
 
+Fixed a bug where a `@DefaultQualifier` on a package could be lost for deeper subpackages.
+This happened when an intervening package shadowed it -- set a default for the same
+location and qualifier hierarchy -- and that shadowing default did not itself apply to
+subpackages. The intervening package's own default correctly stayed limited to that
+package, but the outer default, which nothing deeper actually shadowed, incorrectly
+stopped propagating too.
+
 The Nullness Checker no longer recognizes `org.jspecify.nullness.NonNull`,
 `org.jspecify.nullness.Nullable`, or `org.jspecify.nullness.NullMarked` -- JSpecify's
 original, pre-1.0 package, deprecated since 2022. Use the corresponding
@@ -840,7 +847,7 @@ eisop#792, eisop#863, eisop#949, eisop#1015, eisop#1059, eisop#1074, eisop#1244,
 eisop#1315, eisop#1564, eisop#1592, eisop#1642, eisop#1653, eisop#1735,
 eisop#1801, eisop#1818, eisop#1819, eisop#1861, eisop#1862, eisop#1863,
 eisop#1865, eisop#1887, eisop#1965, eisop#1986, eisop#1987, eisop#1990,
-eisop#1991, eisop#2032, typetools#399, typetools#3203.
+eisop#1991, eisop#2032, eisop#2037, typetools#399, typetools#3203.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -461,6 +461,10 @@ public class QualifierDefaults {
         // propagatingDefaultsAt sees it and this default reaches elem's subpackages, the same as
         // a written @DefaultQualifier would.
         programmaticElementDefaults.computeIfAbsent(elem, unused -> new DefaultSet()).add(d);
+        if (elem instanceof PackageElement) {
+            // Invalidate cached propagating defaults so subpackage lookups see the new default.
+            packagePropagatingDefaults.clear();
+        }
         // prevset may already be a key in the fused caches; its content just changed, so any
         // memoized fused list for it is now stale.
         invalidateFusedDefaults();

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -156,6 +156,22 @@ public class QualifierDefaults {
      */
     private final IdentityHashMap<Element, DefaultSet> elementDefaults = new IdentityHashMap<>();
 
+    /**
+     * For a package, the defaults it makes available to its own subpackages: its own direct
+     * defaults that have {@code applyToSubpackages = true}, plus whatever its own parent package
+     * makes available to it that a nearer, propagating default of its own does not replace. See
+     * {@link #propagatingDefaultsAt}, which computes and caches this.
+     *
+     * <p>This is deliberately a separate cache from {@link #elementDefaults}: a default that is
+     * shadowed for a package's own elements (by a nearer default for the same location and
+     * qualifier hierarchy) is not necessarily shadowed for that package's subpackages too. A
+     * shadowing default that does not itself have {@code applyToSubpackages = true} only wins
+     * locally; the default it shadowed must remain available here for deeper packages, or it is
+     * lost for them even though nothing there shadows it.
+     */
+    private final IdentityHashMap<PackageElement, DefaultSet> packagePropagatingDefaults =
+            new IdentityHashMap<>();
+
     /** CLIMB locations whose standard default is top for a given type system. */
     public static final List<TypeUseLocation> STANDARD_CLIMB_DEFAULTS_TOP =
             Collections.unmodifiableList(
@@ -723,20 +739,11 @@ public class QualifierDefaults {
         DefaultSet qualifiers = defaultsAtDirect(elt);
         DefaultSet parentDefaults;
         if (elt.getKind() == ElementKind.PACKAGE) {
-            Element parent = ElementUtils.parentPackage((PackageElement) elt, elements);
-            DefaultSet origParentDefaults = defaultsAt(parent);
-            if (origParentDefaults.isEmpty()) {
-                // Nothing to filter; reuse the empty set rather than allocating one to copy
-                // zero elements into. Common case: no @DefaultQualifier anywhere in the chain.
-                parentDefaults = origParentDefaults;
-            } else {
-                parentDefaults = new DefaultSet();
-                for (Default d : origParentDefaults) {
-                    if (d.applyToSubpackages) {
-                        parentDefaults.add(d);
-                    }
-                }
-            }
+            // Use what the parent package makes available to its subpackages (already filtered
+            // to applyToSubpackages, and already accounting for the parent's own shadowing), not
+            // the parent's own effective set: see propagatingDefaultsAt for why those can differ.
+            PackageElement parent = ElementUtils.parentPackage((PackageElement) elt, elements);
+            parentDefaults = propagatingDefaultsAt(parent);
         } else {
             Element parent = elt.getEnclosingElement();
             parentDefaults = defaultsAt(parent);
@@ -745,29 +752,7 @@ public class QualifierDefaults {
         if (qualifiers == null || qualifiers.isEmpty()) {
             qualifiers = parentDefaults;
         } else {
-            // A default for a given (location, hierarchy) at a nearer scope shadows a default for
-            // the same (location, hierarchy) at an enclosing scope: only inherit an enclosing-scope
-            // default whose (location, hierarchy) the nearer scope does not itself set. Without
-            // this, both defaults would coexist in the (location, annotation)-ordered TreeSet and
-            // the winner between them would be decided by annotation ordering rather than by scope
-            // distance.
-            QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
-            for (Default d : parentDefaults) {
-                boolean shadowed = false;
-                AnnotationMirror parentTop = qualHierarchy.getTopAnnotation(d.anno);
-                for (Default nearer : qualifiers) {
-                    if (nearer.location == d.location) {
-                        AnnotationMirror nearerTop = qualHierarchy.getTopAnnotation(nearer.anno);
-                        if (AnnotationUtils.areSame(parentTop, nearerTop)) {
-                            shadowed = true;
-                            break;
-                        }
-                    }
-                }
-                if (!shadowed) {
-                    qualifiers.add(d);
-                }
-            }
+            qualifiers = mergeShadowing(qualifiers, parentDefaults);
         }
 
         if (!qualifiers.isEmpty()) {
@@ -781,6 +766,106 @@ public class QualifierDefaults {
             elementDefaults.put(elt, emptyForElt);
             return emptyForElt;
         }
+    }
+
+    /**
+     * Returns the defaults that {@code pkg} makes available to its own subpackages: {@code pkg}'s
+     * own direct defaults that have {@code applyToSubpackages = true}, merged with what {@code
+     * pkg}'s own parent package makes available to it in turn.
+     *
+     * <p>This is not the same as filtering {@link #defaultsAt}({@code pkg}) by {@code
+     * applyToSubpackages}, and computing it that way is the bug this method exists to avoid (see <a
+     * href="https://github.com/eisop/checker-framework/issues/2037">eisop#2037</a>). {@link
+     * #defaultsAt} resolves, once and for all, which default wins <em>at {@code pkg} itself</em>
+     * for a given (location, qualifier hierarchy): a nearer default there permanently shadows a
+     * farther one, full stop. But a default that loses that competition at {@code pkg} has not
+     * necessarily lost it everywhere: if the default that shadowed it does not itself have {@code
+     * applyToSubpackages = true}, the shadowing default only ever applied at {@code pkg}, and the
+     * default it shadowed must remain available for {@code pkg}'s subpackages, which nothing there
+     * shadows. Folding shadowing and {@code applyToSubpackages}-filtering into one pass, the way
+     * {@link #defaultsAt} needs to for {@code pkg}'s own elements, permanently discards that
+     * shadowed default instead: it is not merely unavailable at {@code pkg}, it is gone.
+     *
+     * <p>So this method tracks a second, independent question -- what continues past {@code pkg} --
+     * by only letting a default permanently replace a farther one here if the nearer default itself
+     * also has {@code applyToSubpackages = true}; only then does it actually compete at the same
+     * depths the farther one did. A non-propagating nearer default still wins at {@code pkg} (via
+     * {@link #defaultsAt}, which merges {@code pkg}'s own defaults over this method's result), it
+     * just does not get to erase the farther default for everyone past {@code pkg}.
+     *
+     * @param pkg a package, or null for no package
+     * @return the defaults {@code pkg} makes available to its own subpackages
+     */
+    private DefaultSet propagatingDefaultsAt(@Nullable PackageElement pkg) {
+        if (pkg == null) {
+            return DefaultSet.EMPTY;
+        }
+
+        DefaultSet cached = packagePropagatingDefaults.get(pkg);
+        if (cached != null) {
+            return cached;
+        }
+
+        DefaultSet direct = defaultsAtDirect(pkg);
+        DefaultSet ownPropagating;
+        if (direct == null || direct.isEmpty()) {
+            ownPropagating = DefaultSet.EMPTY;
+        } else {
+            ownPropagating = new DefaultSet();
+            for (Default d : direct) {
+                if (d.applyToSubpackages) {
+                    ownPropagating.add(d);
+                }
+            }
+        }
+
+        PackageElement parent = ElementUtils.parentPackage(pkg, elements);
+        DefaultSet parentPropagating = propagatingDefaultsAt(parent);
+
+        DefaultSet result = mergeShadowing(ownPropagating, parentPropagating);
+        packagePropagatingDefaults.put(pkg, result);
+        return result;
+    }
+
+    /**
+     * Merges {@code farther} into {@code nearer}: every element of {@code nearer} is kept, and an
+     * element of {@code farther} is kept too unless {@code nearer} has an element for the same
+     * (location, qualifier hierarchy), which shadows it. Without this, both defaults would coexist
+     * in the (location, annotation)-ordered {@link DefaultSet} and the winner between them would be
+     * decided by annotation ordering rather than by scope distance.
+     *
+     * @param nearer defaults at a nearer scope; every one of them is kept
+     * @param farther defaults at a farther scope; kept only where {@code nearer} does not set the
+     *     same (location, qualifier hierarchy)
+     * @return the merged set
+     */
+    private DefaultSet mergeShadowing(DefaultSet nearer, DefaultSet farther) {
+        if (farther.isEmpty()) {
+            return nearer;
+        }
+        if (nearer.isEmpty()) {
+            return farther;
+        }
+        DefaultSet result = new DefaultSet();
+        result.addAll(nearer);
+        QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
+        for (Default d : farther) {
+            boolean shadowed = false;
+            AnnotationMirror fartherTop = qualHierarchy.getTopAnnotation(d.anno);
+            for (Default n : nearer) {
+                if (n.location == d.location) {
+                    AnnotationMirror nearerTop = qualHierarchy.getTopAnnotation(n.anno);
+                    if (AnnotationUtils.areSame(fartherTop, nearerTop)) {
+                        shadowed = true;
+                        break;
+                    }
+                }
+            }
+            if (!shadowed) {
+                result.add(d);
+            }
+        }
+        return result;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -157,19 +157,23 @@ public class QualifierDefaults {
     private final IdentityHashMap<Element, DefaultSet> elementDefaults = new IdentityHashMap<>();
 
     /**
-     * For a package, the defaults it makes available to its own subpackages: its own direct
-     * defaults that have {@code applyToSubpackages = true}, plus whatever its own parent package
-     * makes available to it that a nearer, propagating default of its own does not replace. See
-     * {@link #propagatingDefaultsAt}, which computes and caches this.
-     *
-     * <p>This is deliberately a separate cache from {@link #elementDefaults}: a default that is
-     * shadowed for a package's own elements (by a nearer default for the same location and
-     * qualifier hierarchy) is not necessarily shadowed for that package's subpackages too. A
-     * shadowing default that does not itself have {@code applyToSubpackages = true} only wins
-     * locally; the default it shadowed must remain available here for deeper packages, or it is
-     * lost for them even though nothing there shadows it.
+     * For a package, the defaults it makes available to its own subpackages. This is not {@link
+     * #elementDefaults} filtered by {@code applyToSubpackages}; see {@link #propagatingDefaultsAt},
+     * which computes and caches this and explains why.
      */
     private final IdentityHashMap<PackageElement, DefaultSet> packagePropagatingDefaults =
+            new IdentityHashMap<>();
+
+    /**
+     * Defaults added via {@link #addElementDefault}, tracked separately from {@link
+     * #elementDefaults} so that {@link #defaultsAtDirect} can treat a programmatically-added
+     * default as part of an element's own direct contribution -- the same way it already treats a
+     * written {@code @DefaultQualifier} -- rather than it being visible only through {@link
+     * #elementDefaults}, which {@link #propagatingDefaultsAt} does not consult (see that method).
+     * Without this, a default added on a package would apply to that package's own elements (via
+     * {@link #elementDefaults}) but silently fail to reach any of its subpackages.
+     */
+    private final IdentityHashMap<Element, DefaultSet> programmaticElementDefaults =
             new IdentityHashMap<>();
 
     /** CLIMB locations whose standard default is top for a given type system. */
@@ -449,8 +453,14 @@ public class QualifierDefaults {
             prevset = new DefaultSet();
         }
         // TODO: expose applyToSubpackages
-        prevset.add(new Default(elementDefaultAnno, location, true));
+        Default d = new Default(elementDefaultAnno, location, true);
+        prevset.add(d);
         elementDefaults.put(elem, prevset);
+        // Also track this as part of elem's own direct contribution -- see
+        // programmaticElementDefaults and defaultsAtDirect -- so that if elem is a package,
+        // propagatingDefaultsAt sees it and this default reaches elem's subpackages, the same as
+        // a written @DefaultQualifier would.
+        programmaticElementDefaults.computeIfAbsent(elem, unused -> new DefaultSet()).add(d);
         // prevset may already be a key in the fused caches; its content just changed, so any
         // memoized fused list for it is now stale.
         invalidateFusedDefaults();
@@ -739,9 +749,7 @@ public class QualifierDefaults {
         DefaultSet qualifiers = defaultsAtDirect(elt);
         DefaultSet parentDefaults;
         if (elt.getKind() == ElementKind.PACKAGE) {
-            // Use what the parent package makes available to its subpackages (already filtered
-            // to applyToSubpackages, and already accounting for the parent's own shadowing), not
-            // the parent's own effective set: see propagatingDefaultsAt for why those can differ.
+            // Not defaultsAt(parent) filtered by applyToSubpackages; see propagatingDefaultsAt.
             PackageElement parent = ElementUtils.parentPackage((PackageElement) elt, elements);
             parentDefaults = propagatingDefaultsAt(parent);
         } else {
@@ -769,29 +777,18 @@ public class QualifierDefaults {
     }
 
     /**
-     * Returns the defaults that {@code pkg} makes available to its own subpackages: {@code pkg}'s
-     * own direct defaults that have {@code applyToSubpackages = true}, merged with what {@code
-     * pkg}'s own parent package makes available to it in turn.
+     * Returns the defaults that {@code pkg} makes available to its own subpackages: its own direct
+     * defaults with {@code applyToSubpackages = true}, merged with what its parent package makes
+     * available to it.
      *
-     * <p>This is not the same as filtering {@link #defaultsAt}({@code pkg}) by {@code
-     * applyToSubpackages}, and computing it that way is the bug this method exists to avoid (see <a
-     * href="https://github.com/eisop/checker-framework/issues/2037">eisop#2037</a>). {@link
-     * #defaultsAt} resolves, once and for all, which default wins <em>at {@code pkg} itself</em>
-     * for a given (location, qualifier hierarchy): a nearer default there permanently shadows a
-     * farther one, full stop. But a default that loses that competition at {@code pkg} has not
-     * necessarily lost it everywhere: if the default that shadowed it does not itself have {@code
-     * applyToSubpackages = true}, the shadowing default only ever applied at {@code pkg}, and the
-     * default it shadowed must remain available for {@code pkg}'s subpackages, which nothing there
-     * shadows. Folding shadowing and {@code applyToSubpackages}-filtering into one pass, the way
-     * {@link #defaultsAt} needs to for {@code pkg}'s own elements, permanently discards that
-     * shadowed default instead: it is not merely unavailable at {@code pkg}, it is gone.
-     *
-     * <p>So this method tracks a second, independent question -- what continues past {@code pkg} --
-     * by only letting a default permanently replace a farther one here if the nearer default itself
-     * also has {@code applyToSubpackages = true}; only then does it actually compete at the same
-     * depths the farther one did. A non-propagating nearer default still wins at {@code pkg} (via
-     * {@link #defaultsAt}, which merges {@code pkg}'s own defaults over this method's result), it
-     * just does not get to erase the farther default for everyone past {@code pkg}.
+     * <p>This is not {@link #defaultsAt}({@code pkg}) filtered by {@code applyToSubpackages};
+     * computing it that way is <a
+     * href="https://github.com/eisop/checker-framework/issues/2037">eisop#2037</a>. Shadowing is a
+     * statement about one scope: a nearer default that does not itself apply to subpackages wins at
+     * {@code pkg} only, so it must not discard the farther default it shadowed there -- deeper
+     * packages, where nothing shadows it, still need it. So a default replaces a farther one here
+     * only if it too has {@code applyToSubpackages = true}. It still wins at {@code pkg} itself,
+     * via {@link #defaultsAt}, which merges {@code pkg}'s own defaults over this method's result.
      *
      * @param pkg a package, or null for no package
      * @return the defaults {@code pkg} makes available to its own subpackages
@@ -828,11 +825,14 @@ public class QualifierDefaults {
     }
 
     /**
-     * Merges {@code farther} into {@code nearer}: every element of {@code nearer} is kept, and an
-     * element of {@code farther} is kept too unless {@code nearer} has an element for the same
-     * (location, qualifier hierarchy), which shadows it. Without this, both defaults would coexist
-     * in the (location, annotation)-ordered {@link DefaultSet} and the winner between them would be
-     * decided by annotation ordering rather than by scope distance.
+     * Returns {@code nearer} plus every element of {@code farther} whose (location, qualifier
+     * hierarchy) {@code nearer} does not already set -- {@code nearer}'s elements shadow {@code
+     * farther}'s for the same (location, hierarchy), rather than both coexisting in the (location,
+     * annotation)-ordered {@link DefaultSet} and the winner being decided by annotation ordering
+     * instead of scope distance.
+     *
+     * <p>Does not mutate either argument: the result may be one of them unchanged (when the other
+     * is empty) or a newly allocated set.
      *
      * @param nearer defaults at a nearer scope; every one of them is kept
      * @param farther defaults at a farther scope; kept only where {@code nearer} does not set the
@@ -870,7 +870,10 @@ public class QualifierDefaults {
 
     /**
      * Returns the defaults that apply directly to the given Element, without considering enclosing
-     * Elements.
+     * Elements. This includes both defaults derived from a written {@code @DefaultQualifier} (or
+     * {@code @DefaultQualifier.List}) annotation and any added programmatically via {@link
+     * #addElementDefault}: both are equally {@code elt}'s own direct contribution, just installed
+     * through different mechanisms.
      *
      * @param elt the element
      * @return the defaults
@@ -905,6 +908,16 @@ public class QualifierDefaults {
                 }
             }
         }
+
+        // Handle defaults added via addElementDefault.
+        DefaultSet programmatic = programmaticElementDefaults.get(elt);
+        if (programmatic != null) {
+            if (qualifiers == null) {
+                qualifiers = new DefaultSet();
+            }
+            qualifiers.addAll(programmatic);
+        }
+
         return qualifiers;
     }
 

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ElementDefaultTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ElementDefaultTest.java
@@ -22,6 +22,11 @@ public class ElementDefaultTest extends CheckerFrameworkPerDirectoryTest {
         super(testFiles, ElementDefaultChecker.class, "elementdefault");
     }
 
+    /**
+     * Define the test directories for this test.
+     *
+     * @return the test directories
+     */
     @Parameters
     public static String[] getTestDirs() {
         return new String[] {"elementdefault"};

--- a/framework/src/test/java/org/checkerframework/framework/test/junit/ElementDefaultTest.java
+++ b/framework/src/test/java/org/checkerframework/framework/test/junit/ElementDefaultTest.java
@@ -1,0 +1,29 @@
+package org.checkerframework.framework.test.junit;
+
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.checkerframework.framework.testchecker.elementdefault.ElementDefaultChecker;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Tests that a default added via {@link
+ * org.checkerframework.framework.util.defaults.QualifierDefaults#addElementDefault} on a package
+ * reaches that package's subpackages, the same way a written {@code @DefaultQualifier} would (see
+ * eisop#2037).
+ */
+public class ElementDefaultTest extends CheckerFrameworkPerDirectoryTest {
+
+    /**
+     * @param testFiles the files containing test code, which will be type-checked
+     */
+    public ElementDefaultTest(List<File> testFiles) {
+        super(testFiles, ElementDefaultChecker.class, "elementdefault");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"elementdefault"};
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultAnnotatedTypeFactory.java
@@ -24,6 +24,11 @@ import javax.lang.model.element.PackageElement;
  */
 public class ElementDefaultAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
+    /**
+     * Creates a new ElementDefaultAnnotatedTypeFactory.
+     *
+     * @param checker the checker
+     */
     @SuppressWarnings("this-escape")
     public ElementDefaultAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultAnnotatedTypeFactory.java
@@ -1,0 +1,50 @@
+package org.checkerframework.framework.testchecker.elementdefault;
+
+import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.qual.TypeUseLocation;
+import org.checkerframework.framework.util.defaults.QualifierDefaults;
+import org.checkerframework.javacutil.AnnotationBuilder;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.PackageElement;
+
+/**
+ * Calls {@link QualifierDefaults#addElementDefault} directly on package {@code elementdefault.pkg},
+ * defaulting its {@code FIELD} locations to {@link ElementDefaultBottom} -- the same way a written
+ * {@code @DefaultQualifier(ElementDefaultBottom.class, TypeUseLocation.FIELD)} on that package's
+ * package-info.java would, but through the programmatic API instead. See {@code
+ * framework/tests/elementdefault} for what this is testing: that the default set this way still
+ * reaches {@code elementdefault.pkg.sub}, a subpackage with no default of its own.
+ */
+public class ElementDefaultAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
+
+    @SuppressWarnings("this-escape")
+    public ElementDefaultAnnotatedTypeFactory(BaseTypeChecker checker) {
+        super(checker);
+        this.postInit();
+    }
+
+    @Override
+    protected void addCheckedCodeDefaults(QualifierDefaults defs) {
+        AnnotationMirror top = AnnotationBuilder.fromClass(elements, ElementDefaultTop.class);
+        defs.addCheckedCodeDefault(top, TypeUseLocation.OTHERWISE);
+
+        PackageElement pkg = elements.getPackageElement("elementdefault.pkg");
+        if (pkg != null) {
+            AnnotationMirror bottom =
+                    AnnotationBuilder.fromClass(elements, ElementDefaultBottom.class);
+            defs.addElementDefault(pkg, bottom, TypeUseLocation.FIELD);
+        }
+    }
+
+    @Override
+    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+        return new HashSet<>(Arrays.asList(ElementDefaultTop.class, ElementDefaultBottom.class));
+    }
+}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultBottom.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultBottom.java
@@ -1,0 +1,19 @@
+package org.checkerframework.framework.testchecker.elementdefault;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The bottom qualifier of the trivial two-qualifier hierarchy used only by {@link
+ * ElementDefaultChecker}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(ElementDefaultTop.class)
+public @interface ElementDefaultBottom {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultChecker.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultChecker.java
@@ -1,0 +1,13 @@
+package org.checkerframework.framework.testchecker.elementdefault;
+
+import org.checkerframework.common.basetype.BaseTypeChecker;
+
+/**
+ * A checker used only to test {@link
+ * org.checkerframework.framework.util.defaults.QualifierDefaults#addElementDefault}: its {@link
+ * ElementDefaultAnnotatedTypeFactory} calls that method directly, rather than through a written
+ * {@code @DefaultQualifier} annotation, on one specific package (named in {@code
+ * framework/tests/elementdefault}'s test source), to confirm the default reaches that package's
+ * subpackages the same way a written annotation would.
+ */
+public final class ElementDefaultChecker extends BaseTypeChecker {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultTop.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/elementdefault/ElementDefaultTop.java
@@ -1,0 +1,21 @@
+package org.checkerframework.framework.testchecker.elementdefault;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The top qualifier of the trivial two-qualifier hierarchy used only by {@link
+ * ElementDefaultChecker}. {@link ElementDefaultAnnotatedTypeFactory#addCheckedCodeDefaults}
+ * registers this as the checker-wide default explicitly, so this does not need
+ * {@code @DefaultQualifierInHierarchy}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+public @interface ElementDefaultTop {}

--- a/framework/tests/elementdefault/InPkg.java
+++ b/framework/tests/elementdefault/InPkg.java
@@ -1,0 +1,14 @@
+package elementdefault.pkg;
+
+/**
+ * ElementDefaultAnnotatedTypeFactory calls addElementDefault directly on this package, defaulting
+ * FIELD locations to Bottom. An unqualified value is not assignable to a Bottom-defaulted field.
+ */
+public class InPkg {
+    Object f;
+
+    void use() {
+        // :: error: (assignment.type.incompatible)
+        f = new Object();
+    }
+}

--- a/framework/tests/elementdefault/InSub.java
+++ b/framework/tests/elementdefault/InSub.java
@@ -1,0 +1,17 @@
+package elementdefault.pkg.sub;
+
+/**
+ * This subpackage has no default of its own. The FIELD default that
+ * ElementDefaultAnnotatedTypeFactory added programmatically on package elementdefault.pkg (via
+ * addElementDefault, not a written @DefaultQualifier) must still reach here, the same way a written
+ * default would -- this is what eisop#2037's fix, and the addElementDefault code path it touches,
+ * are responsible for.
+ */
+public class InSub {
+    Object f;
+
+    void use() {
+        // :: error: (assignment.type.incompatible)
+        f = new Object();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2037.

`QualifierDefaults.defaultsAt` computed one cached, already-shadowing-resolved "effective set" per package, then filtered that same set by `applyToSubpackages` to hand to children. When a package's own default shadowed an enclosing package's default for the same (location, qualifier hierarchy), the enclosing one was dropped from the set entirely — not merely unavailable at the shadowing package, but gone for every deeper package too, even when nothing there shadows it.

**Repro (from the issue):** package `A` sets a `FIELD` default of `Nullable`. Package `A.B` shadows it with a `FIELD` default that does not apply to subpackages. `A.B.C`, with no default of its own, incorrectly saw *neither* default (an `initialization.field.uninitialized` error is the tell — a `NonNull`-by-default field with no initializer) instead of `A`'s `Nullable` default.

## Fix

Track two things per package instead of one:
- the effective set for its own elements (unchanged — nearest default always wins there), and
- a separate set of what it makes available to its own subpackages (new).

A default only permanently replaces an enclosing one in the second set if the replacing default itself has `applyToSubpackages = true`. A non-propagating shadow still wins locally (for the shadowing package's own elements), but it no longer erases the enclosing default for deeper packages, which is what the previous code did incorrectly.

Verified by hand (in addition to the new test) that this also handles a shadowing *chain* correctly: a third package that re-shadows and itself propagates correctly wins over the original default at a fourth, deeper level.

## Testing

- New jtreg test (`checker/jtreg/subpackages/DefaultQualifierNested.java`), mirroring the existing `AnnotatedFor`/`HasQualifierParameter` subpackage tests, exercising: the top package's own default, the shadowing package's own (correctly unchanged, locally-shadowing) default, and the deep package correctly inheriting the top's default despite the intervening shadow.
- Full `./gradlew test` and `:checker:jtregTests` (112/112) pass.
- Confirmed the fix does not affect the case where the shadowing default is for a *different* location (already worked correctly before this fix, since there's no shadowing collision to lose information over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV