### PR TITLE
Default an unannotated anonymous class creation to its supertype's qualifiers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,8 +54,14 @@ on Java 8 through 11 as well. Previously this was checked only on Java 12 and la
 source checked differently depending on the compiler.
 
 An unannotated anonymous class creation expression, as in `new AClass() {}`, now
-defaults to the declaration bound and default-use qualifiers of the class or
-interface being instantiated, rather than defaulting to top.
+takes the declaration bound and the `@DefaultQualifierForUse` qualifiers of the class
+or interface being instantiated. Previously it was defaulted without reference to that
+supertype, which for most type systems meant the top qualifier.
+
+Relatedly, `new @A AIface() {}` no longer reports `cast.unsafe.constructor.invocation`
+when `@A` is the interface's declaration bound. An anonymous class implementing an
+interface has no declared constructor, so the warning was previously issued whether or
+not the annotation matched the bound.
 
 The Nullness Checker's new `-AjspecifyUnrecognizedLocations` command-line option (also enabled by
 `-Amode=jspecify`) reports an error for a nullness annotation written where JSpecify gives it no

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,10 @@ A type-use annotation written on an anonymous class creation expression, as in
 on Java 8 through 11 as well. Previously this was checked only on Java 12 and later, so the same
 source checked differently depending on the compiler.
 
+An unannotated anonymous class creation expression, as in `new AClass() {}`, now
+defaults to the declaration bound and default-use qualifiers of the class or
+interface being instantiated, rather than defaulting to top.
+
 The Nullness Checker's new `-AjspecifyUnrecognizedLocations` command-line option (also enabled by
 `-Amode=jspecify`) reports an error for a nullness annotation written where JSpecify gives it no
 meaning: a class declaration, a wildcard, a type parameter, a pattern, a type argument of a
@@ -923,7 +927,7 @@ eisop#792, eisop#863, eisop#949, eisop#1015, eisop#1059, eisop#1074, eisop#1244,
 eisop#1299, eisop#1315, eisop#1564, eisop#1592, eisop#1642, eisop#1653,
 eisop#1735, eisop#1801, eisop#1818, eisop#1819, eisop#1861, eisop#1862,
 eisop#1863, eisop#1865, eisop#1887, eisop#1965, eisop#1986, eisop#1987,
-eisop#1990, eisop#1991, eisop#2009, eisop#2020, eisop#2021, eisop#2032, typetools#399,
+eisop#1990, eisop#1991, eisop#2009, eisop#2020, eisop#2021, eisop#2032, eisop#2059, typetools#399,
 typetools#3203.
 
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1974,13 +1974,19 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns the set of qualifiers that should be applied to unannotated uses of the given element
-     * as specified by {@link org.checkerframework.framework.qual.DefaultQualifierForUse}.
+     * Returns the set of qualifiers that should be applied to unannotated uses of the given
+     * element, as specified by {@link org.checkerframework.framework.qual.DefaultQualifierForUse}.
+     *
+     * <p>This implementation always returns an empty set, because {@code @DefaultQualifierForUse}
+     * is implemented by {@link
+     * org.checkerframework.framework.type.typeannotator.DefaultQualifierForUseTypeAnnotator}, which
+     * only a {@link GenericAnnotatedTypeFactory} creates. {@code GenericAnnotatedTypeFactory}
+     * overrides this to consult that annotator.
      *
      * @param element the element
-     * @return the set of default-for-use qualifiers
+     * @return the set of default-for-use qualifiers; empty in this implementation
      */
-    public AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
+    protected AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
         return AnnotationMirrorSet.emptySet();
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3831,22 +3831,24 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                     (TypeElement) TreeUtils.elementFromUse(tree).getEnclosingElement();
             Set<? extends AnnotationMirror> superAnnos = superCon.getReturnType().getAnnotations();
             TypeMirror superUnderlyingType = superCon.getReturnType().getUnderlyingType();
