### PR TITLE
Run `-AajavaChecks` in dedicated JDK 17 CI job instead of all directory tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
           - {script: 'cftests-junit-jdk21',         java: {version: '25', experimental: false}}
           - {script: 'cftests-junit-jdk21',         java: {version: '17', experimental: false}}
           - {script: 'cftests-junit-jdk21',         java: {version: '11', experimental: false}}
+          # --- ajavaChecks consistency tests on JDK 17 ---
+          - {script: 'cftests-ajavachecks',         java: {version: '17', experimental: false}}
           # --- Downstream integration tests on Primary JDK 21 ---
           - {script: 'typecheck-part1',             java: {version: '21', experimental: false}}
           - {script: 'typecheck-part2',             java: {version: '21', experimental: false}}

--- a/build.gradle
+++ b/build.gradle
@@ -1470,6 +1470,10 @@ subprojects {
                 systemProperties += ['emit.test.debug': 'true']
             }
 
+            if (project.hasProperty('ajavaChecks') || Boolean.getBoolean('ajavaChecks')) {
+                systemProperties += ['ajavaChecks': 'true']
+            }
+
             // The typeinference8 incorporation worklist confirms each fixed point with a full rescan
             // that, in production, silently self-heals if the worklist ever skipped needed work. Run
             // this project's own tests in strict mode instead, so such a skip throws and a worklist

--- a/build.gradle
+++ b/build.gradle
@@ -1860,3 +1860,17 @@ tasks.register('printJavaVersion') {
         println currentJvm
     }
 }
+
+tasks.register('checkAjavaChecksProperty') {
+    group = 'Verification'
+    description = 'Verifies that -PajavaChecks or -DajavaChecks is supplied.'
+    def hasProp = project.hasProperty('ajavaChecks') || Boolean.getBoolean('ajavaChecks')
+    inputs.property('hasProperty', hasProp)
+    doLast {
+        if (!hasProp) {
+            throw new GradleException(
+                'Expected -PajavaChecks or -DajavaChecks to be set, but neither was provided. '
+                + 'This check ensures consistency checking is not accidentally skipped.')
+        }
+    }
+}

--- a/checker/bin-devel/test-cftests-ajavachecks.sh
+++ b/checker/bin-devel/test-cftests-ajavachecks.sh
@@ -12,4 +12,4 @@ source "$SCRIPT_DIR"/clone-related.sh
 # See test-cftests-junit.sh for why this is --no-build-cache rather than
 # --max-workers=1.
 # https://github.com/eisop/checker-framework/issues/849
-./gradlew test -PajavaChecks -x javadoc -x allJavadoc --console=plain --warning-mode=all --no-build-cache
+./gradlew checkAjavaChecksProperty test -PajavaChecks -x javadoc -x allJavadoc --console=plain --warning-mode=all --no-build-cache

--- a/checker/bin-devel/test-cftests-ajavachecks.sh
+++ b/checker/bin-devel/test-cftests-ajavachecks.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+# set -o verbose
+set -o xtrace
+export SHELLOPTS
+echo "SHELLOPTS=${SHELLOPTS}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+source "$SCRIPT_DIR"/clone-related.sh
+
+# See test-cftests-junit.sh for why this is --no-build-cache rather than
+# --max-workers=1.
+# https://github.com/eisop/checker-framework/issues/849
+./gradlew test -PajavaChecks -x javadoc -x allJavadoc --console=plain --warning-mode=all --no-build-cache

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -887,6 +887,10 @@ Performance optimizations:
 - `AnnotatedTypeFactory.isFromByteCode(Element)` now caches its result per
   element, avoiding a repeated `Path.toUri()` call (URI construction and
   parsing) on every conservative-defaults check.
+- Made the `-AajavaChecks` test consistency check opt-in via the `ajavaChecks` property (e.g.
+  `-PajavaChecks`) instead of unconditionally running on every directory test. On Java < 21
+  (where JavaParser parsing and AST traversal run), this speeds up test suites by ~20% to ~38%.
+  Consistency testing is now performed in a dedicated CI job (`cftests-ajavachecks` on JDK 17).
 
 Other improvements and bug fixes:
 - `TreeUtils` has a new `inferredTypeArguments(ExpressionTree)` method to

