### PR TITLE
CI: Resubmit the dependency graph on push to master

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,42 @@
+name: Dependency graph submission
+
+# Keeps the repository's Dependency Graph (and therefore Dependabot alerts) in sync with what
+# the build actually resolves. Runs only on push to master and on a daily schedule -- never on
+# pull_request -- so it never touches a fork's content and needs no split generate/submit
+# workaround: a PR-derived snapshot is accepted but explicitly not used to update repository-wide
+# dependency results (see eisop#1045), and a workflow_run-triggered submission step always runs
+# the default branch's copy of the job regardless of which commit triggered it, so the two-stage
+# pattern that tried to submit PR snapshots never actually reflected the PR under review either.
+# Submitting directly on master avoids both problems, since there is no PR content involved.
+
+on:
+  push:
+    branches: [ "master" ]
+  schedule:
+    - cron: '0 8 * * *'  # Runs daily at 08:00 UTC, offset from the CI workflow's 07:00 run.
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v6.0.0
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4
+        with:
+          dependency-graph: generate-and-submit


### PR DESCRIPTION
## Summary

Dependabot's security tab currently shows 45 open alerts, even though PR #2035 already removed most of the vulnerable transitive dependencies (Spark's full tree, etc.) from the actual resolved classpath. All 45 alerts are attributed to `manifest: settings.gradle`, and the repository's current Dependency Graph SBOM (regenerated after #2035 merged) still lists the old Spark tree -- because there is no submission workflow to keep it in sync. Without a submitted snapshot, GitHub falls back to static-parsing the Gradle manifest files, which can't see resolution-time exclusions like `{ transitive = false }`, so #2035's fix is invisible to Dependabot's alerting even though the real classpath is already fixed.

## Why this wasn't just re-adding the old setup

A dependency-submission workflow existed before, disabled by #1047 (eisop#1045) and its already-inert files deleted by #2007. It tried to support `pull_request`-triggered submission for fork PRs, using the generate-on-PR / download-and-submit-on-`workflow_run` split that GitHub's docs recommend for that case. It never actually worked, for two compounding, well-documented GitHub Actions limitations:

1. A snapshot submitted from a PR branch is accepted but explicitly **not used to update repository-wide dependency results** -- GitHub's own message says so verbatim: *"The snapshot was accepted, but it is not for the default branch. It will not update dependency results for the repository."*
2. A `workflow_run`-triggered job always runs **the default branch's copy of itself**, regardless of which commit triggered it -- by design, for security. So even the "download and submit" half never actually reflected the PR under review.

That complexity exists to solve a problem this PR doesn't have. What we actually need is an accurate **repository-wide** graph, which only requires submitting on push to master -- no PR content involved, so neither failure mode applies.

## The change

A new `.github/workflows/dependency-submission.yml`:
- Triggers on `push` to `master` and a daily schedule (a safety net, offset from `ci.yml`'s existing 07:00 UTC cron).
- Never triggers on `pull_request`, so it never runs against fork content and needs no special permission workaround.
- A single `gradle/actions/dependency-submission@v4` step, non-split (`generate-and-submit`), with `contents: write` scoped to just this job.

## Expected effect

Once this runs against master, the ~41 alerts #2035 already fixed at the classpath level should be reflected accurately and close on their own; the remainder (test/build-only dependencies #2035 already identified as out of scope) should remain, correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLjeEW1F1aE2E3ax7EWqV