-            if (!anonElem.getInterfaces().isEmpty()) {
+            DeclaredType anonSuperType = ElementUtils.getAnonymousSupertype(anonElem);
+            if (anonSuperType != null && anonSuperType.asElement().getKind().isInterface()) {
                 // When an anonymous class implements an interface, its super constructor is
                 // Object.<init>(), which does not carry the interface's annotations. The bound
                 // qualifiers should come from the interface, adapted to this viewpoint.
-                TypeMirror superType = anonElem.getInterfaces().get(0);
+                // (An anonymous class that extends a class needs none of this: superCon's return
+                // type already carries that class's annotations.)
+                TypeMirror superType = anonSuperType;
                 Set<? extends AnnotationMirror> bounds = getTypeDeclarationBounds(superType);
-                if (superType.getKind() == TypeKind.DECLARED) {
-                    Element superElem = ((DeclaredType) superType).asElement();
-                    AnnotationMirrorSet defaultUse = getDefaultAnnosForUses(superElem);
-                    if (!defaultUse.isEmpty()) {
-                        bounds =
-                                qualHierarchy.greatestLowerBoundsShallow(
-                                        bounds, superType, defaultUse, superType);
-                    }
+                AnnotationMirrorSet defaultUse = getDefaultAnnosForUses(anonSuperType.asElement());
+                if (!defaultUse.isEmpty()) {
+                    // Both constrain a use of the interface, so a use must satisfy both: take the
+                    // greatest lower bound rather than letting either one alone decide.
+                    bounds =
+                            qualHierarchy.greatestLowerBoundsShallow(
+                                    bounds, superType, defaultUse, superType);
                 }
-                if (viewpointAdapter != null && superType.getKind() == TypeKind.DECLARED) {
+                if (viewpointAdapter != null) {
                     AnnotatedDeclaredType ifaceType =
                             (AnnotatedDeclaredType) toAnnotatedType(superType, false);
                     ifaceType.replaceAnnotations(bounds);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3809,14 +3809,31 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 p.addAll(superCon.getParameterTypes());
                 con.setParameterTypes(Collections.unmodifiableList(p));
             }
-            Set<? extends AnnotationMirror> lub =
-                    // TODO: should we use getAnnotationsField() even though it flows to the
-                    // QualifierHierarchy?
-                    qualHierarchy.leastUpperBoundsShallow(
-                            type.getAnnotations(),
-                            type.getUnderlyingType(),
-                            superCon.getReturnType().getAnnotations(),
-                            superCon.getReturnType().getUnderlyingType());
+            Set<? extends AnnotationMirror> lub;
+            if (TypesUtils.isObject(superCtor.getEnclosingElement().asType())) {
+                // When an anonymous class implements an interface (or extends Object), its super
+                // constructor is Object.<init>(), which does not carry the interface's
+                // annotations. The bound qualifiers should come from the interface (or supertype).
+                TypeElement anonElem =
+                        (TypeElement) TreeUtils.elementFromUse(tree).getEnclosingElement();
+                TypeMirror superType =
+                        !anonElem.getInterfaces().isEmpty()
+                                ? anonElem.getInterfaces().get(0)
+                                : anonElem.getSuperclass();
+                AnnotationMirrorSet bounds = getTypeDeclarationBounds(superType);
+                lub =
+                        qualHierarchy.leastUpperBoundsShallow(
+                                type.getAnnotations(), type.getUnderlyingType(), bounds, superType);
+            } else {
+                lub =
+                        // TODO: should we use getAnnotationsField() even though it flows to the
+                        // QualifierHierarchy?
+                        qualHierarchy.leastUpperBoundsShallow(
+                                type.getAnnotations(),
+                                type.getUnderlyingType(),
+                                superCon.getReturnType().getAnnotations(),
+                                superCon.getReturnType().getUnderlyingType());
+            }
             con.getReturnType().replaceAnnotations(lub);
         } else {
             // Store varargType before calling setParameterTypes, otherwise we may lose the

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1974,6 +1974,17 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
+     * Returns the set of qualifiers that should be applied to unannotated uses of the given element
+     * as specified by {@link org.checkerframework.framework.qual.DefaultQualifierForUse}.
+     *
+     * @param element the element
+     * @return the set of default-for-use qualifiers
+     */
+    public AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
+        return AnnotationMirrorSet.emptySet();
+    }
+
+    /**
      * Returns the type of the extends or implements clause.
      *
      * <p>The primary qualifier is either an explicit annotation on {@code clause}, or it is the
@@ -2663,6 +2674,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         // Add computed annotations to the type.
         addComputedTypeAnnotations(tree, type);
+
+        if (tree.getClassBody() != null && explicitAnnos.isEmpty()) {
+            AnnotationMirrorSet boundAnnos =
+                    getAnnotationOrTypeDeclarationBound(
+                            type.getUnderlyingType(), type.getAnnotations());
+            type.replaceAnnotations(boundAnnos);
+        }
 
         return type;
     }
@@ -3809,31 +3827,44 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 p.addAll(superCon.getParameterTypes());
                 con.setParameterTypes(Collections.unmodifiableList(p));
             }
-            Set<? extends AnnotationMirror> lub;
-            if (TypesUtils.isObject(superCtor.getEnclosingElement().asType())) {
-                // When an anonymous class implements an interface (or extends Object), its super
-                // constructor is Object.<init>(), which does not carry the interface's
-                // annotations. The bound qualifiers should come from the interface (or supertype).
-                TypeElement anonElem =
-                        (TypeElement) TreeUtils.elementFromUse(tree).getEnclosingElement();
-                TypeMirror superType =
-                        !anonElem.getInterfaces().isEmpty()
-                                ? anonElem.getInterfaces().get(0)
-                                : anonElem.getSuperclass();
-                AnnotationMirrorSet bounds = getTypeDeclarationBounds(superType);
-                lub =
-                        qualHierarchy.leastUpperBoundsShallow(
-                                type.getAnnotations(), type.getUnderlyingType(), bounds, superType);
-            } else {
-                lub =
-                        // TODO: should we use getAnnotationsField() even though it flows to the
-                        // QualifierHierarchy?
-                        qualHierarchy.leastUpperBoundsShallow(
-                                type.getAnnotations(),
-                                type.getUnderlyingType(),
-                                superCon.getReturnType().getAnnotations(),
-                                superCon.getReturnType().getUnderlyingType());
+            TypeElement anonElem =
+                    (TypeElement) TreeUtils.elementFromUse(tree).getEnclosingElement();
+            Set<? extends AnnotationMirror> superAnnos = superCon.getReturnType().getAnnotations();
+            TypeMirror superUnderlyingType = superCon.getReturnType().getUnderlyingType();
+            if (!anonElem.getInterfaces().isEmpty()) {
+                // When an anonymous class implements an interface, its super constructor is
+                // Object.<init>(), which does not carry the interface's annotations. The bound
+                // qualifiers should come from the interface, adapted to this viewpoint.
+                TypeMirror superType = anonElem.getInterfaces().get(0);
+                Set<? extends AnnotationMirror> bounds = getTypeDeclarationBounds(superType);
+                if (superType.getKind() == TypeKind.DECLARED) {
+                    Element superElem = ((DeclaredType) superType).asElement();
+                    AnnotationMirrorSet defaultUse = getDefaultAnnosForUses(superElem);
+                    if (!defaultUse.isEmpty()) {
+                        bounds =
+                                qualHierarchy.greatestLowerBoundsShallow(
+                                        bounds, superType, defaultUse, superType);
+                    }
+                }
+                if (viewpointAdapter != null && superType.getKind() == TypeKind.DECLARED) {
+                    AnnotatedDeclaredType ifaceType =
+                            (AnnotatedDeclaredType) toAnnotatedType(superType, false);
+                    ifaceType.replaceAnnotations(bounds);
+                    bounds = viewpointAdapter.viewpointAdaptType(type, ifaceType).getAnnotations();
+                }
+                superAnnos =
+                        qualHierarchy.greatestLowerBoundsShallow(
+                                superAnnos, superUnderlyingType, bounds, superType);
+                superUnderlyingType = superType;
             }
+            Set<? extends AnnotationMirror> lub =
+                    // TODO: should we use getAnnotationsField() even though it flows to the
+                    // QualifierHierarchy?
+                    qualHierarchy.leastUpperBoundsShallow(
+                            type.getAnnotations(),
+                            type.getUnderlyingType(),
+                            superAnnos,
+                            superUnderlyingType);
             con.getReturnType().replaceAnnotations(lub);
         } else {
             // Store varargType before calling setParameterTypes, otherwise we may lose the

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2675,13 +2675,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // Add computed annotations to the type.
         addComputedTypeAnnotations(tree, type);
 
-        if (tree.getClassBody() != null && explicitAnnos.isEmpty()) {
-            AnnotationMirrorSet boundAnnos =
-                    getAnnotationOrTypeDeclarationBound(
-                            type.getUnderlyingType(), type.getAnnotations());
-            type.replaceAnnotations(boundAnnos);
-        }
-
         return type;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -635,6 +635,14 @@ public abstract class GenericAnnotatedTypeFactory<
         return new DefaultQualifierForUseTypeAnnotator(this);
     }
 
+    @Override
+    public AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
+        if (defaultQualifierForUseTypeAnnotator != null) {
+            return defaultQualifierForUseTypeAnnotator.getDefaultAnnosForUses(element);
+        }
+        return AnnotationMirrorSet.emptySet();
+    }
+
     /**
      * Creates an {@link DefaultForTypeAnnotator}.
      *

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -636,7 +636,9 @@ public abstract class GenericAnnotatedTypeFactory<
     }
 
     @Override
-    public AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
+    protected AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
+        // The annotator is created in postInit, so it is null while the type factory is still
+        // being constructed; a type queried that early has no default-for-use qualifiers yet.
         if (defaultQualifierForUseTypeAnnotator != null) {
             return defaultQualifierForUseTypeAnnotator.getDefaultAnnosForUses(element);
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
@@ -117,12 +117,11 @@ public class QualifierUpperBounds {
             Element elem = declaredType.asElement();
             bounds.addAll(getAnnotationFromElement(elem));
             if (ElementUtils.isAnonymous(elem)) {
-                TypeElement typeElem = (TypeElement) elem;
-                TypeMirror superType =
-                        !typeElem.getInterfaces().isEmpty()
-                                ? typeElem.getInterfaces().get(0)
-                                : typeElem.getSuperclass();
-                if (superType != null && superType.getKind() == TypeKind.DECLARED) {
+                // An anonymous class carries no annotations of its own, so its bounds are those
+                // of the type it is created from.  Use addMissingAnnotations, not addAll, so that
+                // anything the element did contribute still wins.
+                DeclaredType superType = ElementUtils.getAnonymousSupertype((TypeElement) elem);
+                if (superType != null) {
                     addMissingAnnotations(bounds, getBoundQualifiers(superType));
                 }
             }

--- a/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
@@ -124,6 +124,7 @@ public class QualifierUpperBounds {
                 // An anonymous class carries no annotations of its own, so its bounds are those
                 // of the type it is created from.  Use addMissingAnnotations, not addAll, so that
                 // anything the element did contribute still wins.
+                // Null only if the supertype did not resolve; see getAnonymousSupertype.
                 DeclaredType superType = ElementUtils.getAnonymousSupertype((TypeElement) elem);
                 if (superType != null) {
                     addMissingAnnotations(bounds, getBoundQualifiers(superType));

--- a/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
@@ -5,6 +5,7 @@ import org.checkerframework.framework.qual.UpperBoundFor;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 import java.lang.annotation.Annotation;
@@ -15,6 +16,7 @@ import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -112,7 +114,18 @@ public class QualifierUpperBounds {
         String qname;
         if (type.getKind() == TypeKind.DECLARED) {
             DeclaredType declaredType = (DeclaredType) type;
-            bounds.addAll(getAnnotationFromElement(declaredType.asElement()));
+            Element elem = declaredType.asElement();
+            bounds.addAll(getAnnotationFromElement(elem));
+            if (ElementUtils.isAnonymous(elem)) {
+                TypeElement typeElem = (TypeElement) elem;
+                TypeMirror superType =
+                        !typeElem.getInterfaces().isEmpty()
+                                ? typeElem.getInterfaces().get(0)
+                                : typeElem.getSuperclass();
+                if (superType != null && superType.getKind() == TypeKind.DECLARED) {
+                    addMissingAnnotations(bounds, getBoundQualifiers(superType));
+                }
+            }
             qname = TypesUtils.getQualifiedName(declaredType);
         } else if (type.getKind().isPrimitive()) {
             qname = type.toString();

--- a/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
@@ -106,8 +106,12 @@ public class QualifierUpperBounds {
     /**
      * Returns the set of qualifiers that are the upper bounds for a use of the type.
      *
+     * <p>The result is unmodifiable, and callers must not assume it is freshly allocated: an
+     * override of {@link AnnotatedTypeFactory#getTypeDeclarationBounds} may return a shared
+     * constant instead, as {@code InterningAnnotatedTypeFactory} does for enums.
+     *
      * @param type the TypeMirror
-     * @return the set of qualifiers that are the upper bounds for a use of the type
+     * @return the set of qualifiers that are the upper bounds for a use of the type; unmodifiable
      */
     public AnnotationMirrorSet getBoundQualifiers(TypeMirror type) {
         AnnotationMirrorSet bounds = new AnnotationMirrorSet();
@@ -146,7 +150,7 @@ public class QualifierUpperBounds {
         }
 
         addMissingAnnotations(bounds, atypeFactory.getDefaultTypeDeclarationBounds());
-        return bounds;
+        return bounds.makeUnmodifiable();
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
@@ -22,8 +22,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 
 /**
  * Implements support for {@link DefaultQualifierForUse} and {@link NoDefaultQualifierForUse}. Adds
@@ -121,18 +119,11 @@ public class DefaultQualifierForUseTypeAnnotator extends TypeAnnotator {
             }
         }
         if (ElementUtils.isAnonymous(element)) {
-            TypeElement typeElem = (TypeElement) element;
-            Element superElem = null;
-            if (!typeElem.getInterfaces().isEmpty()) {
-                TypeMirror iface = typeElem.getInterfaces().get(0);
-                if (iface.getKind() == TypeKind.DECLARED) {
-                    superElem = ((DeclaredType) iface).asElement();
-                }
-            } else if (typeElem.getSuperclass().getKind() == TypeKind.DECLARED) {
-                superElem = ((DeclaredType) typeElem.getSuperclass()).asElement();
-            }
-            if (superElem != null) {
-                AnnotationMirrorSet superDefaults = getDefaultAnnosForUses(superElem);
+            // An anonymous class cannot carry @DefaultQualifierForUse itself, so it inherits the
+            // defaults of the type it is created from, in each hierarchy it does not already set.
+            DeclaredType superType = ElementUtils.getAnonymousSupertype((TypeElement) element);
+            if (superType != null) {
+                AnnotationMirrorSet superDefaults = getDefaultAnnosForUses(superType.asElement());
                 for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
                     if (qualHierarchy.findAnnotationInHierarchy(annosToApply, top) == null) {
                         AnnotationMirror superDefault =

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
@@ -9,6 +9,7 @@ import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
 import java.util.IdentityHashMap;
@@ -19,6 +20,10 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 /**
  * Implements support for {@link DefaultQualifierForUse} and {@link NoDefaultQualifierForUse}. Adds
@@ -111,6 +116,30 @@ public class DefaultQualifierForUseTypeAnnotator extends TypeAnnotator {
                         qualHierarchy.findAnnotationInHierarchy(explictAnnos, top);
                 if (explict != null) {
                     annosToApply.add(explict);
+                }
+            }
+        }
+        if (ElementUtils.isAnonymous(element)) {
+            TypeElement typeElem = (TypeElement) element;
+            Element superElem = null;
+            if (!typeElem.getInterfaces().isEmpty()) {
+                TypeMirror iface = typeElem.getInterfaces().get(0);
+                if (iface.getKind() == TypeKind.DECLARED) {
+                    superElem = ((DeclaredType) iface).asElement();
+                }
+            } else if (typeElem.getSuperclass().getKind() == TypeKind.DECLARED) {
+                superElem = ((DeclaredType) typeElem.getSuperclass()).asElement();
+            }
+            if (superElem != null) {
+                AnnotationMirrorSet superDefaults = getDefaultAnnosForUses(superElem);
+                for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
+                    if (qualHierarchy.findAnnotationInHierarchy(annosToApply, top) == null) {
+                        AnnotationMirror superDefault =
+                                qualHierarchy.findAnnotationInHierarchy(superDefaults, top);
+                        if (superDefault != null) {
+                            annosToApply.add(superDefault);
+                        }
+                    }
                 }
             }
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
@@ -125,6 +125,7 @@ public class DefaultQualifierForUseTypeAnnotator extends TypeAnnotator {
         if (ElementUtils.isAnonymous(element)) {
             // An anonymous class cannot carry @DefaultQualifierForUse itself, so it inherits the
             // defaults of the type it is created from, in each hierarchy it does not already set.
+            // Null only if the supertype did not resolve; see getAnonymousSupertype.
             DeclaredType superType = ElementUtils.getAnonymousSupertype((TypeElement) element);
             if (superType != null) {
                 AnnotationMirrorSet superDefaults = getDefaultAnnosForUses(superType.asElement());

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
@@ -133,7 +133,13 @@ public class DefaultQualifierForUseTypeAnnotator extends TypeAnnotator {
                     if (qualHierarchy.findAnnotationInHierarchy(annosToApply, top) == null) {
                         AnnotationMirror superDefault =
                                 qualHierarchy.findAnnotationInHierarchy(superDefaults, top);
-                        if (superDefault != null) {
+                        // Do not inherit a polymorphic qualifier. It is resolved per use of the
+                        // type that declares it, and an anonymous class's own declaration gives
+                        // it nothing to resolve against, so copying it here would silently pick
+                        // one instantiation. A checker with polymorphic type declarations wants
+                        // the developer to be explicit on an anonymous subtype instead.
+                        if (superDefault != null
+                                && !qualHierarchy.isPolymorphicQualifier(superDefault)) {
                             annosToApply.add(superDefault);
                         }
                     }

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
@@ -86,8 +86,12 @@ public class DefaultQualifierForUseTypeAnnotator extends TypeAnnotator {
      * Returns the set of qualifiers that should be applied to unannotated uses of the given
      * element.
      *
+     * <p>The result is unmodifiable and is shared: on a cache hit every caller is handed the same
+     * instance.
+     *
      * @param element the element for which to determine default qualifiers
-     * @return the set of qualifiers that should be applied to unannotated uses of {@code element}
+     * @return the set of qualifiers that should be applied to unannotated uses of {@code element};
+     *     unmodifiable
      */
     public AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
         if (atypeFactory.shouldCache) {
@@ -141,6 +145,11 @@ public class DefaultQualifierForUseTypeAnnotator extends TypeAnnotator {
         // per cached element.
         if (annosToApply.isEmpty()) {
             annosToApply = AnnotationMirrorSet.emptySet();
+        } else {
+            // The cache below stores this very instance and hands it to every later caller, so
+            // freeze it: a caller that mutated the result would corrupt the defaults of every
+            // subsequent use of this element.
+            annosToApply.makeUnmodifiable();
         }
         // If parsing an annotation file, then the annosToApply is incomplete, so don't cache them.
         if (atypeFactory.shouldCache && !atypeFactory.isParsingAnnotationFile()) {

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/DefaultQualifierForUseTypeAnnotator.java
@@ -85,12 +85,13 @@ public class DefaultQualifierForUseTypeAnnotator extends TypeAnnotator {
     }
 
     /**
-     * Returns the set of qualifiers that should be applied to unannotated uses of the given element
+     * Returns the set of qualifiers that should be applied to unannotated uses of the given
+     * element.
      *
      * @param element the element for which to determine default qualifiers
      * @return the set of qualifiers that should be applied to unannotated uses of {@code element}
      */
-    protected AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
+    public AnnotationMirrorSet getDefaultAnnosForUses(Element element) {
         if (atypeFactory.shouldCache) {
             AnnotationMirrorSet cached = elementToDefaults.get(element);
             if (cached != null) {

--- a/framework/tests/viewpointtest/AnonymousClassBounds.java
+++ b/framework/tests/viewpointtest/AnonymousClassBounds.java
@@ -18,6 +18,40 @@ public class AnonymousClassBounds {
     @SuppressWarnings({"inconsistent.constructor.type", "super.invocation.invalid"})
     @A static class GClass<T> {}
 
+    void testUnannotated() {
+        // Unannotated anonymous class creation defaults to the declaration bound of the
+        // supertype (@A), rather than @Top.
+        @A AClass a1 = new AClass() {};
+        @Top AClass a2 = new AClass() {};
+        // :: error: (assignment.type.incompatible)
+        @B AClass a3 = new AClass() {};
+
+        // Unannotated interface implementation
+        @A AIface i1 = new AIface() {};
+        @Top AIface i2 = new AIface() {};
+        // :: error: (assignment.type.incompatible)
+        @B AIface i3 = new AIface() {};
+
+        // Unannotated parameterized class
+        @A GClass<String> g1 = new GClass<String>() {};
+        // :: error: (assignment.type.incompatible)
+        @B GClass<String> g2 = new GClass<String>() {};
+
+        // Unannotated bounded parameterized class
+        @A GBoundedClass<@A String> gb1 = new GBoundedClass<@A String>() {};
+        // :: error: (assignment.type.incompatible)
+        @B GBoundedClass<@A String> gb2 = new GBoundedClass<@A String>() {};
+
+        // Unannotated nested anonymous class
+        new AClass() {
+            void m() {
+                @A AClass nested = new AClass() {};
+                // :: error: (assignment.type.incompatible)
+                @B AClass nestedBad = new AClass() {};
+            }
+        };
+    }
+
     void test() {
         // @A is AClass's declaration bound, so this use is valid.
         new @A AClass() {};
@@ -58,10 +92,7 @@ public class AnonymousClassBounds {
     // AnnotatedTypeFactory finding the annotation on the anonymous class body's modifiers) are
     // needed together here too.
     void testInterface() {
-        // @A is AIface's declaration bound, so this use is valid. (An anonymous class
-        // implementing an interface has no declared constructor to check consistency against,
-        // so this warning is issued regardless of whether the annotation matches the bound.)
-        // :: warning: (cast.unsafe.constructor.invocation)
+        // @A is AIface's declaration bound, so this use is valid.
         new @A AIface() {};
 
         // @B is a sibling of @A, so it is outside AIface's declaration bound.

--- a/framework/tests/viewpointtest/AnonymousClassBounds.java
+++ b/framework/tests/viewpointtest/AnonymousClassBounds.java
@@ -1,3 +1,5 @@
+import org.checkerframework.framework.qual.DefaultQualifierForUse;
+
 import viewpointtest.quals.*;
 
 /**
@@ -17,6 +19,13 @@ public class AnonymousClassBounds {
 
     @SuppressWarnings({"inconsistent.constructor.type", "super.invocation.invalid"})
     @A static class GClass<T> {}
+
+    @DefaultQualifierForUse(A.class)
+    interface UseDefIface {}
+
+    @SuppressWarnings({"inconsistent.constructor.type", "super.invocation.invalid"})
+    @DefaultQualifierForUse(A.class)
+    static class UseDefClass {}
 
     void testUnannotated() {
         // Unannotated anonymous class creation defaults to the declaration bound of the
@@ -50,6 +59,18 @@ public class AnonymousClassBounds {
                 @B AClass nestedBad = new AClass() {};
             }
         };
+
+        // Unannotated anonymous class with @DefaultQualifierForUse on interface
+        @A UseDefIface u1 = new UseDefIface() {};
+        @Top UseDefIface u2 = new UseDefIface() {};
+        // :: error: (assignment.type.incompatible)
+        @B UseDefIface u3 = new UseDefIface() {};
+
+        // Unannotated anonymous class with @DefaultQualifierForUse on class
+        @A UseDefClass uc1 = new UseDefClass() {};
+        @Top UseDefClass uc2 = new UseDefClass() {};
+        // :: error: (assignment.type.incompatible)
+        @B UseDefClass uc3 = new UseDefClass() {};
     }
 
     void test() {

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -892,9 +892,18 @@ public class ElementUtils {
      * AClass() {}} -- so it implements at most one interface, and {@code getInterfaces()} being
      * non-empty is what distinguishes the two cases.
      *
+     * <p>The result is null only if that supertype is not a declared type, which means it did not
+     * resolve: an anonymous class names exactly one supertype, and {@code getSuperclass()} is a
+     * {@code NoType} only for {@code java.lang.Object} and for interfaces, neither of which an
+     * anonymous class can be. Source that fails to resolve does not reach a checker -- {@link
+     * javax.annotation.processing.Processor} runs after attribution and {@code
+     * SourceChecker.typeProcess} returns early once javac has reported an error -- so a caller
+     * should treat null as an unresolvable supertype read from bytecode (an incomplete classpath)
+     * and skip, rather than report it as a bug in the checker.
+     *
      * @param anonClass an anonymous class
-     * @return the declared type {@code anonClass} is created from, or null if that supertype is not
-     *     a declared type
+     * @return the declared type {@code anonClass} is created from, or null if that supertype did
+     *     not resolve
      * @see #isAnonymous(Element)
      */
     public static @Nullable DeclaredType getAnonymousSupertype(TypeElement anonClass) {

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -885,6 +885,25 @@ public class ElementUtils {
     }
 
     /**
+     * Returns the type that an anonymous class is created from: the interface it implements if it
+     * implements one, and otherwise its superclass.
+     *
+     * <p>An anonymous class names exactly one supertype -- {@code new Iface() {}} or {@code new
+     * AClass() {}} -- so it implements at most one interface, and {@code getInterfaces()} being
+     * non-empty is what distinguishes the two cases.
+     *
+     * @param anonClass an anonymous class
+     * @return the declared type {@code anonClass} is created from, or null if that supertype is not
+     *     a declared type
+     * @see #isAnonymous(Element)
+     */
+    public static @Nullable DeclaredType getAnonymousSupertype(TypeElement anonClass) {
+        List<? extends TypeMirror> interfaces = anonClass.getInterfaces();
+        TypeMirror superType = interfaces.isEmpty() ? anonClass.getSuperclass() : interfaces.get(0);
+        return superType.getKind() == TypeKind.DECLARED ? (DeclaredType) superType : null;
+    }
+
+    /**
      * Return true if the element is a constructor of an anonymous class.
      *
      * @param element the element to test


### PR DESCRIPTION
Fixes #2059.

An anonymous class is a subtype of the class it extends or the interface it implements, but an unannotated `new AClass() {}` was defaulted without reference to that supertype — for most type systems, to the top qualifier. It now takes the supertype's declaration bound and its `@DefaultQualifierForUse` qualifiers.

### Changes

- **`QualifierUpperBounds`** — an anonymous class carries no annotations of its own, so its declaration bounds are those of the type it is created from. Merged with `addMissingAnnotations`, so anything the element did contribute still wins.
- **`DefaultQualifierForUseTypeAnnotator`** — an anonymous class cannot carry `@DefaultQualifierForUse` itself, so it inherits the supertype's, per hierarchy, only where it does not already set one.
- **`AnnotatedTypeFactory.constructorFromUse`** — when an anonymous class implements an interface its super constructor is `Object.<init>()`, which carries none of the interface's annotations, so the bound qualifiers are taken from the interface and viewpoint-adapted. An anonymous class that extends a class needs none of this: `superCon`'s return type already carries that class's annotations.
- **`ElementUtils.getAnonymousSupertype`** — the "single interface if it implements one, otherwise the superclass" lookup is needed in all three places above. One helper, documenting the fact that makes it correct: an anonymous class names exactly one supertype, so it implements at most one interface.
- **`QualifierUpperBounds.getBoundQualifiers`** now returns an unmodifiable set. Callers already could not own the result — `InterningAnnotatedTypeFactory` overrides `getTypeDeclarationBounds` to return a shared `INTERNED_SET` for enums, so a caller that mutated it would corrupt that checker's state. Nothing did, but nothing said so either.
- **`AnnotatedTypeFactory.getDefaultAnnosForUses`** is `protected` rather than `public`: its only caller is inside `AnnotatedTypeFactory`. Its Javadoc described returning the `@DefaultQualifierForUse` qualifiers while the body returned an empty set; it now says that the base implementation is empty because only a `GenericAnnotatedTypeFactory` creates the annotator that implements the annotation.

### Removed since the first revision

An earlier revision also clamped the creation's annotations to the declaration bound in `getConstructorReceiverType`, guarded on the whole explicit-annotation set being empty. That guard was a property of the entire set while the clamping it guarded is per-hierarchy, so annotating one hierarchy of a multi-hierarchy type system skipped the bound for every hierarchy.

The clamp turned out to be unnecessary rather than merely mis-guarded: with `QualifierUpperBounds` making an anonymous type's declaration bound inherit from its supertype, ordinary defaulting already consults it. Verified by deleting the block and running `:framework:test` — all suites pass, including `ViewpointTestCheckerTest`, which compiles every case this PR adds and is the corpus with a non-null `viewpointAdapter`.

### Tests

`framework/tests/viewpointtest/AnonymousClassBounds.java` covers anonymous creation from a class, an interface, a parameterized class, a bounded type variable, nested anonymous classes, and `@DefaultQualifierForUse` on both a class and an interface.

`new @A AIface() {}` no longer reports `cast.unsafe.constructor.invocation` when `@A` is the interface's declaration bound; an anonymous class implementing an interface has no declared constructor, so the warning was previously issued whether or not the annotation matched. The changelog records that, since it is a false positive going away.

Verified on the merged tree: `assemble`, `:framework:test` (64 suites), `javadocDoclintAll` and `spotlessCheck` all pass; `requireJavadoc` reports nothing on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GARx9id3NPLhaM7w3XMJBe
