### PR TITLE
Add tests for explicit `@DefaultQualifier.List` conflicts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -979,7 +979,7 @@ eisop#1299, eisop#1315, eisop#1564, eisop#1592, eisop#1642, eisop#1653,
 eisop#1735, eisop#1801, eisop#1818, eisop#1819, eisop#1861, eisop#1862,
 eisop#1863, eisop#1865, eisop#1887, eisop#1965, eisop#1986, eisop#1987,
 eisop#1990, eisop#1991, eisop#2009, eisop#2020, eisop#2021, eisop#2032,
-eisop#2037, eisop#2047, eisop#2059, eisop#2064, typetools#399, typetools#3203.
+eisop#2037, eisop#2047, eisop#2059, eisop#2061, eisop#2064, typetools#399, typetools#3203.
 
 
 Version 3.49.5-eisop1 (April 26, 2026)

--- a/framework/tests/elementdefault/ConflictingWrittenDefaults.java
+++ b/framework/tests/elementdefault/ConflictingWrittenDefaults.java
@@ -19,4 +19,27 @@ public class ConflictingWrittenDefaults {
         // :: error: (return.type.incompatible)
         return new Object();
     }
+
+    @DefaultQualifier.List({
+        @DefaultQualifier(value = ElementDefaultBottom.class, locations = TypeUseLocation.RETURN),
+        @DefaultQualifier(value = ElementDefaultTop.class, locations = TypeUseLocation.RETURN)
+    })
+    // :: error: (conflicting.defaults)
+    static class ConflictingWrittenDefaultsWithList {
+        Object getBottom() {
+            // :: error: (return.type.incompatible)
+            return new Object();
+        }
+    }
+
+    @DefaultQualifier.List({
+        @DefaultQualifier(value = ElementDefaultTop.class, locations = TypeUseLocation.RETURN),
+        @DefaultQualifier(value = ElementDefaultBottom.class, locations = TypeUseLocation.RETURN)
+    })
+    // :: error: (conflicting.defaults)
+    static class ConflictingWrittenDefaultsWithListTopFirst {
+        Object getTop() {
+            return new Object();
+        }
+    }
 }

--- a/framework/tests/elementdefault/ConflictingWrittenDefaults.java
+++ b/framework/tests/elementdefault/ConflictingWrittenDefaults.java
@@ -20,6 +20,15 @@ public class ConflictingWrittenDefaults {
         return new Object();
     }
 
+    /**
+     * The same conflict as the enclosing class, written as an explicit
+     * {@code @DefaultQualifier.List} rather than as a repeated {@code @DefaultQualifier}. javac
+     * collapses the repeated form into exactly this container, so by the time {@code
+     * AnnotatedTypeFactory#getDefaultQualifierAnnotations} sees either one they are
+     * indistinguishable: this case cannot fail unless the enclosing class's does. It is here to
+     * document that the surface syntax a user writes is handled, not to cover a separate path. The
+     * case below, which reverses the order, is the one that pins which of the two wins.
+     */
     @DefaultQualifier.List({
         @DefaultQualifier(value = ElementDefaultBottom.class, locations = TypeUseLocation.RETURN),
         @DefaultQualifier(value = ElementDefaultTop.class, locations = TypeUseLocation.RETURN)
@@ -32,12 +41,19 @@ public class ConflictingWrittenDefaults {
         }
     }
 
+    /**
+     * The same two defaults in the other order, so Top is first and wins. Returning an unqualified
+     * (Top) value is therefore legal here, whereas it is an error in the two cases above: that
+     * difference is what shows the winner is decided by source order rather than by which qualifier
+     * happens to sort first.
+     */
     @DefaultQualifier.List({
         @DefaultQualifier(value = ElementDefaultTop.class, locations = TypeUseLocation.RETURN),
         @DefaultQualifier(value = ElementDefaultBottom.class, locations = TypeUseLocation.RETURN)
     })
     // :: error: (conflicting.defaults)
     static class ConflictingWrittenDefaultsWithListTopFirst {
+        // RETURN is Top, from the first @DefaultQualifier in the list; no error here.
         Object getTop() {
             return new Object();
         }


### PR DESCRIPTION
Fixes #2061.

PR #2066 already resolved the core issue by delegating `defaultsAtDirect` to `atypeFactory.getDefaultQualifierAnnotations(elt)`, which handles both repeated `@DefaultQualifier` and explicit `@DefaultQualifier.List`.

This PR adds test cases covering explicit `@DefaultQualifier.List` conflicting defaults to ensure the behavior is preserved.