--- a/docs/developer/performance-notes.md
+++ b/docs/developer/performance-notes.md
@@ -1939,7 +1939,25 @@ in `UBQualifier$LessThanLengthOf` — a null path yields an unparseable offset e
 layers from the cause. If this is revisited, the clear has to happen strictly before anything is
 cached for the new unit, and the Index Checker is the canary.
 
+### Opt-in `-AajavaChecks` and dedicated JDK 17 CI job (September 2026, PR #2057)
+
+`CheckerFrameworkPerDirectoryTest` previously hardcoded `-AajavaChecks` across all directory tests.
+In `BaseTypeVisitor`, `ajavaChecks` is only active when `release < 21` (because annotation insertion
+is disabled on Java 21+). On JDK 21+ (including the primary CI JDK 21), `-AajavaChecks` was an
+effective no-op. On JDK < 21 (such as JDK 11 and 17), however, every test file in every directory
+test underwent repeated JavaParser parsing, joint AST traversals, and annotation insertion checks.
+
+This added a ~20%–38% test runtime overhead across routine test executions on JDK < 21:
+for example, `InterningTest` took 25.15 s with `-AajavaChecks` enabled versus 15.66 s without it
+(~37.7% reduction in test execution time).
+
+The option was made opt-in via `-PajavaChecks` / `-DajavaChecks` (reflected in `build.gradle` and
+`TestUtilities.getShouldRunAjavaChecks()`). A dedicated CI matrix job (`cftests-ajavachecks` on
+JDK 17 running `checker/bin-devel/test-cftests-ajavachecks.sh`) preserves full consistency testing
+without paying the parsing and traversal overhead on routine or multi-JDK test runs.
+
 ---
+
 
 ## Tried and rejected
 

--- a/framework-test/src/main/java/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
@@ -140,7 +140,9 @@ public abstract class CheckerFrameworkPerDirectoryTest extends CheckerFrameworkR
         this.testDir = testDir;
         this.classpathExtra = classpathExtra;
         this.checkerOptions = new ArrayList<>(Arrays.asList(checkerOptions));
-        this.checkerOptions.add("-AajavaChecks");
+        if (TestUtilities.getShouldRunAjavaChecks()) {
+            this.checkerOptions.add("-AajavaChecks");
+        }
         this.checkerOptions.add("-AconvertTypeArgInferenceCrashToWarning=false");
     }
 

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
@@ -596,6 +596,15 @@ public class TestUtilities {
     }
 
     /**
+     * Returns the value of system property "ajavaChecks".
+     *
+     * @return the value of system property "ajavaChecks"
+     */
+    public static boolean getShouldRunAjavaChecks() {
+        return SystemPlume.getBooleanSystemProperty("ajavaChecks");
+    }
+
+    /**
      * Adapt a string that uses Unix file and path separators to use the correct operating system
      * separator.
      *

--- a/framework-test/src/test/java/org/checkerframework/framework/test/test/junit/AjavaChecksOptionTest.java
+++ b/framework-test/src/test/java/org/checkerframework/framework/test/test/junit/AjavaChecksOptionTest.java
@@ -1,0 +1,108 @@
+package org.checkerframework.framework.test.test.junit;
+
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.checkerframework.framework.test.TestUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests the ajavaChecks option configuration and behavior in {@link
+ * CheckerFrameworkPerDirectoryTest}.
+ */
+public class AjavaChecksOptionTest {
+
+    /**
+     * An abstract test harness extending {@link CheckerFrameworkPerDirectoryTest} to inspect
+     * options. Being abstract, it is not executed as a test suite.
+     */
+    private abstract static class DummyHarness extends CheckerFrameworkPerDirectoryTest {
+        /** Creates a dummy harness. */
+        DummyHarness() {
+            super(
+                    Collections.<java.io.File>emptyList(),
+                    Collections.<String>emptyList(),
+                    "",
+                    Collections.<String>emptyList());
+        }
+
+        /**
+         * Returns the checker options passed to this test.
+         *
+         * @return the checker options
+         */
+        List<String> getCheckerOptions() {
+            return checkerOptions;
+        }
+    }
+
+    /** Tests that -AajavaChecks is included when the ajavaChecks system property is set to true. */
+    @Test
+    public void testAjavaChecksOptionWhenEnabled() {
+        String prev = System.getProperty("ajavaChecks");
+        try {
+            System.setProperty("ajavaChecks", "true");
+            Assert.assertTrue(TestUtilities.getShouldRunAjavaChecks());
+            DummyHarness harness = new DummyHarness() {};
+            Assert.assertTrue(harness.getCheckerOptions().contains("-AajavaChecks"));
+        } finally {
+            if (prev != null) {
+                System.setProperty("ajavaChecks", prev);
+            } else {
+                System.clearProperty("ajavaChecks");
+            }
+        }
+    }
+
+    /** Tests that -AajavaChecks is omitted when the ajavaChecks system property is unset. */
+    @Test
+    public void testAjavaChecksOptionWhenUnset() {
+        String prev = System.getProperty("ajavaChecks");
+        try {
+            System.clearProperty("ajavaChecks");
+            Assert.assertFalse(TestUtilities.getShouldRunAjavaChecks());
+            DummyHarness harness = new DummyHarness() {};
+            Assert.assertFalse(harness.getCheckerOptions().contains("-AajavaChecks"));
+        } finally {
+            if (prev != null) {
+                System.setProperty("ajavaChecks", prev);
+            } else {
+                System.clearProperty("ajavaChecks");
+            }
+        }
+    }
+
+    /** Tests that -AajavaChecks is omitted when the ajavaChecks system property is set to false. */
+    @Test
+    public void testAjavaChecksOptionWhenExplicitlyFalse() {
+        String prev = System.getProperty("ajavaChecks");
+        try {
+            System.setProperty("ajavaChecks", "false");
+            Assert.assertFalse(TestUtilities.getShouldRunAjavaChecks());
+            DummyHarness harness = new DummyHarness() {};
+            Assert.assertFalse(harness.getCheckerOptions().contains("-AajavaChecks"));
+        } finally {
+            if (prev != null) {
+                System.setProperty("ajavaChecks", prev);
+            } else {
+                System.clearProperty("ajavaChecks");
+            }
+        }
+    }
+
+    /**
+     * Tests that CheckerFrameworkPerDirectoryTest option configuration matches the active
+     * environment.
+     */
+    @Test
+    public void testCurrentEnvironmentConfiguration() {
+        boolean expected = TestUtilities.getShouldRunAjavaChecks();
+        DummyHarness harness = new DummyHarness() {};
+        Assert.assertEquals(
+                "CheckerFrameworkPerDirectoryTest should match TestUtilities.getShouldRunAjavaChecks()",
+                expected,
+                harness.getCheckerOptions().contains("-AajavaChecks"));
+    }
+}


### PR DESCRIPTION
## Summary

- Remove hardcoded `-AajavaChecks` option from `CheckerFrameworkPerDirectoryTest.java:143`.
- Make `-AajavaChecks` conditional on the `ajavaChecks` system property via `TestUtilities.getShouldRunAjavaChecks()`.
- Forward Gradle `-PajavaChecks` / `-DajavaChecks` into `systemProperties` in `build.gradle`.
- Add `checker/bin-devel/test-cftests-ajavachecks.sh` to run the test suite with `-PajavaChecks`.
- Add a single CI matrix run of `cftests-ajavachecks` on JDK 17 in `.github/workflows/ci.yml`.

## Motivation & Performance Impact

Previously, `CheckerFrameworkPerDirectoryTest` unconditionally appended `-AajavaChecks` to every directory test. In `BaseTypeVisitor`, `ajavaChecks` is gated on `release < 21` (because annotation insertion is disabled on Java 21+). As a result:
- On JDK 21+ (including the primary CI JDK 21), `-AajavaChecks` was already an effective no-op.
- On JDK < 21 (JDK 8, 11, 17), every single test file was being parsed by JavaParser multiple times, traversed jointly with javac ASTs, and checked with annotation insertion.
- Benchmark measurements showed this added a ~20%–38% test runtime overhead on JDK < 21 (e.g. `InterningTest` went from 25.15s down to 15.66s without it).

This change eliminates that repeated overhead across all standard test runs while preserving full consistency verification in a single dedicated JDK 17 CI job.